### PR TITLE
rust: drop MSRV to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ on:
 name: rust-ci
 
 env:
-  RUST_MSRV: "1.65"
+  RUST_MSRV: "1.63"
 
 jobs:
   check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,13 +26,26 @@ on:
 
 name: rust-ci
 
+env:
+  RUST_MSRV: "1.65"
+
 jobs:
   check:
-    name: cargo check
+    name: cargo check (stable)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --workspace --all-features --all-targets
+
+  check-msrv:
+    name: cargo check (msrv)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MSRV }}
       - run: cargo check --workspace --all-features --all-targets
 
   rustdoc:
@@ -90,7 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -101,7 +113,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ memchr = "^2"
 rand = "^0.8"
 regex = "^1"
 rustix = { version = "^0.38", features = ["fs"] }
-snafu = "^0.8"
+thiserror = "^1"
 
 [dev-dependencies]
 anyhow = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ readme = "README.md"
 keywords = ["file", "fs", "security", "linux"]
 categories = ["filesystem"]
 edition = "2021"
+rust-version = "1.65"
 
 [badges]
 maintenance = { status = "experimental" }
@@ -49,6 +50,8 @@ panic = "abort"
 [dependencies]
 bitflags = "^2"
 itertools = "^0.13"
+# MSRV(1.70): Use OnceLock.
+# MSRV(1.80): Use LazyLock.
 lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
@@ -59,11 +62,13 @@ snafu = "^0.8"
 
 [dev-dependencies]
 anyhow = "^1"
-clap = { version = "^4", features = ["cargo"] }
+clap = { version = "4.2.*", features = ["cargo"] }
 errno = "^0.3"
 tempfile = "^3"
 paste = "^1"
 pretty_assertions = "^1"
+# Enable the "process" feature for getcwd() in our tests.
+rustix = { version = "^0.38", features = ["process"] }
 
 [lints.rust]
 # We have special handling for coverage runs (which set cfg(coverage)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 keywords = ["file", "fs", "security", "linux"]
 categories = ["filesystem"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.63"
 
 [badges]
 maintenance = { status = "experimental" }
@@ -56,13 +56,14 @@ lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
 rand = "^0.8"
-regex = "^1"
+# MSRV(1.65): Use regex >= 1.10.
+regex = "1.9.*"
 rustix = { version = "^0.38", features = ["fs"] }
 thiserror = "^1"
 
 [dev-dependencies]
 anyhow = "^1"
-clap = { version = "4.2.*", features = ["cargo"] }
+clap = { version = "^3", features = ["cargo"] }
 errno = "^0.3"
 tempfile = "^3"
 paste = "^1"

--- a/examples/rust-cat/main.rs
+++ b/examples/rust-cat/main.rs
@@ -33,7 +33,8 @@ use clap::{Arg, Command};
 
 fn main() -> Result<(), Error> {
     let m = Command::new("cat")
-        .author(clap::crate_authors!("\n"))
+        // MSRV(1.67): Use clap::crate_authors!.
+        .author("Aleksa Sarai <cyphar@cyphar.com>")
         .version(clap::crate_version!())
         .arg(Arg::new("root").value_name("ROOT"))
         .arg(Arg::new("unsafe-path").value_name("PATH"))

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -24,7 +24,7 @@ use crate::{
     procfs::{ProcfsBase, PROCFS_HANDLE},
 };
 
-use std::os::fd::RawFd;
+use std::os::unix::io::RawFd;
 
 use libc::{c_char, c_int, size_t};
 

--- a/src/capi/ret.rs
+++ b/src/capi/ret.rs
@@ -40,7 +40,10 @@ pub(super) trait IntoCReturn {
     fn into_c_return(self) -> CReturn;
 }
 
-// TODO: Switch this to using a slab or similar structure, possibly using a less heavy-weight lock?
+// TODO: Switch this to using a slab or similar structure, possibly using a less
+// heavy-weight lock? Maybe sharded-slab?
+// MSRV(1.70): Use OnceLock.
+// MSRV(1.80): Use LazyLock.
 lazy_static! {
     static ref ERROR_MAP: Mutex<HashMap<CReturn, Error>> = Mutex::new(HashMap::new());
 }

--- a/src/capi/utils.rs
+++ b/src/capi/utils.rs
@@ -17,7 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::error::{self, Error, ErrorKind};
+use crate::error::{Error, ErrorImpl, ErrorKind};
 
 use std::{
     cmp,
@@ -30,13 +30,12 @@ use std::{
 use libc::{c_char, c_int, size_t};
 
 pub(crate) fn parse_path<'a>(path: *const c_char) -> Result<&'a Path, Error> {
-    ensure!(
-        !path.is_null(),
-        error::InvalidArgumentSnafu {
-            name: "path",
-            description: "cannot be NULL",
-        }
-    );
+    if path.is_null() {
+        Err(ErrorImpl::InvalidArgument {
+            name: "path".into(),
+            description: "cannot be NULL".into(),
+        })?
+    }
     // SAFETY: C caller guarantees that the path is a valid C-style string.
     let bytes = unsafe { CStr::from_ptr(path) }.to_bytes();
     Ok(OsStr::from_bytes(bytes).as_ref())

--- a/src/capi/utils.rs
+++ b/src/capi/utils.rs
@@ -53,7 +53,8 @@ pub(crate) fn copy_path_into_buffer<P: AsRef<Path>>(
     // If the linkbuf is null, we just return the number of bytes we
     // would've written.
     if !buf.is_null() && bufsize > 0 {
-        let to_copy = cmp::min(path.count_bytes(), bufsize);
+        // MSRV(1.79): Switch to .count_bytes().
+        let to_copy = cmp::min(path.to_bytes().len(), bufsize);
         // SAFETY: The C caller guarantees that buf is safe to write to
         // up to bufsize bytes.
         unsafe {
@@ -61,7 +62,8 @@ pub(crate) fn copy_path_into_buffer<P: AsRef<Path>>(
         }
     }
 
-    Ok(path.count_bytes() as c_int)
+    // MSRV(1.79): Switch to .count_bytes().
+    Ok(path.to_bytes().len() as c_int)
 }
 
 pub(crate) trait Leakable {

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,7 @@ use std::{borrow::Cow, error::Error as StdError, io::Error as IOError};
 // TODO: Add a backtrace to Error. We would just need to add an automatic
 //       Backtrace::capture() in From. But it's not clear whether we want to
 //       export the crate types here without std::backtrace::Backtrace.
+// MSRV(1.65): Use std::backtrace::Backtrace.
 
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -212,19 +212,19 @@ mod tests {
                     fn [<openflags_ $test_name _access_mode>]() {
                         let flags = $(OpenFlags::$flag)|*;
                         let accmode: Option<i32> = $accmode;
-                        assert_eq!(flags.access_mode(), accmode, "{:?} access mode should be {:?}", flags, accmode.map(OpenFlags::from_bits_retain));
+                        assert_eq!(flags.access_mode(), accmode, "{flags:?} access mode should be {:?}", accmode.map(OpenFlags::from_bits_retain));
                     }
 
                     #[test]
                     fn [<openflags_ $test_name _wants_read>]() {
                         let flags = $(OpenFlags::$flag)|*;
-                        assert_eq!(flags.wants_read(), $wants_read, "{:?} wants_read should be {:?}", flags, $wants_read);
+                        assert_eq!(flags.wants_read(), $wants_read, "{flags:?} wants_read should be {:?}", $wants_read);
                     }
 
                     #[test]
                     fn [<openflags_ $test_name _wants_write>]() {
                         let flags = $(OpenFlags::$flag)|*;
-                        assert_eq!(flags.wants_write(), $wants_write, "{:?} wants_write should be {:?}", flags, $wants_write);
+                        assert_eq!(flags.wants_write(), $wants_write, "{flags:?} wants_write should be {:?}", $wants_write);
                     }
                 }
             )*

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -20,15 +20,13 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    error::{self, Error},
+    error::{Error, ErrorImpl},
     flags::OpenFlags,
     procfs::PROCFS_HANDLE,
     utils::RawFdExt,
 };
 
 use std::fs::File;
-
-use snafu::ResultExt;
 
 /// A handle to an existing inode within a [`Root`].
 ///
@@ -82,8 +80,12 @@ impl Handle {
     pub fn try_clone(&self) -> Result<Self, Error> {
         self.as_file()
             .try_clone()
-            .context(error::OsSnafu {
-                operation: "clone underlying handle file",
+            .map_err(|err| {
+                ErrorImpl::OsError {
+                    operation: "clone underlying handle file".into(),
+                    source: err,
+                }
+                .into()
             })
             .map(Self::from_file_unchecked)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,6 @@
 #![cfg(target_os = "linux")]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::all)]
-// TODO: At the moment our Errors are too big.
-// <https://github.com/openSUSE/libpathrs/issues/44>
-#![allow(clippy::result_large_err)]
 // We use this the coverage_attribute when doing coverage runs.
 // <https://github.com/rust-lang/rust/issues/84605>
 #![cfg_attr(coverage, feature(coverage_attribute))]
@@ -134,8 +131,6 @@ extern crate bitflags;
 extern crate lazy_static;
 extern crate libc;
 extern crate regex;
-#[macro_use]
-extern crate snafu;
 
 /// Bit-flags for controlling various operations.
 pub mod flags;

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -29,13 +29,14 @@ use crate::{
 
 use std::{
     fs::File,
-    os::fd::AsRawFd,
-    os::unix::fs::MetadataExt,
+    os::unix::{fs::MetadataExt, io::AsRawFd},
     path::{Path, PathBuf},
 };
 
 use snafu::{OptionExt, ResultExt};
 
+// MSRV(1.70): Use OnceLock.
+// MSRV(1.80): Use LazyLock.
 lazy_static! {
     /// A `procfs` handle to which is used globally by libpathrs.
     pub(crate) static ref PROCFS_HANDLE: ProcfsHandle =

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -20,7 +20,7 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    error::{self, Error},
+    error::{Error, ErrorImpl},
     flags::{OpenFlags, ResolverFlags},
     resolvers::procfs::ProcfsResolver,
     syscalls::{self, FsmountFlags, FsopenFlags, OpenTreeFlags},
@@ -32,8 +32,6 @@ use std::{
     os::unix::{fs::MetadataExt, io::AsRawFd},
     path::{Path, PathBuf},
 };
-
-use snafu::{OptionExt, ResultExt};
 
 // MSRV(1.70): Use OnceLock.
 // MSRV(1.80): Use LazyLock.
@@ -163,18 +161,21 @@ impl ProcfsHandle {
     ///
     /// [`ProcfsHandle`]: struct.ProcfsHandle.html
     pub(crate) fn new_fsopen() -> Result<Self, Error> {
-        let sfd =
-            syscalls::fsopen("proc", FsopenFlags::FSOPEN_CLOEXEC).context(error::RawOsSnafu {
-                operation: "create procfs suberblock",
-            })?;
+        let sfd = syscalls::fsopen("proc", FsopenFlags::FSOPEN_CLOEXEC).map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "create procfs suberblock".into(),
+                source: err,
+            }
+        })?;
 
         // Try to configure hidepid=ptraceable,subset=pid if possible, but
         // ignore errors.
         let _ = syscalls::fsconfig_set_string(sfd.as_raw_fd(), "hidepid", "ptraceable");
         let _ = syscalls::fsconfig_set_string(sfd.as_raw_fd(), "subset", "pid");
 
-        syscalls::fsconfig_create(sfd.as_raw_fd()).context(error::RawOsSnafu {
-            operation: "instantiate procfs superblock",
+        syscalls::fsconfig_create(sfd.as_raw_fd()).map_err(|err| ErrorImpl::RawOsError {
+            operation: "instantiate procfs superblock".into(),
+            source: err,
         })?;
 
         syscalls::fsmount(
@@ -182,8 +183,12 @@ impl ProcfsHandle {
             FsmountFlags::FSMOUNT_CLOEXEC,
             libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_NOSUID,
         )
-        .context(error::RawOsSnafu {
-            operation: "mount new private procfs",
+        .map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "mount new private procfs".into(),
+                source: err,
+            }
+            .into()
         })
         // NOTE: try_from checks this is an actual procfs root.
         .and_then(Self::try_from)
@@ -200,8 +205,12 @@ impl ProcfsHandle {
             "/proc",
             OpenTreeFlags::OPEN_TREE_CLONE | flags,
         )
-        .context(error::RawOsSnafu {
-            operation: "create private /proc bind-mount",
+        .map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "create private /proc bind-mount".into(),
+                source: err,
+            }
+            .into()
         })
         // NOTE: try_from checks this is an actual procfs root.
         .and_then(Self::try_from)
@@ -214,8 +223,12 @@ impl ProcfsHandle {
     /// [`ProcfsHandle`]: struct.ProcfsHandle.html
     pub(crate) fn new_unsafe_open() -> Result<Self, Error> {
         syscalls::openat(libc::AT_FDCWD, "/proc", libc::O_PATH | libc::O_DIRECTORY, 0)
-            .context(error::RawOsSnafu {
-                operation: "open /proc handle",
+            .map_err(|err| {
+                ErrorImpl::RawOsError {
+                    operation: "open /proc handle".into(),
+                    source: err,
+                }
+                .into()
             })
             // NOTE: try_from checks this is an actual procfs root.
             .and_then(Self::try_from)
@@ -253,35 +266,35 @@ impl ProcfsHandle {
 
     fn check_is_procfs(file: &File) -> Result<(), Error> {
         let fs_type = syscalls::fstatfs(file.as_raw_fd())
-            .context(error::RawOsSnafu {
-                operation: "fstatfs proc handle",
+            .map_err(|err| ErrorImpl::RawOsError {
+                operation: "fstatfs proc handle".into(),
+                source: err,
             })?
             .f_type;
-        ensure!(
-            fs_type == libc::PROC_SUPER_MAGIC,
-            error::SafetyViolationSnafu {
+        if fs_type != libc::PROC_SUPER_MAGIC {
+            Err(ErrorImpl::SafetyViolation {
                 description: format!(
-                    "/proc is not procfs (f_type is 0x{:X}, not 0x{:X})",
-                    fs_type,
+                    "/proc is not procfs (f_type is 0x{fs_type:X}, not 0x{:X})",
                     libc::PROC_SUPER_MAGIC
-                ),
-            }
-        );
+                )
+                .into(),
+            })?
+        }
         Ok(())
     }
 
     fn check_mnt_id<P: AsRef<Path>>(&self, dir: &File, path: P) -> Result<(), Error> {
         let mnt_id = utils::fetch_mnt_id(dir, path)?;
-        ensure!(
-            self.mnt_id == mnt_id,
-            error::SafetyViolationSnafu {
+        if self.mnt_id != mnt_id {
+            Err(ErrorImpl::SafetyViolation {
                 // TODO: Include the full path in the error.
                 description: format!(
-                    "mount id mismatch for procfs subpath (mnt_id is {:?}, not procfs {:?})",
-                    mnt_id, self.mnt_id
-                ),
-            }
-        );
+                    "mount id mismatch for procfs subpath (mnt_id is {mnt_id:?}, not procfs {:?})",
+                    self.mnt_id
+                )
+                .into(),
+            })?
+        }
         Ok(())
     }
 
@@ -358,9 +371,9 @@ impl ProcfsHandle {
 
         // Get a no-follow handle to the parent of the magic-link.
         let (parent, trailing) = utils::path_split(subpath)?;
-        let trailing = trailing.context(error::InvalidArgumentSnafu {
-            name: "path",
-            description: "proc_open_follow path has trailing slash",
+        let trailing = trailing.ok_or_else(|| ErrorImpl::InvalidArgument {
+            name: "path".into(),
+            description: "proc_open_follow path has trailing slash".into(),
         })?;
 
         let parent = self.open(base, parent, OpenFlags::O_PATH | OpenFlags::O_DIRECTORY)?;
@@ -371,11 +384,13 @@ impl ProcfsHandle {
         // for the ProcfsHandle::{new_fsopen,new_open_tree} cases.
         self.check_mnt_id(&parent, trailing)?;
 
-        syscalls::openat_follow(parent.as_raw_fd(), trailing, flags.bits(), 0).context(
-            error::RawOsSnafu {
-                operation: "open final magiclink component",
-            },
-        )
+        syscalls::openat_follow(parent.as_raw_fd(), trailing, flags.bits(), 0).map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "open final magiclink component".into(),
+                source: err,
+            }
+            .into()
+        })
     }
 
     /// Safely open a path inside `procfs`.
@@ -451,8 +466,12 @@ impl ProcfsHandle {
     /// [`ProcfsHandle::open`]: struct.ProcfsHandle.html#method.open
     pub fn readlink<P: AsRef<Path>>(&self, base: ProcfsBase, subpath: P) -> Result<PathBuf, Error> {
         let link = self.open(base, subpath, OpenFlags::O_PATH)?;
-        syscalls::readlinkat(link.as_raw_fd(), "").context(error::RawOsSnafu {
-            operation: "read procfs magiclink",
+        syscalls::readlinkat(link.as_raw_fd(), "").map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "read procfs magiclink".into(),
+                source: err,
+            }
+            .into()
         })
     }
 }
@@ -468,16 +487,15 @@ impl TryFrom<File> for ProcfsHandle {
         // guaranteed to have an inode number of PROC_ROOT_INO. If this check
         // ever stops working, it's a kernel regression.
         let ino = inner.metadata().expect("fstat(/proc) should work").ino();
-        ensure!(
-            ino == Self::PROC_ROOT_INO,
-            error::SafetyViolationSnafu {
+        if ino != Self::PROC_ROOT_INO {
+            Err(ErrorImpl::SafetyViolation {
                 description: format!(
-                    "/proc is not root of a procfs mount (ino is 0x{:X}, not 0x{:X})",
-                    ino,
+                    "/proc is not root of a procfs mount (ino is 0x{ino:X}, not 0x{:X})",
                     Self::PROC_ROOT_INO,
                 )
-            }
-        );
+                .into(),
+            })?
+        }
 
         let mnt_id = utils::fetch_mnt_id(&inner, "")?;
         let resolver = ProcfsResolver::default();
@@ -534,8 +552,7 @@ mod tests {
         let procfs = ProcfsHandle::new();
         assert!(
             procfs.is_ok(),
-            "new procfs handle should succeed, got {:?}",
-            procfs
+            "new procfs handle should succeed, got {procfs:?}",
         );
     }
 }

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -60,6 +60,8 @@ pub enum ResolverBackend {
     //       hyper-concerned users.
 }
 
+// MSRV(1.70): Use OnceLock.
+// MSRV(1.80): Use LazyLock.
 lazy_static! {
     static ref DEFAULT_RESOLVER_TYPE: ResolverBackend = if *syscalls::OPENAT2_IS_SUPPORTED {
         ResolverBackend::KernelOpenat2
@@ -171,6 +173,7 @@ impl From<PartialLookup<Rc<File>>> for PartialLookup<Handle> {
         // current points to. There is nowhere else we could've stashed a
         // reference, and we only do Rc::clone for root (which we've dropped).
         let handle = Handle::from_file_unchecked(
+            // MSRV(1.70): Use Rc::into_inner().
             Rc::try_unwrap(rc)
                 .expect("current handle in lookup should only have a single Rc reference"),
         );

--- a/src/resolvers/opath/impl.rs
+++ b/src/resolvers/opath/impl.rs
@@ -52,7 +52,7 @@ use std::{
     fs::File,
     io::Error as IOError,
     iter,
-    os::{fd::AsRawFd, unix::ffi::OsStrExt},
+    os::unix::{ffi::OsStrExt, io::AsRawFd},
     path::{Path, PathBuf},
     rc::Rc,
 };

--- a/src/resolvers/opath/mod.rs
+++ b/src/resolvers/opath/mod.rs
@@ -21,5 +21,4 @@ mod r#impl;
 pub(crate) use r#impl::*;
 
 mod symlink_stack;
-pub(crate) use symlink_stack::SymlinkStack;
-pub use symlink_stack::SymlinkStackError;
+pub(crate) use symlink_stack::{SymlinkStack, SymlinkStackError};

--- a/src/resolvers/opath/symlink_stack.rs
+++ b/src/resolvers/opath/symlink_stack.rs
@@ -38,7 +38,6 @@ use crate::utils::PathIterExt;
 
 use std::{
     collections::VecDeque,
-    error::Error as StdError,
     ffi::{OsStr, OsString},
     fmt,
     os::unix::ffi::OsStrExt,
@@ -46,28 +45,15 @@ use std::{
     rc::Rc,
 };
 
-#[derive(Debug, PartialEq)]
-pub enum SymlinkStackError {
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub(crate) enum SymlinkStackError {
+    #[error("[internal] empty stack")]
     EmptyStack,
+    #[error("[internal error] broken symlink stack: trying to pop component {part:?} from an empty stack entry")]
     BrokenStackEmpty { part: OsString },
+    #[error("[internal error] broken symlink stack: trying to pop component {part:?} but expected {expected:?}")]
     BrokenStackWrongComponent { part: OsString, expected: OsString },
 }
-
-impl fmt::Display for SymlinkStackError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EmptyStack => write!(f, "[internal] empty stack"),
-            Self::BrokenStackEmpty { part } => {
-                write!(f, "[internal error] broken symlink stack: trying to pop component {part:?} from an empty stack entry")
-            }
-            Self::BrokenStackWrongComponent { part, expected } => {
-                write!(f, "[internal error] broken symlink stack: trying to pop component {part:?} but expected {expected:?}")
-            }
-        }
-    }
-}
-
-impl StdError for SymlinkStackError {}
 
 #[derive(Debug)]
 struct SymlinkStackEntry<F: fmt::Debug> {

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -39,8 +39,11 @@ use crate::{
 };
 
 use std::{
-    collections::VecDeque, fs::File, io::Error as IOError, os::fd::AsRawFd,
-    os::unix::ffi::OsStrExt, path::Path,
+    collections::VecDeque,
+    fs::File,
+    io::Error as IOError,
+    os::unix::{ffi::OsStrExt, io::AsRawFd},
+    path::Path,
 };
 
 use snafu::ResultExt;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -45,6 +45,7 @@ use libc::{c_int, c_uint, dev_t, mode_t, stat, statfs};
 //       wants to be able to derive an Error for Backtrace?). We could add a
 //       backtrace to error::Error but if we also add a backtrace to
 //       syscalls::Error this might get a little complicated.
+// MSRV(1.65): Use std::backtrace::Backtrace.
 
 // MSRV(1.70): Use OnceLock.
 // MSRV(1.80): Use LazyLock.

--- a/src/tests/common/mntns.rs
+++ b/src/tests/common/mntns.rs
@@ -21,7 +21,7 @@ use std::{
     ffi::CString,
     fs::File,
     io::Error as IOError,
-    os::fd::{AsRawFd, RawFd},
+    os::unix::io::{AsRawFd, RawFd},
     path::{Path, PathBuf},
     ptr,
 };
@@ -67,9 +67,11 @@ pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> 
     let ret = match ty {
         MountType::Tmpfs => unsafe {
             libc::mount(
-                c"".as_ptr(),
+                // MSRV(1.77): Use c"".
+                CString::new("")?.as_ptr(),
                 dst_path.as_ptr(),
-                c"tmpfs".as_ptr(),
+                // MSRV(1.77): Use c"tmpfs".
+                CString::new("tmpfs")?.as_ptr(),
                 0,
                 ptr::null(),
             )

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -100,14 +100,14 @@ macro_rules! resolve_tests {
         }
     };
 
-    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, rflags: $($rflag:ident)|+) => $expected:expr ) => {
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, rflags = $($rflag:ident)|+) => $expected:expr ) => {
         resolve_tests! {
             [$root_dir]
             @impl $test_name $op_name($path, $(ResolverFlags::$rflag)|*, false) => $expected
         }
     };
 
-    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, no_follow_trailing: $no_follow_trailing:expr) => $expected:expr ) => {
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, no_follow_trailing = $no_follow_trailing:expr) => $expected:expr ) => {
         resolve_tests! {
             [$root_dir]
             @impl $test_name $op_name($path, ResolverFlags::empty(), $no_follow_trailing) => $expected
@@ -134,15 +134,15 @@ macro_rules! resolve_tests {
 resolve_tests! {
     [Path::new("/proc")] {
         proc_pseudo_magiclink: resolve("self/sched") => Ok(("{{/proc/self}}/sched", libc::S_IFREG));
-        proc_pseudo_magiclink_nosym1: resolve("self", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        proc_pseudo_magiclink_nosym2: resolve("self/sched", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        proc_pseudo_magiclink_nofollow1: resolve("self", no_follow_trailing: true) => Ok(("self", libc::S_IFLNK));
-        proc_pseudo_magiclink_nofollow2: resolve("self/sched", no_follow_trailing: true) => Ok(("{{/proc/self}}/sched", libc::S_IFREG));
+        proc_pseudo_magiclink_nosym1: resolve("self", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        proc_pseudo_magiclink_nosym2: resolve("self/sched", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        proc_pseudo_magiclink_nofollow1: resolve("self", no_follow_trailing = true) => Ok(("self", libc::S_IFLNK));
+        proc_pseudo_magiclink_nofollow2: resolve("self/sched", no_follow_trailing = true) => Ok(("{{/proc/self}}/sched", libc::S_IFREG));
 
         // Verify forced RESOLVE_NO_MAGICLINKS behaviour.
         proc_magiclink: resolve("self/exe") => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        proc_magiclink_nofollow: resolve("self/exe", no_follow_trailing: true) => Ok(("{{/proc/self}}/exe", libc::S_IFLNK));
-        proc_magiclink_component_nofollow: resolve("self/root/etc/passwd", no_follow_trailing: true) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        proc_magiclink_nofollow: resolve("self/exe", no_follow_trailing = true) => Ok(("{{/proc/self}}/exe", libc::S_IFLNK));
+        proc_magiclink_component_nofollow: resolve("self/root/etc/passwd", no_follow_trailing = true) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
     };
 
     // Complete lookups.
@@ -501,12 +501,12 @@ resolve_tests! {
             last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
         });
         // O_NOFOLLOW doesn't matter for trailing-slash paths.
-        partial_symlink_nofollow_slash1: resolve("link3/target_abs/", no_follow_trailing: true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_slash1: resolve_partial("link3/target_abs/", no_follow_trailing: true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
-        partial_symlink_nofollow_slash2: resolve("link3/target_abs//", no_follow_trailing: true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_slash2: resolve_partial("link3/target_abs//", no_follow_trailing: true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
-        partial_symlink_nofollow_dot: resolve("link3/target_abs/.", no_follow_trailing: true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_dot: resolve_partial("link3/target_abs/.", no_follow_trailing: true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        partial_symlink_nofollow_slash1: resolve("link3/target_abs/", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
+        partial_symlink_nofollow_slash1: resolve_partial("link3/target_abs/", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        partial_symlink_nofollow_slash2: resolve("link3/target_abs//", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
+        partial_symlink_nofollow_slash2: resolve_partial("link3/target_abs//", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        partial_symlink_nofollow_dot: resolve("link3/target_abs/.", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
+        partial_symlink_nofollow_dot: resolve_partial("link3/target_abs/.", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         // Dangling symlinks are treated as though they are non_existent.
         dangling1_inroot_trailing: resolve("a-fake1") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
         dangling1_inroot_trailing: resolve_partial("a-fake1") => Ok(PartialLookup::Partial {
@@ -752,37 +752,37 @@ resolve_tests! {
             last_error: ErrorKind::OsError(Some(libc::ELOOP)),
         });
         // NO_FOLLOW.
-        symlink_nofollow: resolve("link3/target_abs", no_follow_trailing: true) => Ok(("link3/target_abs", libc::S_IFLNK));
-        symlink_nofollow: resolve_partial("link3/target_abs", no_follow_trailing: true) => Ok(PartialLookup::Complete(("link3/target_abs", libc::S_IFLNK)));
-        symlink_component_nofollow1: resolve("e/f", no_follow_trailing: true) => Ok(("b/c/d/e/f", libc::S_IFDIR));
-        symlink_component_nofollow1: resolve_partial("e/f", no_follow_trailing: true) => Ok(PartialLookup::Complete(("b/c/d/e/f", libc::S_IFDIR)));
-        symlink_component_nofollow2: resolve("link2/link1_abs/target_rel", no_follow_trailing: true) => Ok(("link1/target_rel", libc::S_IFLNK));
-        symlink_component_nofollow2: resolve_partial("link2/link1_abs/target_rel", no_follow_trailing: true) => Ok(PartialLookup::Complete(("link1/target_rel", libc::S_IFLNK)));
-        loop_nofollow: resolve("loop/link", no_follow_trailing: true) => Ok(("loop/link", libc::S_IFLNK));
-        loop_nofollow: resolve_partial("loop/link", no_follow_trailing: true) => Ok(PartialLookup::Complete(("loop/link", libc::S_IFLNK)));
+        symlink_nofollow: resolve("link3/target_abs", no_follow_trailing = true) => Ok(("link3/target_abs", libc::S_IFLNK));
+        symlink_nofollow: resolve_partial("link3/target_abs", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link3/target_abs", libc::S_IFLNK)));
+        symlink_component_nofollow1: resolve("e/f", no_follow_trailing = true) => Ok(("b/c/d/e/f", libc::S_IFDIR));
+        symlink_component_nofollow1: resolve_partial("e/f", no_follow_trailing = true) => Ok(PartialLookup::Complete(("b/c/d/e/f", libc::S_IFDIR)));
+        symlink_component_nofollow2: resolve("link2/link1_abs/target_rel", no_follow_trailing = true) => Ok(("link1/target_rel", libc::S_IFLNK));
+        symlink_component_nofollow2: resolve_partial("link2/link1_abs/target_rel", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link1/target_rel", libc::S_IFLNK)));
+        loop_nofollow: resolve("loop/link", no_follow_trailing = true) => Ok(("loop/link", libc::S_IFLNK));
+        loop_nofollow: resolve_partial("loop/link", no_follow_trailing = true) => Ok(PartialLookup::Complete(("loop/link", libc::S_IFLNK)));
         // RESOLVE_NO_SYMLINKS.
-        dir_nosym: resolve("b/c/d/e", rflags: NO_SYMLINKS) => Ok(("b/c/d/e", libc::S_IFDIR));
-        dir_nosym: resolve_partial("b/c/d/e", rflags: NO_SYMLINKS) => Ok(PartialLookup::Complete(("b/c/d/e", libc::S_IFDIR)));
-        symlink_nosym: resolve("link3/target_abs", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_nosym: resolve_partial("link3/target_abs", rflags: NO_SYMLINKS) => Ok(PartialLookup::Partial {
+        dir_nosym: resolve("b/c/d/e", rflags = NO_SYMLINKS) => Ok(("b/c/d/e", libc::S_IFDIR));
+        dir_nosym: resolve_partial("b/c/d/e", rflags = NO_SYMLINKS) => Ok(PartialLookup::Complete(("b/c/d/e", libc::S_IFDIR)));
+        symlink_nosym: resolve("link3/target_abs", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        symlink_nosym: resolve_partial("link3/target_abs", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
             handle: ("link3", libc::S_IFDIR),
             remaining: "target_abs".into(),
             last_error: ErrorKind::OsError(Some(libc::ELOOP)),
         });
-        symlink_component_nosym1: resolve("e/f", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_component_nosym1: resolve_partial("e/f", rflags: NO_SYMLINKS) => Ok(PartialLookup::Partial {
+        symlink_component_nosym1: resolve("e/f", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        symlink_component_nosym1: resolve_partial("e/f", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
             handle: ("", libc::S_IFDIR),
             remaining: "e/f".into(),
             last_error: ErrorKind::OsError(Some(libc::ELOOP)),
         });
-        symlink_component_nosym2: resolve("link2/link1_abs/target_rel", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_component_nosym2: resolve_partial("link2/link1_abs/target_rel", rflags: NO_SYMLINKS) => Ok(PartialLookup::Partial {
+        symlink_component_nosym2: resolve("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        symlink_component_nosym2: resolve_partial("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
             handle: ("link2", libc::S_IFDIR),
             remaining: "link1_abs/target_rel".into(),
             last_error: ErrorKind::OsError(Some(libc::ELOOP)),
         });
-        loop_nosym: resolve("loop/link", rflags: NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop_nosym: resolve_partial("loop/link", rflags: NO_SYMLINKS) => Ok(PartialLookup::Partial {
+        loop_nosym: resolve("loop/link", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        loop_nosym: resolve_partial("loop/link", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
             handle: ("loop", libc::S_IFDIR),
             remaining: "link".into(),
             last_error: ErrorKind::OsError(Some(libc::ELOOP)),

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -297,8 +297,10 @@ mod utils {
 
     use std::{
         fs::Permissions,
-        os::fd::AsRawFd,
-        os::unix::fs::{MetadataExt, PermissionsExt},
+        os::unix::{
+            fs::{MetadataExt, PermissionsExt},
+            io::AsRawFd,
+        },
         path::{Path, PathBuf},
     };
 

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -285,7 +285,7 @@ mod tests {
 
     use std::{
         fs::File,
-        os::fd::{AsRawFd, RawFd},
+        os::unix::io::{AsRawFd, RawFd},
         path::{Path, PathBuf},
     };
 

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -17,7 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::error::{self, Error};
+use crate::error::{Error, ErrorImpl};
 
 use std::{
     collections::VecDeque,
@@ -85,18 +85,16 @@ pub(crate) fn path_split(path: &'_ Path) -> Result<(&'_ Path, Option<&'_ Path>),
     // If there are any other path components we must bail.
     if let Some(base) = base {
         let base_bytes = base.as_os_str().as_bytes();
-        ensure!(
-            base_bytes != b"",
-            error::SafetyViolationSnafu {
-                description: "trailing component of split pathname is ''",
-            }
-        );
-        ensure!(
-            !base_bytes.contains(&b'/'),
-            error::SafetyViolationSnafu {
-                description: "trailing component of split pathname contains '/'",
-            }
-        );
+        if base_bytes == b"" {
+            Err(ErrorImpl::SafetyViolation {
+                description: "trailing component of split pathname is empty".into(),
+            })?
+        }
+        if base_bytes.contains(&b'/') {
+            Err(ErrorImpl::SafetyViolation {
+                description: "trailing component of split pathname contains '/'".into(),
+            })?
+        }
     }
 
     Ok((dir, base))
@@ -131,8 +129,7 @@ impl<'a> Iterator for RawComponents<'a> {
                 self.inner = remaining;
                 assert!(
                     !next.as_bytes().contains(&b'/'),
-                    "individual path component {:?} contains '/'",
-                    next
+                    "individual path component {next:?} contains '/'",
                 );
                 Some(next)
             }
@@ -156,8 +153,7 @@ impl<'a> DoubleEndedIterator for RawComponents<'a> {
                 self.inner = remaining;
                 assert!(
                     !next.as_bytes().contains(&b'/'),
-                    "individual path component {:?} contains '/'",
-                    next
+                    "individual path component {next:?} contains '/'",
                 );
                 Some(next)
             }
@@ -359,13 +355,11 @@ mod tests {
 
                         assert_eq!(
                             got_path.as_os_str(), want_path.as_os_str(),
-                            "stripping {:?} produced wrong result -- got {:?}",
-                            path, got_path,
+                            "stripping {path:?} produced wrong result -- got {got_path:?}",
                         );
                         assert_eq!(
                             got_trailing, want_trailing,
-                            "expected {:?} to have trailing_slash={}",
-                            path, want_trailing,
+                            "expected {path:?} to have trailing_slash={want_trailing}",
                         );
                     }
                 )*
@@ -410,7 +404,7 @@ mod tests {
                     fn [<path_split_ $test_name>]() -> Result<(), Error> {
                         let path: PathBuf = $path.into();
                         let (got_dir, got_file) = path_split(&path)
-                            .with_context(|| format!("path_split({:?})", path))?;
+                            .with_context(|| format!("path_split({path:?})"))?;
 
                         let want_dir: PathBuf = $dir.into();
                         let want_file = {

--- a/src/utils/umask.rs
+++ b/src/utils/umask.rs
@@ -27,7 +27,7 @@ use crate::{
 use std::{
     env,
     io::{BufRead, BufReader},
-    os::fd::AsRawFd,
+    os::unix::io::AsRawFd,
 };
 
 use libc::mode_t;
@@ -41,6 +41,8 @@ use snafu::ResultExt;
 //NOTE: While the umask is shared between threads, it unshared with `CLONE_FS`
 //      so a single thread could have a different umask to other threads.
 fn get_umask_procfs(procfs: &ProcfsHandle) -> Result<Option<mode_t>, Error> {
+    // MSRV(1.70): Use OnceLock.
+    // MSRV(1.80): Use LazyLock.
     lazy_static! {
         static ref RE: Regex = Regex::new(r"^Umask:\s*(0[0-7]+)$").unwrap();
     }


### PR DESCRIPTION
This version was released in 2022, so it should be old enough to use for
packaging in regular distributions.

Ideally we would try to use Rust 1.63 (the version in Debian stable),
but the main thing limiting us is std::backtrace::Backtrace. We do plan
to rework errors in the future (to avoid a bunch of the issues with
snafu), so we might make be able to get to 1.63 in the future.

We can't really go older than 1.63 because rustix requires it (likely
because of the BorrowedFd io_safety API), which we plan to migrate to as
well.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>