### PR TITLE
flags: ResolverFlags rework

### DIFF
--- a/contrib/bindings/python/pathrs.py
+++ b/contrib/bindings/python/pathrs.py
@@ -227,6 +227,7 @@ def proc_open_raw(base, path, flags):
 	return WrappedFd(fd)
 
 def proc_readlink(base, path):
+	# TODO: See if we can merge this with Root.readlink.
 	path = _cstr(path)
 	linkbuf_size = 128
 	while True:
@@ -293,6 +294,24 @@ class Root(WrappedFd):
 		if fd < 0:
 			raise Error._fetch(fd) or INTERNAL_ERROR
 		return Handle(fd)
+
+	def readlink(self, path):
+		path = _cstr(path)
+		linkbuf_size = 128
+		while True:
+			linkbuf = _cbuffer(linkbuf_size)
+			n = libpathrs_so.pathrs_readlink(self.fileno(), path, linkbuf, linkbuf_size)
+			if n < 0:
+				raise Error._fetch(n) or INTERNAL_ERROR
+			elif n <= linkbuf_size:
+				return ffi.buffer(linkbuf, linkbuf_size)[:n].decode("latin1")
+			else:
+				# The contents were truncated. Unlike readlinkat, pathrs returns
+				# the size of the link when it checked. So use the returned size
+				# as a basis for the reallocated size (but in order to avoid a DoS
+				# where a magic-link is growing by a single byte each iteration,
+				# make sure we are a fair bit larger).
+				linkbuf_size += n
 
 	def creat(self, path, filemode, mode="r", extra_flags=0):
 		path = _cstr(path)

--- a/contrib/bindings/python/pathrs.py
+++ b/contrib/bindings/python/pathrs.py
@@ -284,9 +284,12 @@ class Root(WrappedFd):
 	def from_file(cls, file):
 		return cls(file)
 
-	def resolve(self, path):
+	def resolve(self, path, follow_trailing=True):
 		path = _cstr(path)
-		fd = libpathrs_so.pathrs_resolve(self.fileno(), path)
+		if follow_trailing:
+			fd = libpathrs_so.pathrs_resolve(self.fileno(), path)
+		else:
+			fd = libpathrs_so.pathrs_resolve_nofollow(self.fileno(), path)
 		if fd < 0:
 			raise Error._fetch(fd) or INTERNAL_ERROR
 		return Handle(fd)

--- a/go-pathrs/libpathrs_linux.go
+++ b/go-pathrs/libpathrs_linux.go
@@ -71,6 +71,14 @@ func pathrsResolve(rootFd uintptr, path string) (uintptr, error) {
 	return uintptr(fd), fetchError(fd)
 }
 
+func pathrsResolveNoFollow(rootFd uintptr, path string) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_resolve_nofollow(C.int(rootFd), cPath)
+	return uintptr(fd), fetchError(fd)
+}
+
 func pathrsCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))

--- a/go-pathrs/libpathrs_linux.go
+++ b/go-pathrs/libpathrs_linux.go
@@ -79,6 +79,30 @@ func pathrsResolveNoFollow(rootFd uintptr, path string) (uintptr, error) {
 	return uintptr(fd), fetchError(fd)
 }
 
+func pathrsReadlink(rootFd uintptr, path string) (string, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	size := 128
+	for {
+		linkBuf := make([]byte, size)
+		n := C.pathrs_readlink(C.int(rootFd), cPath, C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.ulong(len(linkBuf)))
+		switch {
+		case int(n) < 0:
+			return "", fetchError(n)
+		case int(n) <= len(linkBuf):
+			return string(linkBuf[:int(n)]), nil
+		default:
+			// The contents were truncated. Unlike readlinkat, pathrs returns
+			// the size of the link when it checked. So use the returned size
+			// as a basis for the reallocated size (but in order to avoid a DoS
+			// where a magic-link is growing by a single byte each iteration,
+			// make sure we are a fair bit larger).
+			size += int(n)
+		}
+	}
+}
+
 func pathrsCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
@@ -154,6 +178,8 @@ func pathrsProcOpen(base pathrsProcBase, path string, flags int) (uintptr, error
 }
 
 func pathrsProcReadlink(base pathrsProcBase, path string) (string, error) {
+	// TODO: See if we can unify this code with pathrsReadlink.
+
 	cBase := C.pathrs_proc_base_t(base)
 
 	cPath := C.CString(path)

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -133,6 +133,10 @@ int pathrs_reopen(int fd, int flags);
  * Resolve the given path within the rootfs referenced by root_fd. The path
  * *must already exist*, otherwise an error will occur.
  *
+ * All symlinks (including trailing symlinks) are followed, but they are
+ * resolved within the rootfs. If you wish to open a handle to the symlink
+ * itself, use pathrs_resolve_nofollow().
+ *
  * # Return Value
  *
  * On success, this function returns an O_PATH file descriptor referencing the
@@ -144,6 +148,24 @@ int pathrs_reopen(int fd, int flags);
  * pathrs_errorinfo().
  */
 int pathrs_resolve(int root_fd, const char *path);
+
+/**
+ * pathrs_resolve_nofollow() is effectively an O_NOFOLLOW version of
+ * pathrs_resolve(). Their behaviour is identical, except that *trailing*
+ * symlinks will not be followed. If the final component is a trailing symlink,
+ * an O_PATH|O_NOFOLLOW handle to the symlink itself is returned.
+ *
+ * # Return Value
+ *
+ * On success, this function returns an O_PATH file descriptor referencing the
+ * resolved path.
+ *
+ * If an error occurs, this function will return a negative error code. To
+ * retrieve information about the error (such as a string describing the error,
+ * the system errno(7) value associated with the error, etc), use
+ * pathrs_errorinfo().
+ */
+int pathrs_resolve_nofollow(int root_fd, const char *path);
 
 /**
  * Rename a path within the rootfs referenced by root_fd. The flags argument is

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -37,7 +37,7 @@ use std::{
     },
 };
 
-use libc::{c_char, c_int, c_uint, dev_t};
+use libc::{c_char, c_int, c_uint, dev_t, size_t};
 use snafu::ResultExt;
 
 /// Open a root handle.
@@ -144,6 +144,54 @@ pub extern "C" fn pathrs_resolve(root_fd: RawFd, path: *const c_char) -> RawFd {
 pub extern "C" fn pathrs_resolve_nofollow(root_fd: RawFd, path: *const c_char) -> RawFd {
     ret::with_fd(root_fd, |root: &mut Root| {
         root.resolve_nofollow(utils::parse_path(path)?)
+    })
+}
+
+/// Get the target of a symlink within the rootfs referenced by root_fd.
+///
+/// NOTE: The returned path is not modified to be "safe" outside of the
+/// root. You should not use this path for doing further path lookups -- use
+/// pathrs_resolve() instead.
+///
+/// This method is just shorthand for:
+///
+/// ```c
+/// int linkfd = pathrs_resolve_nofollow(rootfd, path);
+/// if (linkfd < 0) {
+///     liberr = fd; // for use with pathrs_errorinfo()
+///     goto err;
+/// }
+/// copied = readlinkat(linkfd, "", linkbuf, linkbuf_size);
+/// close(linkfd);
+/// ```
+///
+/// # Return Value
+///
+/// On success, this function copies the symlink contents to `linkbuf` (up to
+/// `linkbuf_size` bytes) and returns the full size of the symlink path buffer.
+/// This function will not copy the trailing NUL byte, and the return size does
+/// not include the NUL byte. A `NULL` `linkbuf` or invalid `linkbuf_size` are
+/// treated as zero-size buffers.
+///
+/// NOTE: Unlike readlinkat(2), in the case where linkbuf is too small to
+/// contain the symlink contents, pathrs_readlink() will return *the number of
+/// bytes it would have copied if the buffer was large enough*. This matches the
+/// behaviour of pathrs_proc_readlink().
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_readlink(
+    root_fd: RawFd,
+    path: *const c_char,
+    linkbuf: *mut c_char,
+    linkbuf_size: size_t,
+) -> RawFd {
+    ret::with_fd(root_fd, |root: &mut Root| {
+        let link_target = root.readlink(utils::parse_path(path)?)?;
+        utils::copy_path_into_buffer(link_target, linkbuf, linkbuf_size)
     })
 }
 

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -19,8 +19,8 @@
 use crate::{
     capi::{ret::IntoCReturn, utils},
     error::Error,
+    flags::OpenFlags,
     procfs::{ProcfsBase, PROCFS_HANDLE},
-    OpenFlags,
 };
 
 use std::{

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -262,3 +262,14 @@ mod tests {
         );
     }
 }
+
+bitflags! {
+    /// Optional flags to modify the resolution of paths inside a [`Root`].
+    ///
+    /// [`Root`]: struct.Root.html
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+    pub struct ResolverFlags: u64 {
+        // TODO: We should probably have our own bits...
+        const NO_SYMLINKS = libc::RESOLVE_NO_SYMLINKS;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,9 +137,6 @@ extern crate snafu;
 
 /// Bit-flags for controlling various operations.
 pub mod flags;
-// TODO: Remove this.
-#[doc(inline)]
-pub use flags::{OpenFlags, RenameFlags, ResolverFlags};
 
 // `Handle` implementation.
 mod handle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ extern crate snafu;
 pub mod flags;
 // TODO: Remove this.
 #[doc(inline)]
-pub use flags::{OpenFlags, RenameFlags};
+pub use flags::{OpenFlags, RenameFlags, ResolverFlags};
 
 // `Handle` implementation.
 mod handle;
@@ -157,7 +157,7 @@ pub mod error;
 // Backend resolver implementations.
 mod resolvers;
 #[doc(inline)]
-pub use resolvers::{Resolver, ResolverBackend, ResolverFlags};
+pub use resolvers::{Resolver, ResolverBackend};
 
 /// Safe procfs handles.
 pub mod procfs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ```
 //! # extern crate libc;
-//! # use pathrs::{error::Error, Root, OpenFlags};
+//! # use pathrs::{error::Error, flags::OpenFlags, Root};
 //! # fn main() -> Result<(), Error> {
 //! let (root_path, unsafe_path) = ("/path/to/root", "/etc/passwd");
 //! # let root_path = "/";

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -59,7 +59,6 @@ lazy_static! {
 /// [`ProcfsHandle`]: struct.ProcfsHandle.html
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)] // TODO: Remove when we export this properly.
 pub enum ProcfsBase {
     /// Use `/proc/self`. For most programs, this is the standard choice.
     ProcSelf,
@@ -424,9 +423,9 @@ impl ProcfsHandle {
 
         // Do a basic lookup.
         let base = self.open_base(base)?;
-        let file =
-            self.resolver
-                .resolve(&base, subpath, flags, ResolverFlags::NO_FOLLOW_TRAILING)?;
+        let file = self
+            .resolver
+            .resolve(&base, subpath, flags, ResolverFlags::empty())?;
 
         // Detect if the file we landed is in a bind-mount.
         self.check_mnt_id(&file, "")?;

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -20,9 +20,10 @@
 
 use crate::{
     error::{self, Error},
-    resolvers::{procfs::ProcfsResolver, ResolverFlags},
+    flags::{OpenFlags, ResolverFlags},
+    resolvers::procfs::ProcfsResolver,
     syscalls::{self, FsmountFlags, FsopenFlags, OpenTreeFlags},
-    utils, OpenFlags,
+    utils,
 };
 
 use std::{

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -18,7 +18,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{error::Error, syscalls, Handle};
+use crate::{error::Error, flags::ResolverFlags, syscalls, Handle};
 
 use std::{fs::File, path::Path};
 
@@ -31,17 +31,6 @@ pub(crate) mod procfs;
 
 /// Maximum number of symlink traversals we will accept.
 const MAX_SYMLINK_TRAVERSALS: usize = 128;
-
-bitflags! {
-    /// Optional flags to modify the resolution of paths inside a [`Root`].
-    ///
-    /// [`Root`]: struct.Root.html
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-    pub struct ResolverFlags: u64 {
-        // TODO: We should probably have our own bits...
-        const NO_SYMLINKS = libc::RESOLVE_NO_SYMLINKS;
-    }
-}
 
 /// The backend used for path resolution within a [`Root`] to get a [`Handle`].
 ///

--- a/src/resolvers/opath.rs
+++ b/src/resolvers/opath.rs
@@ -165,6 +165,7 @@ pub(crate) fn resolve<P: AsRef<Path>>(
     root: &File,
     path: P,
     flags: ResolverFlags,
+    no_follow_trailing: bool,
 ) -> Result<Handle, Error> {
     let path = path.as_ref();
 
@@ -276,7 +277,7 @@ pub(crate) fn resolve<P: AsRef<Path>>(
         // If we hit the last component and we were told to not follow the
         // trailing symlink, just return the link we have.
         // TODO: Is this behaviour correct for "foo/" cases?
-        if remaining_components.is_empty() && flags.contains(ResolverFlags::NO_FOLLOW_TRAILING) {
+        if remaining_components.is_empty() && no_follow_trailing {
             current = next.into();
             break;
         }

--- a/src/resolvers/opath.rs
+++ b/src/resolvers/opath.rs
@@ -37,8 +37,9 @@
 
 use crate::{
     error::{self, Error, ErrorExt},
+    flags::ResolverFlags,
     procfs::PROCFS_HANDLE,
-    resolvers::{ResolverFlags, MAX_SYMLINK_TRAVERSALS},
+    resolvers::MAX_SYMLINK_TRAVERSALS,
     syscalls,
     utils::{RawComponentsIter, RawFdExt},
     Handle,

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -18,8 +18,7 @@
 
 use crate::{
     error::{self, Error},
-    flags::OpenFlags,
-    resolvers::ResolverFlags,
+    flags::{OpenFlags, ResolverFlags},
     syscalls::{self, OpenHow},
     Handle,
 };

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -366,11 +366,11 @@ fn opath_resolve<P: AsRef<Path>>(
 mod tests {
     use crate::{
         error::{Error as PathrsError, ErrorKind},
+        flags::{OpenFlags, ResolverFlags},
         resolvers::procfs::ProcfsResolver,
         syscalls,
         tests::common as tests_common,
         utils::RawFdExt,
-        OpenFlags, ResolverFlags,
     };
 
     use std::{fs::File, path::PathBuf};

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -31,8 +31,8 @@
 
 use crate::{
     error::{self, Error, ErrorExt},
-    flags::OpenFlags,
-    resolvers::{ResolverFlags, MAX_SYMLINK_TRAVERSALS},
+    flags::{OpenFlags, ResolverFlags},
+    resolvers::MAX_SYMLINK_TRAVERSALS,
     syscalls::{self, OpenHow},
     utils::{self, RawComponentsIter},
 };

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -67,8 +67,8 @@ impl ProcfsResolver {
         &self,
         root: &File,
         path: P,
-        mut oflags: OpenFlags,
-        mut rflags: ResolverFlags,
+        oflags: OpenFlags,
+        rflags: ResolverFlags,
     ) -> Result<File, Error> {
         // These flags don't make sense for procfs and will just result in
         // confusing errors during lookup. O_TMPFILE contains multiple flags
@@ -84,14 +84,6 @@ impl ProcfsResolver {
                 ),
             },
         );
-
-        // If O_NOFOLLOW was specified, convert it to NO_FOLLOW_TRAILING.
-        if oflags.contains(OpenFlags::O_NOFOLLOW) {
-            rflags.insert(ResolverFlags::NO_FOLLOW_TRAILING);
-        }
-        if rflags.contains(ResolverFlags::NO_FOLLOW_TRAILING) {
-            oflags.insert(OpenFlags::O_NOFOLLOW);
-        }
 
         match *self {
             Self::Openat2 => openat2_resolve(root, path, oflags, rflags),
@@ -112,11 +104,9 @@ fn openat2_resolve<P: AsRef<Path>>(
     );
 
     // Copy the O_NOFOLLOW and RESOLVE_NO_SYMLINKS bits from rflags.
-    let oflags = oflags.bits() as u64 | rflags.openat2_flag_bits();
-    let rflags = libc::RESOLVE_BENEATH
-        | libc::RESOLVE_NO_MAGICLINKS
-        | libc::RESOLVE_NO_XDEV
-        | rflags.openat2_resolve_bits();
+    let oflags = oflags.bits() as u64;
+    let rflags =
+        libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_XDEV | rflags.bits();
 
     syscalls::openat2(
         root.as_raw_fd(),

--- a/src/root.rs
+++ b/src/root.rs
@@ -234,20 +234,35 @@ impl Root {
     }
 
     /// Within the given [`Root`]'s tree, resolve `path` and return a
-    /// [`Handle`]. All symlink path components are scoped to [`Root`].
+    /// [`Handle`]. All symlink path components are scoped to [`Root`]. Trailing
+    /// symlinks *are* followed, if you want to get a handle to a symlink use
+    /// [`Root::resolve_nofollow`].
     ///
     /// # Errors
     ///
     /// If `path` doesn't exist, or an attack was detected during resolution, a
-    /// corresponding Error will be returned. If no error is returned, then the
-    /// path is guaranteed to have been reachable from the root of the directory
-    /// tree and thus have been inside the root at one point in the resolution.
+    /// corresponding [`Error`] will be returned. If no error is returned, then
+    /// the path is guaranteed to have been reachable from the root of the
+    /// directory tree and thus have been inside the root at one point in the
+    /// resolution.
     ///
     /// [`Root`]: struct.Root.html
     /// [`Handle`]: trait.Handle.html
+    /// [`Error`]: error/struct.Error.html
+    /// [`Root::resolve_nofollow`]: struct.Root.html#method.resolve_nofollow
     #[inline]
     pub fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
-        self.resolver.resolve(&self.inner, path)
+        self.resolver.resolve(&self.inner, path, false)
+    }
+
+    /// Identical to [`Root::resolve`], except that *trailing* symlinks are
+    /// *not* followed and if the trailing component is a symlink
+    /// `Root::resolve_nofollow` will return a handle to the symlink itself.
+    ///
+    /// [`Root::resolve`]: struct.Root.html#method.resolve
+    #[inline]
+    pub fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
+        self.resolver.resolve(&self.inner, path, true)
     }
 
     // TODO: readlink (need to move ResolverFlags out of Resolver)

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -20,8 +20,8 @@
 #![allow(unsafe_code)]
 
 use crate::{
+    flags::OpenFlags,
     utils::{RawFdExt, ToCString},
-    OpenFlags,
 };
 
 use std::{

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -18,10 +18,10 @@
 
 use crate::{
     error::ErrorKind,
+    flags::OpenFlags,
     procfs::{ProcfsBase, ProcfsHandle},
     resolvers::procfs::ProcfsResolver,
     syscalls::{self, OpenTreeFlags},
-    OpenFlags,
 };
 use utils::ExpectedResult;
 

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -19,10 +19,11 @@
 use std::{fs::File, path::Path};
 
 use crate::{
+    flags::ResolverFlags,
     resolvers::{opath, openat2},
     syscalls,
     tests::common as tests_common,
-    Handle, ResolverBackend, ResolverFlags, Root,
+    Handle, ResolverBackend, Root,
 };
 use utils::ExpectedResult;
 
@@ -336,7 +337,7 @@ resolve_tests! {
 mod utils {
     use std::{fs::File, io, os::linux::fs::MetadataExt, path::Path};
 
-    use crate::{error::Error as PathrsError, utils::RawFdExt, Handle, OpenFlags, Root};
+    use crate::{error::Error as PathrsError, flags::OpenFlags, utils::RawFdExt, Handle, Root};
 
     use anyhow::Error;
     use errno::Errno;

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -307,11 +307,18 @@ mod utils {
                     }
                     // Check symlink is correct.
                     InodeType::Symlink(target) => {
+                        // Check using the a resolved handle.
                         let actual_target =
                             syscalls::readlinkat(created.as_file().as_raw_fd(), "")?;
                         assert_eq!(
                             target, actual_target,
                             "readlinkat(handle) link target mismatch"
+                        );
+                        // Double-check with Root::readlink.
+                        let actual_target = root.readlink(path)?;
+                        assert_eq!(
+                            target, actual_target,
+                            "root.readlink(path) link target mismatch"
                         );
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,8 +20,9 @@
 
 use crate::{
     error::{self, Error},
+    flags::OpenFlags,
     procfs::{ProcfsBase, ProcfsHandle},
-    syscalls, OpenFlags,
+    syscalls,
 };
 
 use std::{


### PR DESCRIPTION
`O_NOFOLLOW` doesn't make a sense as a flag. Instead, we should have a `Root::resolve_nofollow`. This also makes it easy to implement `Root::readlink`.