### PR TITLE
*: migrate from lazy_static! to std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ panic = "abort"
 
 [dependencies]
 bitflags = "^2"
-lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
 rand = "^0.8"

--- a/src/capi/ret.rs
+++ b/src/capi/ret.rs
@@ -27,7 +27,7 @@ use std::{
     fs::File,
     mem::ManuallyDrop,
     os::unix::io::{FromRawFd, IntoRawFd, RawFd},
-    sync::Mutex,
+    sync::{LazyLock, Mutex},
 };
 
 use libc::c_int;
@@ -40,9 +40,8 @@ pub(super) trait IntoCReturn {
 }
 
 // TODO: Switch this to using a slab or similar structure, possibly using a less heavy-weight lock?
-lazy_static! {
-    static ref ERROR_MAP: Mutex<HashMap<CReturn, Error>> = Mutex::new(HashMap::new());
-}
+static ERROR_MAP: LazyLock<Mutex<HashMap<CReturn, Error>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 fn store_error(err: Error) -> CReturn {
     let mut err_map = ERROR_MAP.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 extern crate libc;
 #[macro_use]
 extern crate snafu;

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -31,15 +31,14 @@ use std::{
     os::fd::AsRawFd,
     os::unix::fs::MetadataExt,
     path::{Path, PathBuf},
+    sync::LazyLock,
 };
 
 use snafu::{OptionExt, ResultExt};
 
-lazy_static! {
-    /// A `procfs` handle to which is used globally by libpathrs.
-    pub(crate) static ref PROCFS_HANDLE: ProcfsHandle =
-        ProcfsHandle::new().expect("should be able to get some /proc handle");
-}
+/// A `procfs` handle to which is used globally by libpathrs.
+pub(crate) static PROCFS_HANDLE: LazyLock<ProcfsHandle> =
+    LazyLock::new(|| ProcfsHandle::new().expect("should be able to get some /proc handle"));
 
 /// Indicate what base directory should be used when doing `/proc/...`
 /// operations with a [`ProcfsHandle`].

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::{error::Error, flags::ResolverFlags, syscalls, Handle};
 
-use std::{fs::File, path::Path};
+use std::{fs::File, path::Path, sync::LazyLock};
 
 /// `O_PATH`-based userspace resolver.
 pub mod opath;
@@ -51,13 +51,13 @@ pub enum ResolverBackend {
     //       hyper-concerned users.
 }
 
-lazy_static! {
-    static ref DEFAULT_RESOLVER_TYPE: ResolverBackend = if *syscalls::OPENAT2_IS_SUPPORTED {
+static DEFAULT_RESOLVER_TYPE: LazyLock<ResolverBackend> = LazyLock::new(|| {
+    if *syscalls::OPENAT2_IS_SUPPORTED {
         ResolverBackend::KernelOpenat2
     } else {
         ResolverBackend::EmulatedOpath
-    };
-}
+    }
+});
 
 impl Default for ResolverBackend {
     fn default() -> Self {

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -36,15 +36,11 @@ use std::{
     },
     path::{Path, PathBuf},
     ptr,
+    sync::LazyLock,
 };
 
 use libc::{c_int, c_uint, dev_t, mode_t, stat, statfs};
 use snafu::ResultExt;
-
-lazy_static! {
-    pub(crate) static ref OPENAT2_IS_SUPPORTED: bool =
-        openat2(libc::AT_FDCWD, ".", &Default::default()).is_ok();
-}
 
 /// Representation of a file descriptor and its associated path at a given point
 /// in time.
@@ -639,21 +635,19 @@ pub(crate) fn renameat<P1: AsRef<Path>, P2: AsRef<Path>>(
     }
 }
 
-lazy_static! {
-    pub(crate) static ref RENAME_FLAGS_SUPPORTED: bool = {
-        match renameat2(
-            libc::AT_FDCWD,
-            ".",
-            libc::AT_FDCWD,
-            ".",
-            libc::RENAME_EXCHANGE,
-        ) {
-            Ok(_) => true,
-            // We expect EBUSY, but just to be safe we only check for ENOSYS.
-            Err(err) => err.root_cause().raw_os_error() != Some(libc::ENOSYS),
-        }
-    };
-}
+pub(crate) static RENAME_FLAGS_SUPPORTED: LazyLock<bool> = LazyLock::new(|| {
+    match renameat2(
+        libc::AT_FDCWD,
+        ".",
+        libc::AT_FDCWD,
+        ".",
+        libc::RENAME_EXCHANGE,
+    ) {
+        Ok(_) => true,
+        // We expect EBUSY, but just to be safe we only check for ENOSYS.
+        Err(err) => err.root_cause().raw_os_error() != Some(libc::ENOSYS),
+    }
+});
 
 /// Wrapper for `renameat2(2)`.
 ///
@@ -780,6 +774,9 @@ pub(crate) fn statx<P: AsRef<Path>>(
         })
     }
 }
+
+pub(crate) static OPENAT2_IS_SUPPORTED: LazyLock<bool> =
+    LazyLock::new(|| openat2(libc::AT_FDCWD, ".", &Default::default()).is_ok());
 
 /// Arguments for how `openat2` should open the target path.
 // TODO: Maybe switch to libc::open_how?


### PR DESCRIPTION
This was only stabilised in Rust 1.80.0, so this might cause issues when building on older distributions (depending on when libpathrs starts getting packaged).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>