### PR TITLE
procfs: add safe procfs API and harden proc operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,18 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
 
-      - name: cargo nextest
+      - name: unit tests
         run: cargo llvm-cov --no-report nextest
-      - name: cargo test --doc
+      - name: doctests
         run: cargo llvm-cov --no-report --doc
+
+      # Run the unit tests as root.
+      # NOTE: Ideally this would be configured in .cargo/config.toml so it
+      #       would also work locally, but unfortunately it seems cargo doesn't
+      #       support cfg(feature=...) for target runner configs.
+      #       See <https://github.com/rust-lang/cargo/issues/14306>.
+      - name: unit tests (root)
+        run: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo llvm-cov --no-report --features _test_as_root nextest
 
       - name: calculate coverage
         run: cargo llvm-cov report

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ travis-ci = { repository = "openSUSE/libpathrs" }
 [lib]
 crate-type = ["rlib", "cdylib", "staticlib"]
 
+[features]
+# Only used for tests.
+_test_as_root = []
+
 [profile.release]
 # Enable link-time optimisations.
 lto = true

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -70,6 +70,8 @@ aligned_n = "__CBINDGEN_ALIGNED"
 
 [export]
 exclude = [
+	# CReturn is a rust-only typedef.
+	"CReturn",
 	# Don't export the RESOLVE_* definitions.
 	"RESOLVE_NO_XDEV",
 	"RESOLVE_NO_MAGICLINKS",
@@ -80,6 +82,7 @@ exclude = [
 
 # Clean up the naming of structs.
 [export.rename]
+"CProcfsBase" = "pathrs_proc_base_t"
 
 # Error API.
 "CError" = "pathrs_error_t"

--- a/go-pathrs/procfs_linux.go
+++ b/go-pathrs/procfs_linux.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+// libpathrs: safe path resolution on Linux
+// Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2019-2024 SUSE LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathrs
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+type ProcBase int
+
+const (
+	unimplementedProcBaseRoot ProcBase = iota
+	// Use /proc/self. For most programs, this is the standard choice.
+	ProcBaseSelf
+	// Use /proc/thread-self. In multi-threaded programs where one thread has
+	// a different CLONE_FS, it is possible for /proc/self to point the wrong
+	// thread and so /proc/thread-self may be necessary.
+	ProcBaseThreadSelf
+)
+
+func (b ProcBase) toPathrsBase() (pathrsProcBase, error) {
+	switch b {
+	case ProcBaseSelf:
+		return pathrsProcSelf, nil
+	case ProcBaseThreadSelf:
+		return pathrsProcThreadSelf, nil
+	default:
+		return 0, fmt.Errorf("invalid proc base: %v", b)
+	}
+}
+
+// ProcHandleCloser is a callback that needs to be called when you are done
+// operating on an *os.File fetched using ProcThreadSelfOpen.
+type ProcHandleCloser func()
+
+// TODO: Consider exporting procOpen once we have ProcBaseRoot.
+
+func procOpen(base ProcBase, path string, flags int) (*os.File, ProcHandleCloser, error) {
+	pathrsBase, err := base.toPathrsBase()
+	if err != nil {
+		return nil, nil, err
+	}
+	switch base {
+	case ProcBaseSelf:
+		fd, err := pathrsProcOpen(pathrsBase, path, flags)
+		if err != nil {
+			return nil, nil, err
+		}
+		return os.NewFile(fd, "/proc/self/"+path), nil, nil
+	case ProcBaseThreadSelf:
+		runtime.LockOSThread()
+		fd, err := pathrsProcOpen(pathrsBase, path, flags)
+		if err != nil {
+			runtime.UnlockOSThread()
+			return nil, nil, err
+		}
+		return os.NewFile(fd, "/proc/thread-self/"+path), runtime.UnlockOSThread, nil
+	}
+	panic("unreachable")
+}
+
+// ProcSelfOpen safely opens a given path from inside /proc/self/.
+//
+// This method is recommend for getting process information about the current
+// process for almost all Go processes *except* for cases where there are
+// runtime.LockOSThread threads that have changed some aspect of their state
+// (such as through unshare(CLONE_FS) or changing namespaces).
+//
+// For such non-heterogeneous processes, /proc/self may reference to a task
+// that has different state from the current goroutine and so it may be
+// preferable to use ProcThreadSelfOpen. The same is true if a user really
+// wants to inspect the current OS thread's information (such as
+// /proc/thread-self/stack or /proc/thread-self/status which is always uniquely
+// per-thread).
+//
+// Unlike ProcThreadSelfOpen, this method does not involve locking the
+// goroutine to the current OS thread and so is simpler to use.
+func ProcSelfOpen(path string, flags int) (*os.File, error) {
+	file, closer, err := procOpen(ProcBaseSelf, path, flags)
+	if closer != nil {
+		// should not happen
+		panic("non-zero closer returned from procOpen(ProcBaseSelf)")
+	}
+	return file, err
+}
+
+// ProcThreadSelfOpen safely opens a given path from inside /proc/thread-self/.
+//
+// Most Go processes have heterogeneous threads (all threads have most of the
+// same kernel state such as CLONE_FS) and so ProcSelfOpen is preferable for
+// most users.
+//
+// For non-heterogeneous threads, or users that actually want thread-specific
+// information (such as /proc/thread-self/stack or /proc/thread-self/status),
+// this method is necessary.
+//
+// Because Go can change the running OS thread of your goroutine without notice
+// (and then subsequently kill the old thread), this method will lock the
+// current goroutine to ths OS thread (with runtime.LockOSThread) and the
+// caller is responsible for unlocking the the OS thread with the
+// ProcHandleCloser callback once they are done using the returned file. This
+// callback MUST be called AFTER you have finished using the returned *os.File.
+// This callback is completely separate to (*os.File).Close, so it must be
+// called regardless of how you close the handle.
+func ProcThreadSelfOpen(path string, flags int) (*os.File, ProcHandleCloser, error) {
+	return procOpen(ProcBaseThreadSelf, path, flags)
+}
+
+// ProcReadlink safely reads the contents of a symlink from the given procfs
+// base.
+//
+// This is effectively equivalent to doing a Proc*Open(O_PATH|O_NOFOLLOW) of
+// the path and then doing unix.Readlinkat(fd, ""), but with the benefit that
+// thread locking is not necessary for ProcBaseThreadSelf.
+func ProcReadlink(base ProcBase, path string) (string, error) {
+	pathrsBase, err := base.toPathrsBase()
+	if err != nil {
+		return "", err
+	}
+	return pathrsProcReadlink(pathrsBase, path)
+}

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -21,7 +21,9 @@ use crate::{
         ret::{self, IntoCReturn},
         utils,
     },
-    error, syscalls,
+    error,
+    procfs::PROCFS_HANDLE,
+    syscalls,
     utils::RawFdExt,
     InodeType, OpenFlags, RenameFlags, Root,
 };
@@ -86,7 +88,7 @@ pub extern "C" fn pathrs_root_open(path: *const c_char) -> RawFd {
 pub extern "C" fn pathrs_reopen(fd: RawFd, flags: c_int) -> RawFd {
     let flags = OpenFlags::from_bits_retain(flags);
 
-    fd.reopen(flags)
+    fd.reopen(&PROCFS_HANDLE, flags)
         .and_then(|file| {
             // Rust sets O_CLOEXEC by default, without an opt-out. We need to
             // disable it if we weren't asked to do O_CLOEXEC.

--- a/src/capi/mod.rs
+++ b/src/capi/mod.rs
@@ -26,6 +26,9 @@
 /// Core pathrs function wrappers.
 pub mod core;
 
+/// procfs-related function wrappers.
+pub mod procfs;
+
 /// Helpers for converting Result<...> into C-style int returns.
 pub mod ret;
 

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -1,0 +1,187 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi::{ret::IntoCReturn, utils},
+    error::Error,
+    procfs::{ProcfsBase, PROCFS_HANDLE},
+    OpenFlags,
+};
+
+use std::{
+    cmp,
+    ffi::CString,
+    os::{fd::RawFd, unix::ffi::OsStringExt},
+    ptr,
+};
+
+use libc::{c_char, c_int, size_t};
+
+/// Indicate what base directory should be used when doing operations with
+/// pathrs_proc_*. This is necessary because /proc/thread-self is not present on
+/// pre-3.17 kernels and so it may be necessary to emulate /proc/thread-self
+/// access on those older kernels.
+///
+/// NOTE: Currently, operating on /proc/... directly is not supported.
+///
+/// [`ProcfsHandle`]: struct.ProcfsHandle.html
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[allow(non_camel_case_types, dead_code)]
+pub enum CProcfsBase {
+    //PATHRS_PROC_ROOT, // TODO
+    /// Use /proc/self. For most programs, this is the standard choice.
+    PATHRS_PROC_SELF = 0x091D_5E1F,
+
+    /// Use /proc/thread-self. In multi-threaded programs where one thread has a
+    /// different CLONE_FS, it is possible for /proc/self to point the wrong
+    /// thread and so /proc/thread-self may be necessary.
+    ///
+    /// NOTE: Using /proc/thread-self may require care if used from langauges
+    /// where your code can change threads without warning and old threads can
+    /// be killed (such as Go -- where you want to use runtime.LockOSThread).
+    PATHRS_PROC_THREAD_SELF = 0x3EAD_5E1F,
+}
+
+impl From<CProcfsBase> for ProcfsBase {
+    fn from(c_base: CProcfsBase) -> Self {
+        match c_base {
+            CProcfsBase::PATHRS_PROC_SELF => ProcfsBase::ProcSelf,
+            CProcfsBase::PATHRS_PROC_THREAD_SELF => ProcfsBase::ProcThreadSelf,
+        }
+    }
+}
+
+/// Safely open a path inside a `/proc` handle.
+///
+/// Any bind-mounts or other over-mounts will (depending on what kernel features
+/// are available) be detected and an error will be returned. Non-trailing
+/// symlinks are followed but care is taken to ensure the symlinks are
+/// legitimate.
+///
+/// Unless you intend to open a magic-link, `O_NOFOLLOW` should be set in flags.
+/// Lookups with `O_NOFOLLOW` are guaranteed to never be tricked by bind-mounts
+/// (on new enough Linux kernels).
+///
+/// If you wish to resolve a magic-link, you need to unset `O_NOFOLLOW`.
+/// Unfortunately (if libpathrs is using the regular host `/proc` mount), this
+/// lookup mode cannot protect you against an attacker that can modify the mount
+/// table during this operation.
+///
+/// NOTE: Instead of using paths like `/proc/thread-self/fd`, `base` is used to
+/// indicate what "base path" inside procfs is used. For example, to re-open a
+/// file descriptor:
+///
+/// ```c
+/// fd = pathrs_proc_open(PATHRS_PROC_THREAD_SELF, "fd/101", O_RDWR);
+/// if (fd < 0) {
+///     liberr = fd; // for use with pathrs_errorinfo()
+///     goto err;
+/// }
+/// ```
+///
+/// # Return Value
+///
+/// On success, this function returns a file descriptor.
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_proc_open(base: CProcfsBase, path: *const c_char, flags: c_int) -> RawFd {
+    || -> Result<_, Error> {
+        let path = utils::parse_path(path)?;
+        let oflags = OpenFlags::from_bits_retain(flags);
+
+        match oflags.contains(OpenFlags::O_NOFOLLOW) {
+            true => PROCFS_HANDLE.open(base.into(), path, oflags),
+            false => PROCFS_HANDLE.open_follow(base.into(), path, oflags),
+        }
+    }()
+    .into_c_return()
+}
+
+/// Safely read the contents of a symlink inside `/proc`.
+///
+/// As with `pathrs_proc_open`, any bind-mounts or other over-mounts will
+/// (depending on what kernel features are available) be detected and an error
+/// will be returned. Non-trailing symlinks are followed but care is taken to
+/// ensure the symlinks are legitimate.
+///
+/// This function is effectively shorthand for
+///
+/// ```c
+/// fd = pathrs_proc_readlink(base, path, O_PATH|O_NOFOLLOW);
+/// if (fd < 0) {
+///     liberr = fd; // for use with pathrs_errorinfo()
+///     goto err;
+/// }
+/// copied = readlinkat(fd, "", linkbuf, linkbuf_size);
+/// close(fd);
+/// ```
+///
+/// # Return Value
+///
+/// On success, this function copies the symlink contents to `linkbuf` (up to
+/// `linkbuf_size` bytes) and returns the full size of the symlink path buffer.
+/// This function will not copy the trailing NUL byte, and the return size does
+/// not include the NUL byte. A `NULL` `linkbuf` or invalid `linkbuf_size` are
+/// treated as zero-size buffers.
+///
+/// NOTE: Unlike `readlinkat(2)`, in the case where `linkbuf` is too small to
+/// contain the symlink contents, `pathrs_proc_readlink` will return *the number
+/// of bytes it would have copied if the buffer was large enough*.
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_proc_readlink(
+    base: CProcfsBase,
+    path: *const c_char,
+    linkbuf: *mut c_char,
+    linkbuf_size: size_t,
+) -> c_int {
+    || -> Result<_, Error> {
+        let path = utils::parse_path(path)?;
+
+        let link_target = CString::new(
+            PROCFS_HANDLE
+                .readlink(base.into(), path)?
+                .into_os_string()
+                .into_vec(),
+        )
+        .expect("link from readlink should not contain any nulls");
+
+        // If the linkbuf is null, we just return the number of bytes we
+        // would've written.
+        if !linkbuf.is_null() && linkbuf_size > 0 {
+            let to_copy = cmp::min(link_target.count_bytes(), linkbuf_size);
+            // SAFETY: The C caller guarantees that linkbuf is safe to write to
+            // up to linkbuf_size bytes.
+            unsafe {
+                ptr::copy_nonoverlapping(link_target.as_ptr(), linkbuf, to_copy);
+            }
+        }
+
+        Ok(link_target.count_bytes() as c_int)
+    }()
+    .into_c_return()
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -18,7 +18,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{error::Error, flags::OpenFlags, utils::RawFdExt};
+use crate::{error::Error, flags::OpenFlags, procfs::PROCFS_HANDLE, utils::RawFdExt};
 
 use std::fs::File;
 
@@ -63,7 +63,7 @@ impl Handle {
     /// [`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
     /// [`Root::create`]: struct.Root.html#method.create
     pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
-        self.inner.reopen(flags.into())
+        self.inner.reopen(&PROCFS_HANDLE, flags.into())
     }
 
     /// Create a copy of an existing [`Handle`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@ mod resolvers;
 #[doc(inline)]
 pub use resolvers::{Resolver, ResolverBackend, ResolverFlags};
 
+// Safe procfs handles.
+mod procfs;
+
 // C API.
 mod capi;
 

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -1,0 +1,328 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    error::{self, Error},
+    syscalls, utils, OpenFlags,
+};
+
+use std::{
+    convert::TryFrom,
+    fs::File,
+    os::fd::AsRawFd,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+use snafu::{OptionExt, ResultExt};
+
+lazy_static! {
+    /// A `procfs` handle to which is used globally by libpathrs.
+    pub(crate) static ref PROCFS_HANDLE: ProcfsHandle =
+        ProcfsHandle::new().expect("should be able to get some /proc handle");
+}
+
+/// Indicate what base directory should be used when doing `/proc/...`
+/// operations with [`ProcfsHandle`]. This is necessary because
+/// `/proc/thread-self` is not present on pre-3.17 kernels and so it may be
+/// necessary to emulate `/proc/thread-self` access on those older kernels.
+///
+/// [`ProcfsHandle`]: struct.ProcfsHandle.html
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // TODO: Remove when we export this properly.
+pub(crate) enum ProcfsBase {
+    /// Use `/proc/self`. For most programs, this is the standard choice.
+    ProcSelf,
+    /// Use `/proc/thread-self`. In multi-threaded programs where one thread has
+    /// a different `CLONE_FS`, it is possible for `/proc/self` to point the
+    /// wrong thread and so `/proc/thread-self` may be necessary.
+    ProcThreadSelf,
+}
+
+impl ProcfsBase {
+    pub(crate) fn into_path(self) -> PathBuf {
+        match self {
+            Self::ProcSelf => PathBuf::from("self"),
+            // TODO: Add fallback handling for pre-3.17 kernels.
+            Self::ProcThreadSelf => PathBuf::from("thread-self"),
+        }
+    }
+    // TODO: Add into_raw_path() that doesn't use symlinks?
+}
+
+/// A wrapper around a handle to `/proc` that is designed to be safe against
+/// various attacks.
+///
+/// Unlike most regular filesystems, `/proc` serves several important purposes
+/// for system administration programs:
+///
+///  1. As a mechanism for doing certain filesystem operations through
+///     `/proc/self/fd/...` (and other similar magic-links) that cannot be done
+///     by other means.
+///  2. As a source of true information about processes and the general system.
+///  3. As an administrative tool for managing other processes (such as setting
+///     LSM labels).
+///
+/// libpathrs uses `/proc` internally for the first purpose and many libpathrs
+/// users use `/proc` for all three. As such, it is not sufficient that
+/// operations on `/proc` paths do not escape the `/proc` filesystem -- it is
+/// absolutely critical that operations through `/proc` operate on the path that
+/// the caller expected.
+///
+/// This might seem like an esoteric concern, but there have been several
+/// security vulnerabilities where a maliciously configured `/proc` could be
+/// used to trick administrative processes into doing unexpected operations (for
+/// example, [CVE-2019-16884][] and [CVE-2019-19921][]). See [this
+/// video][lca2020] for a longer explanation of the many other issues that
+/// `/proc`-based checking is needed to protect against and [this other
+/// video][lpc2022] for some other procfs challenges libpathrs has to contend
+/// with.
+///
+/// NOTE: At the moment, `ProcfsHandle` only supports doing operations within
+/// `/proc/self` and `/proc/thread-self/`. This is because there are tools like
+/// [lxcfs] which intentionally mask parts of `/proc` in order to fix issues
+///
+/// [cve-2019-16884]: https://nvd.nist.gov/vuln/detail/CVE-2019-16884
+/// [cve-2019-19921]: https://nvd.nist.gov/vuln/detail/CVE-2019-19921
+/// [lca2020]: https://youtu.be/tGseJW_uBB8
+/// [lpc2022]: https://youtu.be/y1PaBzxwRWQ
+/// [lxcfs]: https://github.com/lxc/lxcfs
+#[derive(Debug)]
+pub(crate) struct ProcfsHandle {
+    inner: File,
+}
+
+// TODO: Add mnt_id hardening.
+
+// TODO: Use a restricted resolver for doing subpath lookups.
+
+impl ProcfsHandle {
+    // This is part of Linux's ABI.
+    const PROC_ROOT_INO: u64 = 1;
+
+    pub fn new() -> Result<Self, Error> {
+        // TODO: Add support for fsopen(2) and open_tree(2) based proc handles,
+        // which are safe against racing mounts (for the privileged users that
+        // can create them).
+        syscalls::openat(libc::AT_FDCWD, "/proc", libc::O_PATH | libc::O_DIRECTORY, 0)
+            .context(error::RawOsSnafu {
+                operation: "open /proc handle",
+            })
+            // NOTE: try_from checks this is an actual procfs root.
+            .and_then(Self::try_from)
+    }
+
+    fn check_is_procfs(file: &File) -> Result<(), Error> {
+        let fs_type = syscalls::fstatfs(file.as_raw_fd())
+            .context(error::RawOsSnafu {
+                operation: "fstatfs proc handle",
+            })?
+            .f_type;
+        ensure!(
+            fs_type == libc::PROC_SUPER_MAGIC,
+            error::SafetyViolationSnafu {
+                description: format!(
+                    "/proc is not procfs (f_type is 0x{:X}, not 0x{:X})",
+                    fs_type,
+                    libc::PROC_SUPER_MAGIC
+                ),
+            }
+        );
+        Ok(())
+    }
+
+    fn open_base(&self, base: ProcfsBase) -> Result<File, Error> {
+        // TODO: Switch this with a proper resolver.
+        let file = syscalls::openat_follow(
+            self.inner.as_raw_fd(),
+            base.into_path(),
+            libc::O_PATH | libc::O_DIRECTORY,
+            0,
+        )
+        .context(error::RawOsSnafu {
+            operation: "open procfs base path",
+        })?;
+        // TODO: Until we add STATX_MNT_ID checks, the best we can do is check
+        // the fs_type to avoid mounts non-procfs filesystems. Unfortunately,
+        // attackers can bind-mount procfs files and still cause damage so this
+        // protection is marginal at best.
+        Self::check_is_procfs(&file)?;
+        Ok(file)
+    }
+
+    pub fn open_follow<P: AsRef<Path>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        mut flags: OpenFlags,
+    ) -> Result<File, Error> {
+        let subpath = subpath.as_ref();
+
+        // Drop any trailing /-es.
+        let (subpath, trailing_slash) = utils::path_strip_trailing_slash(subpath);
+        if trailing_slash {
+            // A trailing / implies we want O_DIRECTORY.
+            flags.insert(OpenFlags::O_DIRECTORY);
+        }
+
+        // If the target is not a symlink, use an O_NOFOLLOW open. This defends
+        // against C users forgetting to set O_NOFOLLOW for files that aren't
+        // magic-links and thus shouldn't be followed.
+        //
+        // We could do this after splitting the path and getting the directory
+        // components (to reduce the amount of work on non-openat2 systems), but
+        // that would be more work for openat2 systems so let's give preference
+        // to openat2.
+        if self.readlink(base, subpath).is_err() {
+            return self.open(base, subpath, flags);
+        }
+
+        // Get a no-follow handle to the parent of the magic-link.
+        let (parent, trailing) = utils::path_split(subpath)?;
+        let trailing = trailing.context(error::InvalidArgumentSnafu {
+            name: "path",
+            description: "proc_open_follow path has trailing slash",
+        })?;
+
+        let parent = self.open(base, parent, OpenFlags::O_PATH | OpenFlags::O_DIRECTORY)?;
+
+        // TODO: Until we add STATX_MNT_ID checks, the best we can do is check
+        // the fs_type to avoid mounts non-procfs filesystems. Unfortunately,
+        // attackers can bind-mount procfs files and still cause damage so this
+        // protection is marginal at best.
+        Self::check_is_procfs(&parent)?;
+
+        syscalls::openat_follow(parent.as_raw_fd(), trailing, flags.bits(), 0).context(
+            error::RawOsSnafu {
+                operation: "open final magiclink component",
+            },
+        )
+    }
+
+    pub fn open<P: AsRef<Path>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: OpenFlags,
+    ) -> Result<File, Error> {
+        let base = self.open_base(base)?;
+
+        // TODO: Switch this with a proper resolver.
+        let file = syscalls::openat(
+            base.as_raw_fd(),
+            subpath,
+            flags.bits() | libc::O_PATH | libc::O_NOFOLLOW,
+            0,
+        )
+        .context(error::RawOsSnafu {
+            operation: "open procfs path",
+        })?;
+        // TODO: Until we add STATX_MNT_ID checks, the best we can do is check
+        // the fs_type to avoid mounts non-procfs filesystems. Unfortunately,
+        // attackers can bind-mount procfs files and still cause damage so this
+        // protection is marginal at best.
+        Self::check_is_procfs(&file)?;
+        Ok(file)
+    }
+
+    pub fn readlink<P: AsRef<Path>>(&self, base: ProcfsBase, subpath: P) -> Result<PathBuf, Error> {
+        let link = self.open(base, subpath, OpenFlags::O_PATH | OpenFlags::O_NOFOLLOW)?;
+        syscalls::readlinkat(link.as_raw_fd(), "").context(error::RawOsSnafu {
+            operation: "read procfs magiclink",
+        })
+    }
+}
+
+impl TryFrom<File> for ProcfsHandle {
+    type Error = Error;
+
+    fn try_from(inner: File) -> Result<Self, Self::Error> {
+        // Make sure the file is actually a procfs handle.
+        Self::check_is_procfs(&inner)?;
+
+        // And make sure it's the root of procfs. The root directory is
+        // guaranteed to have an inode number of PROC_ROOT_INO. If this check
+        // ever stops working, it's a kernel regression.
+        let ino = inner.metadata().expect("fstat(/proc) should work").ino();
+        ensure!(
+            ino == Self::PROC_ROOT_INO,
+            error::SafetyViolationSnafu {
+                description: format!(
+                    "/proc is not root of a procfs mount (ino is 0x{:X}, not 0x{:X})",
+                    ino,
+                    Self::PROC_ROOT_INO,
+                )
+            }
+        );
+
+        Ok(Self { inner })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::File;
+
+    #[test]
+    fn bad_root() {
+        let file = File::open("/").expect("open root");
+        let procfs = ProcfsHandle::try_from(file);
+
+        assert!(
+            procfs.is_err(),
+            "creating a procfs handle from the wrong filesystem should return an error"
+        );
+    }
+
+    #[test]
+    fn bad_tmpfs() {
+        let file = File::open("/tmp").expect("open tmpfs");
+        let procfs = ProcfsHandle::try_from(file);
+
+        assert!(
+            procfs.is_err(),
+            "creating a procfs handle from the wrong filesystem should return an error"
+        );
+    }
+
+    #[test]
+    fn bad_proc_nonroot() {
+        let file = File::open("/proc/tty").expect("open tmpfs");
+        let procfs = ProcfsHandle::try_from(file);
+
+        assert!(
+            procfs.is_err(),
+            "creating a procfs handle from non-root of procfs should return an error"
+        );
+    }
+
+    #[test]
+    fn new() {
+        let procfs = ProcfsHandle::new();
+        assert!(
+            procfs.is_ok(),
+            "new procfs handle should succeed, got {:?}",
+            procfs
+        );
+    }
+}

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -137,7 +137,7 @@ impl ProcfsHandle {
     // This is part of Linux's ABI.
     const PROC_ROOT_INO: u64 = 1;
 
-    fn new_fsopen() -> Result<Self, Error> {
+    pub(crate) fn new_fsopen() -> Result<Self, Error> {
         let sfd =
             syscalls::fsopen("proc", FsopenFlags::FSOPEN_CLOEXEC).context(error::RawOsSnafu {
                 operation: "create procfs suberblock",
@@ -164,7 +164,7 @@ impl ProcfsHandle {
         .and_then(Self::try_from)
     }
 
-    fn new_open_tree(flags: OpenTreeFlags) -> Result<Self, Error> {
+    pub(crate) fn new_open_tree(flags: OpenTreeFlags) -> Result<Self, Error> {
         syscalls::open_tree(
             -libc::EBADF,
             "/proc",
@@ -177,7 +177,7 @@ impl ProcfsHandle {
         .and_then(Self::try_from)
     }
 
-    fn new_unsafe_open() -> Result<Self, Error> {
+    pub(crate) fn new_unsafe_open() -> Result<Self, Error> {
         syscalls::openat(libc::AT_FDCWD, "/proc", libc::O_PATH | libc::O_DIRECTORY, 0)
             .context(error::RawOsSnafu {
                 operation: "open /proc handle",

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -26,6 +26,11 @@ use std::{fs::File, path::Path};
 pub mod opath;
 /// `openat2(2)`-based in-kernel resolver.
 pub mod openat2;
+/// A limited resolver only used for `/proc` lookups in `ProcfsHandle`.
+pub(crate) mod procfs;
+
+/// Maximum number of symlink traversals we will accept.
+const MAX_SYMLINK_TRAVERSALS: usize = 128;
 
 bitflags! {
     /// Optional flags to modify the resolution of paths inside a [`Root`].

--- a/src/resolvers/opath.rs
+++ b/src/resolvers/opath.rs
@@ -37,8 +37,8 @@
 
 use crate::{
     error::{self, Error, ErrorExt},
-    resolvers::ResolverFlags,
     procfs::PROCFS_HANDLE,
+    resolvers::{ResolverFlags, MAX_SYMLINK_TRAVERSALS},
     syscalls,
     utils::{FileExt, RawComponentsIter, RawFdExt},
     Handle,
@@ -56,9 +56,6 @@ use std::{
 };
 
 use snafu::ResultExt;
-
-/// Maximum number of symlink traversals we will accept.
-const MAX_SYMLINK_TRAVERSALS: usize = 128;
 
 /// Ensure that the expected path within the root matches the current fd.
 fn check_current<P: AsRef<Path>>(current: &File, root: &File, expected: P) -> Result<(), Error> {

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -1,0 +1,492 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! `procfs_beneath::resolve` is a very minimal resolver that doesn't allow:
+//!
+//!  1. Any ".." components.
+//!  2. Any absolute symlinks.
+//!  3. (If `statx` is supported), any mount-point crossings are disallowed.
+//!
+//! This allows us to avoid using any `/proc` checks, and thus this resolver can
+//! be used within the `pathrs::procfs` helpers that are used by other parts of
+//! libpathrs.
+
+// TODO: So much of this code is a copy of opath::resolver, maybe we can merge
+// them somehow?
+
+use crate::{
+    error::{self, Error, ErrorExt},
+    flags::OpenFlags,
+    resolvers::{ResolverFlags, MAX_SYMLINK_TRAVERSALS},
+    syscalls::{self, OpenHow},
+    utils::{self, RawComponentsIter, RawFdExt},
+};
+
+use std::{
+    collections::VecDeque, fs::File, io::Error as IOError, os::fd::AsRawFd,
+    os::unix::ffi::OsStrExt, path::Path,
+};
+
+use snafu::ResultExt;
+
+/// Used internally for tests to force the usage of a specific resolver. You
+/// should always use the default.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ProcfsResolver {
+    Openat2,
+    RestrictedOpath,
+}
+
+impl Default for ProcfsResolver {
+    fn default() -> Self {
+        if *syscalls::OPENAT2_IS_SUPPORTED {
+            Self::Openat2
+        } else {
+            Self::RestrictedOpath
+        }
+    }
+}
+
+impl ProcfsResolver {
+    pub(crate) fn resolve<P: AsRef<Path>>(
+        &self,
+        root: &File,
+        path: P,
+        mut oflags: OpenFlags,
+        mut rflags: ResolverFlags,
+    ) -> Result<File, Error> {
+        // These flags don't make sense for procfs and will just result in
+        // confusing errors during lookup. O_TMPFILE contains multiple flags
+        // (including O_DIRECTORY!) so we have to check it separately.
+        let invalid_flags = OpenFlags::O_CREAT | OpenFlags::O_EXCL;
+        ensure!(
+            oflags.intersection(invalid_flags).is_empty() && !oflags.contains(OpenFlags::O_TMPFILE),
+            error::InvalidArgumentSnafu {
+                name: "flags",
+                description: format!(
+                    "invalid flags {:?} specified",
+                    oflags.intersection(invalid_flags)
+                ),
+            },
+        );
+
+        // If O_NOFOLLOW was specified, convert it to NO_FOLLOW_TRAILING.
+        if oflags.contains(OpenFlags::O_NOFOLLOW) {
+            rflags.insert(ResolverFlags::NO_FOLLOW_TRAILING);
+        }
+        if rflags.contains(ResolverFlags::NO_FOLLOW_TRAILING) {
+            oflags.insert(OpenFlags::O_NOFOLLOW);
+        }
+
+        match *self {
+            Self::Openat2 => openat2_resolve(root, path, oflags, rflags),
+            Self::RestrictedOpath => opath_resolve(root, path, oflags, rflags),
+        }
+    }
+}
+
+fn openat2_resolve<P: AsRef<Path>>(
+    root: &File,
+    path: P,
+    oflags: OpenFlags,
+    rflags: ResolverFlags,
+) -> Result<File, Error> {
+    ensure!(
+        *syscalls::OPENAT2_IS_SUPPORTED,
+        error::NotSupportedSnafu { feature: "openat2" }
+    );
+
+    // Copy the O_NOFOLLOW and RESOLVE_NO_SYMLINKS bits from rflags.
+    let oflags = oflags.bits() as u64 | rflags.openat2_flag_bits();
+    let rflags = libc::RESOLVE_BENEATH
+        | libc::RESOLVE_NO_MAGICLINKS
+        | libc::RESOLVE_NO_XDEV
+        | rflags.openat2_resolve_bits();
+
+    syscalls::openat2(
+        root.as_raw_fd(),
+        path,
+        &OpenHow {
+            flags: oflags,
+            resolve: rflags,
+            ..Default::default()
+        },
+    )
+    .context(error::RawOsSnafu {
+        operation: "open subpath in procfs",
+    })
+}
+
+fn check_mnt_id(root_mnt_id: Option<u64>, file: &File) -> Result<(), Error> {
+    let got_mnt_id = utils::fetch_mnt_id(file, "")?;
+    if got_mnt_id != root_mnt_id {
+        Err(IOError::from_raw_os_error(libc::EXDEV))
+            .context(error::OsSnafu {
+                operation: "emulated RESOLVE_NO_XDEV",
+            })
+            .with_wrap(|| {
+                format!(
+                "mount id mismatch in restricted procfs resolver (mnt_id is {:?}, not procfs {:?})",
+                got_mnt_id, root_mnt_id
+            )
+            })?;
+    }
+    Ok(())
+}
+
+fn opath_resolve<P: AsRef<Path>>(
+    root: &File,
+    path: P,
+    oflags: OpenFlags,
+    rflags: ResolverFlags,
+) -> Result<File, Error> {
+    let root_mnt_id = utils::fetch_mnt_id(root, "")?;
+
+    // We only need to keep track of our current dirfd, since we are applying
+    // the components one-by-one.
+    let mut current = root.try_clone_hotfix().wrap("dup root as starting point")?;
+
+    // Get initial set of components from the passed path. We remove components
+    // as we do the path walk, and update them with the contents of any symlinks
+    // we encounter. Path walking terminates when there are no components left.
+    let mut remaining_components = path
+        .as_ref()
+        .raw_components()
+        .map(|p| p.to_os_string())
+        .collect::<VecDeque<_>>();
+
+    let mut symlink_traversals = 0;
+    while let Some(part) = remaining_components
+        .pop_front()
+        // If we hit an empty component, we need to treat it as though it is
+        // "." so that trailing "/" and "//" components on a non-directory
+        // correctly return the right error code.
+        .map(|part| if part.is_empty() { ".".into() } else { part })
+    {
+        // We cannot walk into ".." without checking if there was a breakout
+        // with /proc (a-la opath::resolve) so return an error if we hit "..".
+        if part.as_bytes() == b".." {
+            return Err(IOError::from_raw_os_error(libc::EXDEV))
+                .context(error::OsSnafu {
+                    operation: "step into '..'",
+                })
+                .wrap("cannot walk into '..' with restricted procfs resolver")?;
+        }
+
+        // Get our next element.
+        let next = syscalls::openat(
+            current.as_raw_fd(),
+            &part,
+            libc::O_PATH | libc::O_NOFOLLOW,
+            0,
+        )
+        .context(error::RawOsSnafu {
+            operation: "open next component of resolution",
+        })?;
+
+        // Check that the next component is on the same mountpoint.
+        // NOTE: If the root is the host /proc mount, this is only safe if there
+        // are no racing mounts.
+        check_mnt_id(root_mnt_id, &next).with_wrap(|| format!("open next component {:?}", part))?;
+
+        let next_type = next
+            // NOTE: File::metadata definitely does an fstat(2) here.
+            .metadata()
+            .context(error::OsSnafu {
+                operation: "fstat of next component",
+            })?
+            .file_type();
+
+        // If this is the last component, try to open the same component again
+        // with with the requested flags. Unlike the other Handle resolvers, we
+        // can't re-open the file through procfs (since this is the resolver
+        // used for procfs lookups) so we need to do it this way.
+        //
+        // Because we force O_NOFOLLOW for safety reasons, we can't just blindly
+        // return the error we get from openat here (in particular, if the user
+        // specifies O_PATH or O_DIRECTORY without O_NOFOLLOW, you will get the
+        // wrong results). The following is a table of the relevant cases.
+        //
+        // Each entry of the form [a](b) means that the user expects [a] to
+        // happen but because of O_NOFOLLOW we get (b). **These are the cases
+        // which we need to handle with care.**
+        //
+        //                   symlink        directory    other-file
+        //
+        // OPATH         [cont](ret-sym) *1    ret           ret
+        // ODIR          [cont](ENOTDIR) *2    ret         ENOTDIR
+        // OPATH|ODIR    [cont](ENOTDIR) *3    ret         ENOTDIR
+        // ONF               ELOOP             ret           ret
+        // ONF|OPATH        ret-sym      *4    ret           ret
+        // ONF|ODIR         ENOTDIR            ret         ENOTDIR
+        // ONF|OPATH|ODIR   ENOTDIR            ret         EDOTDIR
+        //
+        // Legend:
+        // - Flags:
+        //   - OPATH = O_PATH, ODIR = O_DIRECTORY, ONF = O_NOFOLLOW
+        // - Actions:
+        //   - ret     = return this handle as the final component
+        //   - ret-sym = return this *symlink* handle as the final component
+        //   - cont    = continue iterating (for symlinks)
+        //   - EFOO    = returns an error EFOO
+        //
+        // Unfortunately, note that you -ENOTDIR for most of the file and
+        // symlink cases, but we need to differentiate between them. That's why
+        // we need to do the O_PATH|O_NOFOLLOW first -- we need to figure out
+        // whether we are dealing with a symlink or not. If we are dealing with
+        // a symlink, we want to continue walking in all cases (except plain
+        // O_NOFOLLOW and O_DIRECTORY|O_NOFOLLOW).
+        //
+        // NOTE: There is a possible race here -- the file type might've changed
+        // after we opened it. This is unlikely under procfs because the
+        // structure is basically static (an attacker could bind-mount something
+        // but we detect bind-mounts already), but even if it did happen the
+        // worst case result is that we return an error.
+        //
+        // NOTE: Most of these cases don't apply to the ProcfsResolver because
+        // it handles trailing-symlink follows manually and auto-applies
+        // O_NOFOLLOW if the trailing component is not a symlink. However, we
+        // handle them all for correctness reasons (and we have tests for the
+        // resolver itself to verify the behaviour).
+        if remaining_components.is_empty()
+            // Case (*1):
+            // If the user specified *just* O_PATH (without O_NOFOLLOW nor
+            // O_DIRECTORY), we can continue to parse as normal (if next_type is
+            // a non-symlink we will return it, if it is a symlink we will
+            // continue walking).
+            && oflags.intersection(OpenFlags::O_PATH | OpenFlags::O_NOFOLLOW | OpenFlags::O_DIRECTORY) != OpenFlags::O_PATH
+        {
+            match syscalls::openat(
+                current.as_raw_fd(),
+                &part,
+                oflags.bits() | libc::O_NOFOLLOW,
+                0,
+            ) {
+                Ok(final_reopen) => {
+                    // Re-verify the next component is on the same mount.
+                    check_mnt_id(root_mnt_id, &final_reopen).wrap("open final component")?;
+                    return Ok(final_reopen);
+                }
+                Err(err) => {
+                    // Cases (*2) and (*3):
+                    //
+                    // If all of the following are true:
+                    //
+                    //  1. The user didn't ask for O_NOFOLLOW.
+                    //  2. The user did ask for O_DIRECTORY.
+                    //  3. The error is ENOTDIR.
+                    //  4. The next component was a symlink.
+                    //
+                    // We want to continue walking, rather than return an error.
+                    if oflags.contains(OpenFlags::O_NOFOLLOW)
+                        || !oflags.contains(OpenFlags::O_DIRECTORY)
+                        || err.root_cause().raw_os_error() != Some(libc::ENOTDIR)
+                        || !next_type.is_symlink()
+                    {
+                        return Err(err).context(error::RawOsSnafu {
+                            operation: format!(
+                                "open last component of resolution with {:?}",
+                                oflags
+                            ),
+                        })?;
+                    }
+                }
+            }
+        }
+
+        // Is the next dirfd a symlink or an ordinary path? If we're an ordinary
+        // dirent, we just update current and move on to the next component.
+        // Nothing special here.
+        if !next_type.is_symlink() {
+            current = next;
+            continue;
+        }
+
+        // Don't continue walking if user asked for no symlinks.
+        if rflags.contains(ResolverFlags::NO_SYMLINKS) {
+            return Err(IOError::from_raw_os_error(libc::ELOOP))
+                .context(error::OsSnafu {
+                    operation: "emulated symlink resolution",
+                })
+                .with_wrap(|| {
+                    format!(
+                        "component {:?} is a symlink but symlink resolution is disabled",
+                        part
+                    )
+                })?;
+        }
+
+        // We need a limit on the number of symlinks we traverse to avoid
+        // hitting filesystem loops and DoSing.
+        //
+        // Given all of the other restrictions of this lookup code, it seems unlikely
+        // that you could even run into a symlink loop (procfs doesn't have
+        // regular symlink loops). But for procfs can
+        symlink_traversals += 1;
+        if symlink_traversals >= MAX_SYMLINK_TRAVERSALS {
+            return Err(IOError::from_raw_os_error(libc::ELOOP)).context(error::OsSnafu {
+                operation: "emulated symlink resolution",
+            })?;
+        }
+
+        let link_target =
+            syscalls::readlinkat(next.as_raw_fd(), "").context(error::RawOsSnafu {
+                operation: "readlink next symlink component",
+            })?;
+
+        // The hardened resolver is called using a root that is a subdir of
+        // /proc (such as /proc/self or /proc/thread-self), so it makes no sense
+        // to try to scope absolute symlinks. Also, we shouldn't expect to walk
+        // into an absolute symlink (which is almost certainly a magic-link --
+        // though we can't detect that directly without openat2).
+        if link_target.is_absolute() {
+            return Err(IOError::from_raw_os_error(libc::ELOOP))
+                .context(error::OsSnafu {
+                    operation: format!("step into absolute symlink {:?}", link_target),
+                })
+                .wrap("cannot walk into absolute symlinks with restricted procfs resolver")?;
+        }
+
+        link_target
+            .raw_components()
+            .prepend(&mut remaining_components);
+    }
+
+    Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        error::{Error as PathrsError, ErrorKind},
+        resolvers::procfs::ProcfsResolver,
+        syscalls,
+        tests::common as tests_common,
+        utils::RawFdExt,
+        OpenFlags, ResolverFlags,
+    };
+
+    use std::{fs::File, path::PathBuf};
+
+    use anyhow::Error;
+
+    type ExpectedResult = Result<PathBuf, ErrorKind>;
+
+    macro_rules! procfs_resolver_tests {
+        ($($test_name:ident ($root:expr, $path:expr, $($oflag:ident)|+, $rflags:expr) == $expected_result:expr);* $(;)?) => {
+            $(
+                paste::paste! {
+                    #[test]
+                    fn [<procfs_openat2_resolver_ $test_name>]() -> Result<(), Error> {
+                        if !*syscalls::OPENAT2_IS_SUPPORTED {
+                            // skip test
+                            return Ok(());
+                        }
+                        let root_dir: PathBuf = $root.into();
+                        let root = File::open(&root_dir)?;
+                        let expected: ExpectedResult = $expected_result.map(|p: PathBuf| root_dir.join(p));
+                        let oflags = $(OpenFlags::$oflag)|*;
+                        let res = ProcfsResolver::Openat2
+                            .resolve(&root, $path, oflags, $rflags)
+                            .as_ref()
+                            .map(|f| {
+                                f.as_unsafe_path_unchecked()
+                                    .expect("get actual path of resolved handle")
+                            })
+                            .map_err(PathrsError::kind);
+                        assert_eq!(
+                            res, expected,
+                            "expected resolve({:?}, {:?}, {:?}, {:?}) to give {:?}, got {:?}",
+                            $root, $path, oflags, $rflags, expected, res
+                        );
+                        Ok(())
+                    }
+
+                    #[test]
+                    fn [<procfs_opath_resolver_ $test_name>]() -> Result<(), Error> {
+                        let root_dir: PathBuf = $root.into();
+                        let root = File::open(&root_dir)?;
+                        let expected: ExpectedResult = $expected_result.map(|p: PathBuf| root_dir.join(p));
+                        let oflags = $(OpenFlags::$oflag)|*;
+                        let res = ProcfsResolver::RestrictedOpath
+                            .resolve(&root, $path, oflags, $rflags)
+                            .as_ref()
+                            .map(|f| {
+                                f.as_unsafe_path_unchecked()
+                                    .expect("get actual path of resolved handle")
+                            })
+                            .map_err(PathrsError::kind);
+                        assert_eq!(
+                            res, expected,
+                            "expected resolve({:?}, {:?}, {:?}, {:?}) to give {:?}, got {:?}",
+                            $root, $path, oflags, $rflags, expected, res
+                        );
+                        Ok(())
+                    }
+                }
+            )*
+        };
+    }
+
+    procfs_resolver_tests! {
+        xdev("/", "proc", O_DIRECTORY, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::EXDEV)));
+        bad_flag_ocreat("/tmp", "foobar", O_CREAT|O_RDWR, ResolverFlags::empty()) == Err(ErrorKind::InvalidArgument);
+        bad_flag_otmpfile("/tmp", "foobar", O_TMPFILE|O_RDWR, ResolverFlags::empty()) == Err(ErrorKind::InvalidArgument);
+
+        // Check RESOLVE_NO_SYMLINKS handling.
+        resolve_no_symlinks1("/proc", "self", O_DIRECTORY, ResolverFlags::NO_SYMLINKS) == Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        resolve_no_symlinks2("/proc", "self/status", O_RDONLY, ResolverFlags::NO_SYMLINKS) == Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        resolve_no_symlinks3("/proc", "self/../cgroups", O_RDONLY, ResolverFlags::NO_SYMLINKS) == Err(ErrorKind::OsError(Some(libc::ELOOP)));
+
+        // Check symlink loops.
+        symloop(tests_common::create_basic_tree()?.into_path(), "loop/basic-loop1", O_PATH, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        symloop_opath_onofollow(tests_common::create_basic_tree()?.into_path(), "loop/basic-loop1", O_PATH|O_NOFOLLOW, ResolverFlags::empty()) == Ok("loop/basic-loop1".into());
+
+        // Check that our {O_PATH, O_NOFOLLOW, O_DIRECTORY} logic is correct,
+        // based on the table in opath_resolve().
+
+        // OPATH         [cont](ret)     *1    ret           ret
+        sym_opath("/proc", "self", O_PATH, ResolverFlags::empty()) == Ok(format!("/proc/{}", syscalls::getpid()).into());
+        dir_opath("/proc", "tty", O_PATH, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_opath("/proc", "filesystems", O_PATH, ResolverFlags::empty()) == Ok("/proc/filesystems".into());
+        // ODIR          [cont](ENOTDIR) *2    ret         ENOTDIR
+        sym_odir("/proc", "self", O_DIRECTORY, ResolverFlags::empty()) == Ok(format!("/proc/{}", syscalls::getpid()).into());
+        dir_odir("/proc", "tty", O_DIRECTORY, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_odir("/proc", "filesystems", O_DIRECTORY, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+        // OPATH|ODIR    [cont](ENOTDIR) *3    ret         ENOTDIR
+        sym_opath_odir("/proc", "self", O_PATH|O_DIRECTORY, ResolverFlags::empty()) == Ok(format!("/proc/{}", syscalls::getpid()).into());
+        dir_opath_odir("/proc", "tty", O_PATH|O_DIRECTORY, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_opath_odir("/proc", "filesystems", O_PATH|O_DIRECTORY, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+        // ONF               ELOOP             ret           ret
+        sym_onofollow("/proc", "self", O_NOFOLLOW, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        dir_onofollow("/proc", "tty", O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_onofollow("/proc", "filesystems", O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/filesystems".into());
+        // ONF|OPATH        ret-sym            ret           ret
+        sym_opath_onofollow("/proc", "self", O_PATH|O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/self".into());
+        dir_opath_onofollow("/proc", "tty", O_PATH|O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_opath_onofollow("/proc", "filesystems", O_PATH|O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/filesystems".into());
+        // ONF|ODIR         ENOTDIR            ret         ENOTDIR
+        sym_odir_onofollow("/proc", "self", O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+        dir_odir_onofollow("/proc", "tty", O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_odir_onofollow("/proc", "filesystems", O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+        // ONF|OPATH|ODIR   ENOTDIR            ret         EDOTDIR
+        sym_opath_odir_onofollow("/proc", "self", O_PATH|O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+        dir_opath_odir_onofollow("/proc", "tty", O_PATH|O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Ok("/proc/tty".into());
+        file_opath_odir_onofollow("/proc", "filesystems", O_PATH|O_DIRECTORY|O_NOFOLLOW, ResolverFlags::empty()) == Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    }
+}

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -66,7 +66,7 @@ impl From<RawFd> for FrozenFd {
         } else {
             // SAFETY: as_unsafe_path is safe here since it is only used for
             //         pretty-printing error messages and no real logic.
-            FrozenFd(fd, fd.as_unsafe_path().ok())
+            FrozenFd(fd, fd.as_unsafe_path_unchecked().ok())
         }
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use std::{
     backtrace::Backtrace,
-    ffi::OsStr,
+    ffi::{CString, OsStr},
     fmt,
     fs::File,
     io::Error as IOError,
@@ -35,6 +35,7 @@ use std::{
         io::{FromRawFd, RawFd},
     },
     path::{Path, PathBuf},
+    ptr,
 };
 
 use libc::{c_int, dev_t, mode_t, stat, statfs};
@@ -285,6 +286,48 @@ pub enum Error {
         source: IOError,
         backtrace: Option<Backtrace>,
     },
+
+    #[snafu(display("fsopen({:?}, {:?})", fstype, flags))]
+    Fsopen {
+        fstype: String,
+        flags: FsopenFlags,
+        source: IOError,
+        backtrace: Option<Backtrace>,
+    },
+
+    #[snafu(display("fsconfig({}, FSCONFIG_CMD_CREATE)", sfd))]
+    FsconfigCreate {
+        sfd: FrozenFd,
+        source: IOError,
+        backtrace: Option<Backtrace>,
+    },
+
+    #[snafu(display("fsconfig({}, FSCONFIG_SET_STRING, {:?}, {:?})", sfd, key, value))]
+    FsconfigSetString {
+        sfd: FrozenFd,
+        key: String,
+        value: String,
+        source: IOError,
+        backtrace: Option<Backtrace>,
+    },
+
+    #[snafu(display("fsmount({}, {:?}, 0x{:x})", sfd, flags, mount_attrs))]
+    Fsmount {
+        sfd: FrozenFd,
+        flags: FsmountFlags,
+        mount_attrs: u64,
+        source: IOError,
+        backtrace: Option<Backtrace>,
+    },
+
+    #[snafu(display("open_tree({}, {:?}, {:?})", dirfd, path, flags))]
+    OpenTree {
+        dirfd: FrozenFd,
+        path: PathBuf,
+        flags: OpenTreeFlags,
+        source: IOError,
+        backtrace: Option<Backtrace>,
+    },
 }
 
 impl Error {
@@ -307,6 +350,11 @@ impl Error {
             Error::Fstatfs { source, .. } => source,
             Error::Fstatat { source, .. } => source,
             Error::Statx { source, .. } => source,
+            Error::Fsopen { source, .. } => source,
+            Error::FsconfigCreate { source, .. } => source,
+            Error::FsconfigSetString { source, .. } => source,
+            Error::Fsmount { source, .. } => source,
+            Error::OpenTree { source, .. } => source,
         }
     }
 }
@@ -815,4 +863,145 @@ pub fn getpid() -> libc::pid_t {
 pub fn gettid() -> libc::pid_t {
     // SAFETY: Obviously safe libc function.
     unsafe { libc::gettid() }
+}
+
+bitflags! {
+    #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
+    pub struct FsopenFlags: i32 {
+        const FSOPEN_CLOEXEC = 0x1;
+    }
+
+    #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
+    pub struct FsmountFlags: i32 {
+        const FSMOUNT_CLOEXEC = 0x1;
+    }
+
+    #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
+    pub struct OpenTreeFlags: i32 {
+        const AT_RECURSIVE = libc::AT_RECURSIVE;
+        const OPEN_TREE_CLOEXEC = libc::O_CLOEXEC;
+        const OPEN_TREE_CLONE = 0x1;
+    }
+}
+
+#[repr(i32)]
+#[allow(dead_code)]
+enum FsconfigCmd {
+    SetFlag = 0x0,      // FSCONFIG_SET_FLAG
+    SetString = 0x1,    // FSCONFIG_SET_STRING
+    SetBinary = 0x2,    // FSCONFIG_SET_BINARY
+    SetPath = 0x3,      // FSCONFIG_SET_PATH
+    SetPathEmpty = 0x4, // FSCONFIG_SET_PATH_EMPTY
+    SetFd = 0x5,        // FSCONFIG_SET_FD
+    Create = 0x6,       // FSCONFIG_SET_FD
+    Reconfigure = 0x7,  // FSCONFIG_SET_FD
+}
+
+pub fn fsopen<S: AsRef<str>>(fstype: S, flags: FsopenFlags) -> Result<File, Error> {
+    let fstype = fstype.as_ref();
+    let c_fstype = CString::new(fstype).expect("fsopen argument should be valid C string");
+
+    // SAFETY: Obviously safe-to-use Linux syscall.
+    let fd = unsafe { libc::syscall(libc::SYS_fsopen, c_fstype.as_ptr(), flags.bits()) as RawFd };
+    let err = IOError::last_os_error();
+
+    if fd >= 0 {
+        // SAFETY: We know it's a real file descriptor.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    } else {
+        Err(err).context(FsopenSnafu { fstype, flags })
+    }
+}
+
+pub fn fsconfig_set_string<K: AsRef<str>, V: AsRef<str>>(
+    sfd: RawFd,
+    key: K,
+    value: V,
+) -> Result<(), Error> {
+    let key = key.as_ref();
+    let c_key = CString::new(key).expect("fsconfig_set_string key should be valid C string");
+    let value = value.as_ref();
+    let c_value = CString::new(value).expect("fsconfig_set_string value should be valid C string");
+
+    // SAFETY: Obviously safe-to-use Linux syscall.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_fsconfig,
+            sfd,
+            FsconfigCmd::SetString,
+            c_key.as_ptr(),
+            c_value.as_ptr(),
+            0,
+        )
+    };
+    let err = IOError::last_os_error();
+
+    if ret >= 0 {
+        Ok(())
+    } else {
+        Err(err).context(FsconfigCreateSnafu { sfd })
+    }
+}
+
+// clippy doesn't understand that we need to specify a type for ptr::null() here
+// because libc::syscall() is variadic.
+#[allow(clippy::unnecessary_cast)]
+pub fn fsconfig_create(sfd: RawFd) -> Result<(), Error> {
+    // SAFETY: Obviously safe-to-use Linux syscall.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_fsconfig,
+            sfd,
+            FsconfigCmd::Create,
+            ptr::null() as *const (),
+            ptr::null() as *const (),
+            0,
+        )
+    };
+    let err = IOError::last_os_error();
+
+    if ret >= 0 {
+        Ok(())
+    } else {
+        Err(err).context(FsconfigCreateSnafu { sfd })
+    }
+}
+
+pub fn fsmount(sfd: RawFd, flags: FsmountFlags, mount_attrs: u64) -> Result<File, Error> {
+    // SAFETY: Obviously safe-to-use Linux syscall.
+    let fd = unsafe { libc::syscall(libc::SYS_fsmount, sfd, flags.bits(), mount_attrs) as RawFd };
+    let err = IOError::last_os_error();
+
+    if fd >= 0 {
+        // SAFETY: We know it's a real file descriptor.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    } else {
+        Err(err).context(FsmountSnafu {
+            sfd,
+            flags,
+            mount_attrs,
+        })
+    }
+}
+
+pub fn open_tree<P: AsRef<Path>>(
+    dirfd: RawFd,
+    path: P,
+    flags: OpenTreeFlags,
+) -> Result<File, Error> {
+    let path = path.as_ref();
+    let c_path = path.to_c_string();
+
+    // SAFETY: Obviously safe-to-use Linux syscall.
+    let fd = unsafe {
+        libc::syscall(libc::SYS_open_tree, dirfd, c_path.as_ptr(), flags.bits()) as RawFd
+    };
+    let err = IOError::last_os_error();
+
+    if fd >= 0 {
+        // SAFETY: We know it's a real file descriptor.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    } else {
+        Err(err).context(OpenTreeSnafu { dirfd, path, flags })
+    }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -811,3 +811,8 @@ pub fn getpid() -> libc::pid_t {
     // SAFETY: Obviously safe libc function.
     unsafe { libc::getpid() }
 }
+
+pub fn gettid() -> libc::pid_t {
+    // SAFETY: Obviously safe libc function.
+    unsafe { libc::gettid() }
+}

--- a/src/tests/common/mntns.rs
+++ b/src/tests/common/mntns.rs
@@ -1,0 +1,117 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::{
+    ffi::CString,
+    fs::File,
+    io::Error as IOError,
+    os::fd::{AsRawFd, RawFd},
+    path::{Path, PathBuf},
+    ptr,
+};
+
+use crate::syscalls;
+
+use anyhow::Error;
+use libc::c_int;
+
+unsafe fn unshare(flags: c_int) -> Result<(), IOError> {
+    // SAFETY: Caller guarantees that this unshare operation is safe.
+    let ret = unsafe { libc::unshare(flags) };
+    let err = IOError::last_os_error();
+    if ret >= 0 {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
+unsafe fn setns(fd: RawFd, flags: c_int) -> Result<(), IOError> {
+    // SAFETY: Caller guarantees that this setns operation is safe.
+    let ret = unsafe { libc::setns(fd, flags) };
+    let err = IOError::last_os_error();
+    if ret >= 0 {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum MountType {
+    Tmpfs,
+    Bind { src: PathBuf },
+}
+
+pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> {
+    let dst = dst.as_ref();
+    let dst_file = syscalls::openat(libc::AT_FDCWD, dst, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
+    let dst_path = CString::new(format!("/proc/self/fd/{}", dst_file.as_raw_fd()))?;
+
+    let ret = match ty {
+        MountType::Tmpfs => unsafe {
+            libc::mount(
+                CString::new("")?.as_ptr(),
+                dst_path.as_ptr(),
+                CString::new("tmpfs")?.as_ptr(),
+                0,
+                ptr::null(),
+            )
+        },
+        MountType::Bind { src } => {
+            let src_file =
+                syscalls::openat(libc::AT_FDCWD, src, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
+            let src_path = CString::new(format!("/proc/self/fd/{}", src_file.as_raw_fd()))?;
+            unsafe {
+                libc::mount(
+                    src_path.as_ptr(),
+                    dst_path.as_ptr(),
+                    ptr::null(),
+                    libc::MS_BIND,
+                    ptr::null(),
+                )
+            }
+        }
+    };
+    let err = IOError::last_os_error();
+
+    if ret >= 0 {
+        Ok(())
+    } else {
+        Err(err.into())
+    }
+}
+
+pub(crate) fn in_mnt_ns<F, T>(func: F) -> Result<T, Error>
+where
+    F: FnOnce() -> Result<T, Error>,
+{
+    let old_ns = File::open("/proc/self/ns/mnt")?;
+
+    // TODO: Run this in a subprocess.
+
+    unsafe { unshare(libc::CLONE_FS | libc::CLONE_NEWNS) }
+        .expect("unable to create a mount namespace");
+
+    let ret = func();
+
+    unsafe { setns(old_ns.as_raw_fd(), libc::CLONE_NEWNS) }
+        .expect("unable to rejoin old namespace");
+
+    ret
+}

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -17,4 +17,4 @@
  */
 
 mod root;
-pub(in crate::tests) use root::*;
+pub(crate) use root::*;

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -18,3 +18,6 @@
 
 mod root;
 pub(crate) use root::*;
+
+mod mntns;
+pub(in crate::tests) use mntns::*;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -18,4 +18,5 @@
 
 pub(crate) mod common;
 
+mod test_procfs;
 mod test_resolve;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,6 +16,6 @@
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-mod common;
+pub(crate) mod common;
 
 mod test_resolve;

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -1,0 +1,281 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::ErrorKind,
+    procfs::{ProcfsBase, ProcfsHandle},
+    resolvers::procfs::ProcfsResolver,
+    syscalls::{self, OpenTreeFlags},
+    OpenFlags,
+};
+use utils::ExpectedResult;
+
+use anyhow::Error;
+
+macro_rules! procfs_test {
+    // Create the actual test functions.
+    (@fn [<$func_prefix:ident $test_name:ident>] $procfs_var:ident = { $procfs_inst:expr } <- $do_test:expr => (over_mounts: $over_mounts:expr, error: $expect_error:expr) ;) => {
+        paste::paste! {
+            #[test]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            fn [<$func_prefix $test_name>]() -> Result<(), Error> {
+                utils::in_mnt_ns_with_overmounts($over_mounts, ExpectedResult::$expect_error, || {
+                    let $procfs_var = { $procfs_inst } ?;
+                    $do_test
+                })
+            }
+
+            #[test]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            fn [<$func_prefix openat2_ $test_name>]() -> Result<(), Error> {
+                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                    // skip this test
+                    return Ok(());
+                }
+                utils::in_mnt_ns_with_overmounts($over_mounts, ExpectedResult::$expect_error, || {
+                    let mut $procfs_var = { $procfs_inst } ?;
+                    // Force openat2 resolver.
+                    $procfs_var.resolver = ProcfsResolver::Openat2;
+                    $do_test
+                })
+            }
+
+            #[test]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            fn [<$func_prefix opath_ $test_name>]() -> Result<(), Error> {
+                utils::in_mnt_ns_with_overmounts($over_mounts, ExpectedResult::$expect_error, || {
+                    let mut $procfs_var = { $procfs_inst } ?;
+                    // Force opath resolver.
+                    $procfs_var.resolver = ProcfsResolver::RestrictedOpath;
+                    $do_test
+                })
+            }
+        }
+    };
+
+    // Create a test for each ProcfsHandle::new_* method.
+    (@impl $test_name:ident $procfs_var:ident <- $do_test:expr => ($($tt:tt)*) ;) => {
+        procfs_test! {
+            @fn [<procfs_overmounts_new_ $test_name>]
+                $procfs_var = { ProcfsHandle::new() } <- $do_test => (over_mounts: false, $($tt)*);
+        }
+
+        procfs_test! {
+            @fn [<procfs_overmounts_new_fsopen_ $test_name>]
+                $procfs_var = { ProcfsHandle::new_fsopen() } <- $do_test => (over_mounts: false, $($tt)*);
+        }
+
+        procfs_test! {
+            @fn [<procfs_overmounts_new_open_tree_ $test_name>]
+                $procfs_var = {
+                    ProcfsHandle::new_open_tree(OpenTreeFlags::OPEN_TREE_CLONE)
+                } <- $do_test => (over_mounts: false, $($tt)*);
+        }
+
+        procfs_test! {
+            @fn [<procfs_overmounts_new_open_tree_recursive_ $test_name>]
+                $procfs_var = {
+                    ProcfsHandle::new_open_tree(OpenTreeFlags::OPEN_TREE_CLONE | OpenTreeFlags::AT_RECURSIVE)
+                } <- $do_test => (over_mounts: true, $($tt)*);
+        }
+
+        procfs_test! {
+            @fn [<procfs_overmounts_new_unsafe_open $test_name>]
+                $procfs_var = { ProcfsHandle::new_unsafe_open() } <- $do_test => (over_mounts: true, $($tt)*);
+        }
+    };
+
+    // procfs_test! { abc: readlink("foo") => (error: ExpectedResult::Some(ErrorKind::OsError(Some(libc::ENOENT)))) }
+    ($test_name:ident : readlink ( $path:expr ) => ($($tt:tt)*)) => {
+        paste::paste! {
+            procfs_test! {
+                @impl [<self_readlink_ $test_name>]
+                    procfs <- procfs.readlink(ProcfsBase::ProcSelf, $path) => ($($tt)*);
+            }
+            procfs_test! {
+                @impl [<threadself_readlink_ $test_name>]
+                    procfs <- procfs.readlink(ProcfsBase::ProcThreadSelf, $path) => ($($tt)*);
+            }
+        }
+    };
+
+    // procfs_test! { xyz: open("self/fd", O_DIRECTORY) => (error: None) }
+    ($test_name:ident : open ( $path:expr, $($flag:ident)|* ) => ($($tt:tt)*)) => {
+        paste::paste! {
+            procfs_test! {
+                @impl [<self_open_ $test_name>]
+                    procfs <- procfs.open(ProcfsBase::ProcSelf, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
+            }
+            procfs_test! {
+                @impl [<threadself_open_ $test_name>]
+                    procfs <- procfs.open(ProcfsBase::ProcThreadSelf, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
+            }
+        }
+    };
+
+    // procfs_test! { def: open_follow("self/exe", O_DIRECTORY | O_PATH) => (error: ErrorKind::OsError(Some(libc::ENOTDIR) }
+    ($test_name:ident : open_follow ( $path:expr, $($flag:ident)|* ) => ($($tt:tt)*)) => {
+        paste::paste! {
+            procfs_test! {
+                @impl [<self_open_follow_ $test_name>]
+                    procfs <- procfs.open_follow(ProcfsBase::ProcSelf, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
+            }
+            procfs_test! {
+                @impl [<threadself_open_follow_ $test_name>]
+                    procfs <- procfs.open_follow(ProcfsBase::ProcThreadSelf, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
+            }
+        }
+    };
+}
+
+// Non-procfs overmount.
+procfs_test! { tmpfs_dir: open("fdinfo", O_DIRECTORY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { tmpfs_dir: open_follow("fdinfo", O_DIRECTORY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+// No overmounts.
+procfs_test! { nomount: open("attr/current", O_RDONLY) => (error: Ok) }
+procfs_test! { nomount: open_follow("attr/current", O_RDONLY) => (error: Ok) }
+// Procfs regular file overmount.
+procfs_test! { proc_file_wr: open("attr/exec", O_WRONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { proc_file_wr: open_follow("attr/exec", O_WRONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { proc_file_rd: open("mountinfo", O_RDONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { proc_file_rd: open_follow("mountinfo", O_RDONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+// Magic-links with no overmount.
+procfs_test! { magiclink_nomount: open("cwd", O_PATH) => (error: Ok) }
+procfs_test! { magiclink_nomount: open_follow("cwd", O_RDONLY) => (error: Ok) }
+procfs_test! { magiclink_nomount: readlink("cwd") => (error: Ok) }
+procfs_test! { magiclink_nomount_fd1: readlink("fd/1") => (error: Ok) }
+procfs_test! { magiclink_nomount_fd2: readlink("fd/2") => (error: Ok) }
+// Magic-links with overmount.
+procfs_test! { magiclink_exe: open("exe", O_PATH) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { magiclink_exe: open_follow("exe", O_RDONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { magiclink_exe: readlink("exe") => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { magiclink_fd0: open("fd/0", O_PATH) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { magiclink_fd0: open_follow("fd/0", O_RDONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { magiclink_fd0: readlink("fd/0") => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV)))) }
+// Behaviour-related testing.
+procfs_test! { proc_cwd_trailing_slash: open_follow("cwd/", O_RDONLY) => (error: Ok) }
+procfs_test! { proc_fdlink_trailing_slash: open_follow("fd//1/", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR)))) }
+// TODO: root can always open procfs files with O_RDWR even if writes fail.
+//procfs_test! { proc_nowrite: open("status", O_RDWR) => (error: Err(ErrorKind::OsError(Some(libc::EACCES)))) }
+procfs_test! { proc_dotdot_escape: open_follow("../..", O_PATH) => (error: Err(ErrorKind::OsError(Some(libc::EXDEV)))) }
+// TODO: openat2(RESOLVE_BENEATH) seems to handle "fd/../.." incorrectly (-EAGAIN), and "fd/.." is allowed.
+//procfs_test! { proc_dotdot_escape: open_follow("fd/../..", O_PATH) => (error: Err(ErrorKind::OsError(Some(libc::EXDEV)))) }
+//procfs_test! { proc_dotdot: open_follow("fd/..", O_PATH) => (error: Err(ErrorKind::OsError(Some(libc::EXDEV)))) }
+procfs_test! { proc_magic_component: open("root/etc/passwd", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ELOOP)))) }
+procfs_test! { proc_magic_component: open_follow("root/etc/passwd", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ELOOP)))) }
+procfs_test! { proc_magic_component: readlink("root/etc/passwd") => (error: Err(ErrorKind::OsError(Some(libc::ELOOP)))) }
+procfs_test! { proc_sym_onofollow: open("fd/1", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ELOOP)))) }
+procfs_test! { proc_sym_opath_onofollow: open("fd/1", O_PATH) => (error: Ok) }
+procfs_test! { proc_sym_odir_opath_onofollow: open("fd/1", O_DIRECTORY|O_PATH) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR)))) }
+procfs_test! { proc_dir_odir_opath_onofollow: open("fd", O_DIRECTORY|O_PATH) => (error: Ok) }
+
+mod utils {
+    use std::{fmt::Debug, path::PathBuf};
+
+    use crate::{
+        error::{Error as PathrsError, ErrorKind},
+        tests::common::{self as tests_common, MountType},
+    };
+
+    use anyhow::Error;
+
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub(super) enum ExpectedResult {
+        Ok,
+        Err(ErrorKind),
+        ErrOvermount(ErrorKind),
+    }
+
+    fn check_proc_error<T: Debug>(
+        res: Result<T, PathrsError>,
+        over_mounts: bool,
+        expected: ExpectedResult,
+    ) {
+        let want_error = match expected {
+            ExpectedResult::Ok => None,
+            ExpectedResult::Err(kind) => Some(kind),
+            ExpectedResult::ErrOvermount(kind) => {
+                if over_mounts {
+                    Some(kind)
+                } else {
+                    None
+                }
+            }
+        };
+        assert_eq!(
+            res.as_ref().err().map(PathrsError::kind),
+            want_error,
+            "unexpected result for overmounts={} got {:?} (expected error {:?})",
+            over_mounts,
+            res,
+            expected
+        );
+    }
+
+    pub(super) fn in_mnt_ns_with_overmounts<T, F>(
+        are_over_mounts_visible: bool,
+        expected: ExpectedResult,
+        func: F,
+    ) -> Result<(), Error>
+    where
+        T: Debug,
+        F: FnOnce() -> Result<T, PathrsError>,
+    {
+        tests_common::in_mnt_ns(|| {
+            // Add some overmounts to /proc/self and /proc/thread-self.
+            for prefix in vec!["/proc/self", "/proc/thread-self"] {
+                let prefix = PathBuf::from(prefix);
+
+                // A tmpfs on top of /proc/.../fdinfo.
+                tests_common::mount(prefix.join("fdinfo"), MountType::Tmpfs)?;
+                // A bind-mount of a real procfs file that ignores all writes.
+                tests_common::mount(
+                    prefix.join("attr/exec"),
+                    MountType::Bind {
+                        src: "/proc/1/sched".into(),
+                    },
+                )?;
+                // A bind-mount of a real procfs file that can have custom data.
+                tests_common::mount(
+                    prefix.join("mountinfo"),
+                    MountType::Bind {
+                        src: "/proc/1/environ".into(),
+                    },
+                )?;
+                // Magic-link overmounts.
+                tests_common::mount(
+                    prefix.join("exe"),
+                    MountType::Bind {
+                        src: "/proc/1/fd/0".into(),
+                    },
+                )?;
+                tests_common::mount(
+                    prefix.join("fd/0"),
+                    MountType::Bind {
+                        src: "/proc/1/exe".into(),
+                    },
+                )?;
+                // TODO: Add some tests for mounts on top of /proc/self.
+            }
+
+            let res = func();
+            check_proc_error(res, are_over_mounts_visible, expected);
+            Ok(())
+        })
+    }
+}

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -354,7 +354,7 @@ mod utils {
             (Ok(f), Some(expected)) => anyhow::bail!(
                 "expected to get io::Error {} but instead got file {}",
                 errno_description(expected),
-                f.as_unsafe_path()?.display(),
+                f.as_unsafe_path_unchecked()?.display(),
             ),
             (Err(err), Some(want_err)) => {
                 assert_eq!(
@@ -370,8 +370,8 @@ mod utils {
             }
         };
 
-        let real_handle_path = handle.as_file().as_unsafe_path()?;
-        let real_reopen_path = file.as_unsafe_path()?;
+        let real_handle_path = handle.as_file().as_unsafe_path_unchecked()?;
+        let real_reopen_path = file.as_unsafe_path_unchecked()?;
 
         assert_eq!(
             real_handle_path, real_reopen_path,
@@ -420,7 +420,7 @@ mod utils {
                 (Ok(h), ExpectedResult::Err(want_err)) => anyhow::bail!(
                     "expected to get io::Error {} but instead got file {}",
                     errno_description(*want_err),
-                    h.as_file().as_unsafe_path()?.display(),
+                    h.as_file().as_unsafe_path_unchecked()?.display(),
                 ),
 
                 (Err(err), ExpectedResult::Err(want_err)) => {
@@ -438,7 +438,7 @@ mod utils {
             };
 
         let expected_path = expected_path.trim_start_matches('/');
-        let real_handle_path = handle.as_file().as_unsafe_path()?;
+        let real_handle_path = handle.as_file().as_unsafe_path_unchecked()?;
         assert_eq!(
             real_handle_path,
             root_dir.as_ref().join(expected_path),
@@ -491,7 +491,7 @@ mod utils {
                     .map_err(Into::into)
             },
             root,
-            root.as_unsafe_path()?,
+            root.as_unsafe_path_unchecked()?,
             unsafe_path,
             expected,
             reopen_tests,
@@ -510,7 +510,7 @@ mod utils {
         check_resolve(
             |root: &Root, unsafe_path: P| root.resolve(unsafe_path).map_err(Into::into),
             root,
-            root.as_file().as_unsafe_path()?,
+            root.as_file().as_unsafe_path_unchecked()?,
             unsafe_path,
             expected,
             reopen_tests,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,101 +20,22 @@
 
 use crate::{
     error::{self, Error},
+    procfs::{ProcfsBase, ProcfsHandle},
     syscalls, OpenFlags,
 };
 
 use std::{
     collections::VecDeque,
     ffi::{CString, OsStr, OsString},
-    fs::File,
+    fs::{self, File},
     os::unix::{
         ffi::OsStrExt,
-        fs::MetadataExt,
         io::{AsRawFd, RawFd},
     },
     path::{Path, PathBuf},
 };
 
 use snafu::ResultExt;
-
-// This is part of Linux's ABI.
-const PROC_ROOT_INO: u64 = 1;
-
-lazy_static! {
-    /// A handle to `/proc` which is used globally by libpathrs. This ensures
-    /// that anyone doing funny business with the `/proc` mount on the host
-    /// won't be able to impact our re-opening attempts (because this handle is
-    /// checked against PROC_SUPER_MAGIC).
-    // TODO TODO TODO TODO
-    //
-    // This "grab a handle to /proc" setup is far from ideal and will need to be
-    // pretty massively reworked. The main issue is that bind-mounts could be
-    // placed over subpaths of /proc, and all of the semi-obvious approaches to
-    // work around this are non-starters for the following reasons:
-    //
-    // * Using the safe-lookup code itself will be difficult because of
-    //   re-entrancy problems. These could be worked-around by adding additional
-    //   restrictions to our usage of procfs (don't go through any symlinks, for
-    //   instance) and being a bit more clever about procfs usage for procfs
-    //   lookups. But then you run into the other issues...
-    //
-    // * Checking whether the target of an operation is the correct filesystem
-    //   is a pointless "hardening" because there are procfs files which can be
-    //   used to substitute any procfs file with a no-op one (/proc/self/sched
-    //   and /proc/self/environ). So we *really* need to detect bind-mount
-    //   crossings as well.
-    //
-    // * RESOLVE_NO_XDEV requires Linux 5.6, and in older kernels there was no
-    //   trivial way to emulate it. The closest you can get is MNT_EXPIRE
-    //   (umount) but that approach is incredibly fragile (a stray ".." and
-    //   you've broken your check) and also requires privileges that are not
-    //   accessible everywhere.
-    //
-    // * It's possible to mount over symlinks -- meaning that any magic-link
-    //   operations (which we have to do a proper in-kernel symlink follow
-    //   through) cannot be trusted. RESOLVE_NO_XDEV would work "too well" here
-    //   (all magic-links would be blocked because they'd almost certainly
-    //   involve a mount-point crossing).
-    //
-    // While this may seem like a theoretical concern, it has been exploited in
-    // the past[1,2]. See [3] for a longer explanation of the many other issues
-    // that /proc-based checking is needed to protect against.
-    //
-    // Another issue is how do we deal with "good" examples of /proc mounting
-    // such as LXCFS. LXCFS doesn't touch /proc/$pid right now (and we only care
-    // about /proc/$pid right now), but it's something to keep in mind --
-    // especially if we end up exposing this to C callers.
-    //
-    // [1]: https://nvd.nist.gov/vuln/detail/CVE-2019-16884
-    // [2]: https://nvd.nist.gov/vuln/detail/CVE-2019-19921
-    // [3]: https://youtu.be/tGseJW_uBB8
-    static ref PROCFS_HANDLE: File = {
-        // Get a /proc handle for the lifetime of the process.
-        let proc = syscalls::openat(
-            libc::AT_FDCWD,
-            "/proc",
-            libc::O_PATH | libc::O_DIRECTORY,
-            0
-        ).expect("/proc should be available");
-
-        // Actually check that /proc isn't a sneaky exploit.
-        let fs_type = syscalls::fstatfs(proc.as_raw_fd()).expect("fstatfs(/proc) should work").f_type;
-        if fs_type != libc::PROC_SUPER_MAGIC {
-            panic!("/proc is not procfs (f_type is 0x{:X}, not 0x{:X})", fs_type, libc::PROC_SUPER_MAGIC)
-        }
-
-        // And make sure it's the root of procfs. The root directory is
-        // guaranteed to have an inode number of PROC_ROOT_INO. If this check
-        // ever stops working, it's a kernel regression.
-        let ino = proc.metadata().expect("fstat(/proc) should work").ino();
-        if ino != PROC_ROOT_INO {
-            panic!("/proc is not root of a procfs mount (ino is 0x{:X}, not 0x{:X})", ino, PROC_ROOT_INO)
-        }
-
-        // All great -- this will be re-used by all "/proc" users.
-        proc
-    };
-}
 
 // Private trait necessary to work around the "orphan trait" restriction.
 pub(crate) trait ToCString {
@@ -137,6 +58,30 @@ impl ToCString for OsStr {
 impl ToCString for Path {
     fn to_c_string(&self) -> CString {
         self.as_os_str().to_c_string()
+    }
+}
+
+/// Helper to strip trailing / components from a path.
+pub(crate) fn path_strip_trailing_slash(path: &Path) -> (&Path, bool) {
+    let path_bytes = path.as_os_str().as_bytes();
+    let idx = match path_bytes.iter().rposition(|c| *c != b'/') {
+        Some(idx) => idx,
+        None => {
+            if path_bytes.len() > 1 {
+                // Nothing but b'/' components -- return a single /.
+                return (Path::new("/"), true);
+            } else {
+                // Either "/" or "".
+                return (path, false);
+            }
+        }
+    };
+    if idx == path_bytes.len() - 1 {
+        // No slashes to strip.
+        (path, false)
+    } else {
+        // Strip trailing slashes.
+        (Path::new(OsStr::from_bytes(&path_bytes[..=idx])), true)
     }
 }
 
@@ -192,7 +137,7 @@ pub(crate) fn path_split(path: &'_ Path) -> Result<(&'_ Path, Option<&'_ Path>),
 
 pub(crate) trait RawFdExt {
     /// Re-open a file descriptor.
-    fn reopen(&self, flags: OpenFlags) -> Result<File, Error>;
+    fn reopen(&self, procfs: &ProcfsHandle, flags: OpenFlags) -> Result<File, Error>;
 
     /// Get the path this RawFd is referencing.
     ///
@@ -201,7 +146,21 @@ pub(crate) trait RawFdExt {
     /// understanding that it only provides the guarantee that "at some point
     /// during execution this was the path the fd pointed to" and
     /// no more.
-    fn as_unsafe_path(&self) -> Result<PathBuf, Error>;
+    ///
+    /// NOTE: This method uses a [`procfs::ProcfsHandle`] to
+    ///
+    /// [`procfs::ProcfsHandle`]: procfs/struct.ProcfsHandle.html
+    fn as_unsafe_path(&self, procfs: &ProcfsHandle) -> Result<PathBuf, Error>;
+
+    /// Like [`as_unsafe_path`], except that the lookup is done using the basic
+    /// host `/proc` mount. This is not safe against various races, and thus
+    /// MUST ONLY be used in codepaths that
+    ///
+    /// Currently this should only be used by the `syscall::FrozenFd` logic
+    /// which saves the path a file descriptor references.
+    ///
+    /// [`as_unsafe_path`]: #method.as_unsafe_path
+    fn as_unsafe_path_unchecked(&self) -> Result<PathBuf, Error>;
 
     /// This is a fixed version of the Rust stdlib's `File::try_clone()` which
     /// works on `O_PATH` file descriptors, added to [work around an upstream
@@ -215,9 +174,9 @@ pub(crate) trait RawFdExt {
 
 fn proc_subpath(fd: RawFd) -> Result<String, Error> {
     if fd == libc::AT_FDCWD {
-        Ok("self/cwd".to_string())
+        Ok("cwd".to_string())
     } else if fd.is_positive() {
-        Ok(format!("self/fd/{}", fd))
+        Ok(format!("fd/{}", fd))
     } else {
         error::InvalidArgumentSnafu {
             name: "fd",
@@ -228,27 +187,28 @@ fn proc_subpath(fd: RawFd) -> Result<String, Error> {
 }
 
 impl RawFdExt for RawFd {
-    fn reopen(&self, flags: OpenFlags) -> Result<File, Error> {
+    fn reopen(&self, procfs: &ProcfsHandle, flags: OpenFlags) -> Result<File, Error> {
         // TODO: We should look into using O_EMPTYPATH if it's available to
         //       avoid the /proc dependency -- though then again, as_unsafe_path
         //       necessarily requires /proc.
-        syscalls::openat_follow(
-            PROCFS_HANDLE.as_raw_fd(),
-            proc_subpath(*self)?,
-            flags.bits(),
-            0,
-        )
-        .context(error::RawOsSnafu {
-            operation: "reopen fd through procfs",
-        })
+        procfs.open_follow(ProcfsBase::ProcThreadSelf, proc_subpath(*self)?, flags)
     }
 
-    fn as_unsafe_path(&self) -> Result<PathBuf, Error> {
-        syscalls::readlinkat(PROCFS_HANDLE.as_raw_fd(), proc_subpath(*self)?).context(
-            error::RawOsSnafu {
-                operation: "get fd's path through procfs",
-            },
-        )
+    fn as_unsafe_path(&self, procfs: &ProcfsHandle) -> Result<PathBuf, Error> {
+        procfs.readlink(ProcfsBase::ProcThreadSelf, proc_subpath(*self)?)
+    }
+
+    fn as_unsafe_path_unchecked(&self) -> Result<PathBuf, Error> {
+        // "/proc/thread-self/fd/$n"
+        let fd_path = PathBuf::from("/proc")
+            .join(ProcfsBase::ProcThreadSelf.into_path())
+            .join(proc_subpath(*self)?);
+
+        // Because this code is used within syscalls, we can't even check the
+        // filesystem type of /proc (unless we were to copy the logic here).
+        fs::read_link(&fd_path).context(error::OsSnafu {
+            operation: format!("readlink fd magic-link {:?}", fd_path),
+        })
     }
 
     fn try_clone_hotfix(&self) -> Result<File, Error> {
@@ -264,13 +224,18 @@ impl RawFdExt for RawFd {
 //      types we are going to be using.
 
 impl RawFdExt for File {
-    fn reopen(&self, flags: OpenFlags) -> Result<File, Error> {
-        self.as_raw_fd().reopen(flags)
+    fn reopen(&self, procfs: &ProcfsHandle, flags: OpenFlags) -> Result<File, Error> {
+        self.as_raw_fd().reopen(procfs, flags)
     }
 
-    fn as_unsafe_path(&self) -> Result<PathBuf, Error> {
+    fn as_unsafe_path(&self, procfs: &ProcfsHandle) -> Result<PathBuf, Error> {
         // SAFETY: Caller guarantees that as_unsafe_path usage is safe.
-        self.as_raw_fd().as_unsafe_path()
+        self.as_raw_fd().as_unsafe_path(procfs)
+    }
+
+    fn as_unsafe_path_unchecked(&self) -> Result<PathBuf, Error> {
+        // SAFETY: Caller guarantees that as_unsafe_path usage is safe.
+        self.as_raw_fd().as_unsafe_path_unchecked()
     }
 
     fn try_clone_hotfix(&self) -> Result<File, Error> {
@@ -397,13 +362,70 @@ impl<P: AsRef<Path>> RawComponentsIter for P {
 
 #[cfg(test)]
 mod tests {
-    use super::path_split;
+    use super::{path_split, path_strip_trailing_slash};
 
     use std::path::{Path, PathBuf};
 
     use anyhow::{Context, Error};
 
     // TODO: Add propcheck tests?
+
+    macro_rules! path_strip_slash_tests {
+        // path_strip_slash_tests! {
+        //      abc("a/b" => "a/b");
+        //      xyz("/foo/bar///" => "/foo/bar");
+        //      xyz("//" => "/");
+        // }
+        ($($test_name:ident ($path:expr => $stripped:expr, $trailing:expr));* $(;)? ) => {
+            paste::paste! {
+                $(
+                    #[test]
+                    fn [<path_strip_slash_ $test_name>]() {
+                        let path: PathBuf = $path.into();
+                        let (got_path, got_trailing) = path_strip_trailing_slash(&path);
+
+                        let want_path: PathBuf = $stripped.into();
+                        let want_trailing = $trailing;
+
+                        assert_eq!(
+                            got_path.as_os_str(), want_path.as_os_str(),
+                            "stripping {:?} produced wrong result -- got {:?}",
+                            path, got_path,
+                        );
+                        assert_eq!(
+                            got_trailing, want_trailing,
+                            "expected {:?} to have trailing_slash={}",
+                            path, want_trailing,
+                        );
+                    }
+                )*
+            }
+        };
+    }
+
+    path_strip_slash_tests! {
+        empty("" => "", false);
+        dot("." => ".", false);
+        root("/" => "/", false);
+
+        regular_notrailing1("/foo/bar/baz" => "/foo/bar/baz", false);
+        regular_notrailing2("../../a/b/c" => "../../a/b/c", false);
+        regular_notrailing3("/a" => "/a", false);
+
+        regular_trailing1("/foo/bar/baz/" => "/foo/bar/baz", true);
+        regular_trailing2("../../a/b/c/" => "../../a/b/c", true);
+        regular_trailing3("/a/" => "/a", true);
+
+        trailing_dot1("/foo/." => "/foo/.", false);
+        trailing_dot2("foo/../bar/../." => "foo/../bar/../.", false);
+
+        root_multi1("////////" => "/", true);
+        root_multi2("//" => "/", true);
+
+        complex1("foo//././bar/baz//./" => "foo//././bar/baz//.", true);
+        complex2("//a/.///b/../../" => "//a/.///b/../..", true);
+        complex3("../foo/bar/.///" => "../foo/bar/.", true);
+    }
 
     macro_rules! path_split_tests {
         // path_tests! {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -201,7 +201,7 @@ impl RawFdExt for RawFd {
     fn as_unsafe_path_unchecked(&self) -> Result<PathBuf, Error> {
         // "/proc/thread-self/fd/$n"
         let fd_path = PathBuf::from("/proc")
-            .join(ProcfsBase::ProcThreadSelf.into_path())
+            .join(ProcfsBase::ProcThreadSelf.into_path(None))
             .join(proc_subpath(*self)?);
 
         // Because this code is used within syscalls, we can't even check the


### PR DESCRIPTION
A toy example of using this API to do a few operations runc needs to do internally: 

```c
int get_self_exe()
{
	/* This follows the trailing magic-link! */
	int fd = pathrs_proc_open(PATHRS_PROC_SELF, "exe", O_PATH);
	if (fd < 0) {
		pathrs_error_t *error = pathrs_errorinfo(fd);
		/* ... print the error ... */
		pathrs_errorinfo_free(error);
		return -1;
	}
	return fd;
}

int write_apparmor_label(char *label)
{
	int fd, err, saved_errno = 0;

	fd = pathrs_proc_open(PATHRS_PROC_SELF, "attr/exec", O_WRONLY|O_NOFOLLOW);
	if (fd < 0) {
		pathrs_error_t *error = pathrs_errorinfo(fd);
		/* ... print the error ... */
		pathrs_errorinfo_free(error);
		return -1;
	}

	err = write(fd, label, strlen(label));
	close(fd);
	return err;
}

char *get_unsafe_path(int fd)
{
	char *fdpath;

	if (asprintf(&fdpath, "fd/%d", fd) < 0)
		return NULL;

	int linkbuf_size = 128;
	char *linkbuf = malloc(size);
	if (!linkbuf)
		goto err;
	for (;;) {
		int len = pathrs_proc_readlink(PATHRS_PROC_THREAD_SELF, fdpath, linkbuf, linkbuf_size);
		if (len < 0) {
			pathrs_error_t *error = pathrs_errorinfo(fd);
			/* ... print the error ... */
			pathrs_errorinfo_free(error);
			goto err;
		}

		if (len <= linkbuf_size)
			break;

		linkbuf_size = len;
		linkbuf = realloc(linkbuf, linkbuf_size);
		if (!linkbuf)
			goto err;
	}

	free(fdpath);
	return name_buf;

err:
	free(fdpath);
	free(name_buf);
	return NULL;
}
```

Fixes #7
Fixes #15
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>