### PR TITLE
root: implement remove_all and fix up removal methods

### DIFF
--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -338,6 +338,18 @@ class Root(WrappedFd):
 		if err < 0:
 			raise Error._fetch(err) or INTERNAL_ERROR
 
+	def rmdir(self, path):
+		path = _cstr(path)
+		err = libpathrs_so.pathrs_rmdir(self.fileno(), path)
+		if err < 0:
+			raise Error._fetch(err) or INTERNAL_ERROR
+
+	def unlink(self, path):
+		path = _cstr(path)
+		err = libpathrs_so.pathrs_unlink(self.fileno(), path)
+		if err < 0:
+			raise Error._fetch(err) or INTERNAL_ERROR
+
 	def mkdir(self, path, mode):
 		path = _cstr(path)
 		err = libpathrs_so.pathrs_mkdir(self.fileno(), path, mode)

--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -350,6 +350,12 @@ class Root(WrappedFd):
 		if err < 0:
 			raise Error._fetch(err) or INTERNAL_ERROR
 
+	def remove_all(self, path):
+		path = _cstr(path)
+		err = libpathrs_so.pathrs_remove_all(self.fileno(), path)
+		if err < 0:
+			raise Error._fetch(err) or INTERNAL_ERROR
+
 	def mkdir(self, path, mode):
 		path = _cstr(path)
 		err = libpathrs_so.pathrs_mkdir(self.fileno(), path, mode)

--- a/go-pathrs/libpathrs_linux.go
+++ b/go-pathrs/libpathrs_linux.go
@@ -103,6 +103,22 @@ func pathrsReadlink(rootFd uintptr, path string) (string, error) {
 	}
 }
 
+func pathrsRmdir(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_rmdir(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
+func pathrsUnlink(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_unlink(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
 func pathrsCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))

--- a/go-pathrs/libpathrs_linux.go
+++ b/go-pathrs/libpathrs_linux.go
@@ -119,6 +119,14 @@ func pathrsUnlink(rootFd uintptr, path string) error {
 	return fetchError(err)
 }
 
+func pathrsRemoveAll(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_remove_all(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
 func pathrsCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -174,6 +174,16 @@ func (r *Root) Remove(path string) error {
 	}
 }
 
+// RemoveAll recursively deletes a path and all of its children. This is
+// designed to match the semantics of os.RemoveAll.
+func (r *Root) RemoveAll(path string) error {
+	_, err := withFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := pathrsRemoveAll(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
 // Mkdir creates a directory within a Root's directory tree. The provided mode
 // is used for the new directory (the process's umask applies).
 func (r *Root) Mkdir(path string, mode os.FileMode) error {

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -21,6 +21,8 @@ package pathrs
 import (
 	"fmt"
 	"os"
+
+	"syscall"
 )
 
 // Root is a handle to the root of a directory tree to resolve within. The only
@@ -130,6 +132,46 @@ func (r *Root) Rename(src, dst string, flags uint) error {
 		return struct{}{}, err
 	})
 	return err
+}
+
+// RemoveDir removes the named empty directory within a Root's directory tree.
+func (r *Root) RemoveDir(path string) error {
+	_, err := withFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := pathrsRmdir(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// RemoveFile removes the named file within a Root's directory tree.
+func (r *Root) RemoveFile(path string) error {
+	_, err := withFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := pathrsUnlink(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Remove removes the named file or (empty) directory within a Root's directory
+// tree. This is designed to match the semantics of os.Remove.
+func (r *Root) Remove(path string) error {
+	// In order to match os.Remove's implementation we need to also do both
+	// syscalls unconditionally and adjust the error based on whether
+	// pathrs_rmdir() returned ENOTDIR.
+	unlinkErr := r.RemoveFile(path)
+	if unlinkErr == nil {
+		return nil
+	}
+	rmdirErr := r.RemoveDir(path)
+	if rmdirErr == nil {
+		return nil
+	}
+	// Both failed, adjust the error in the same way that os.Remove does.
+	if err, ok := rmdirErr.(*Error); ok && err.errno != syscall.ENOTDIR {
+		return rmdirErr
+	} else {
+		return unlinkErr
+	}
 }
 
 // Mkdir creates a directory within a Root's directory tree. The provided mode

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -264,6 +264,21 @@ int pathrs_rmdir(int root_fd, const char *path);
 int pathrs_unlink(int root_fd, const char *path);
 
 /**
+ * Recursively delete the path and any children it contains if it is a
+ * directory. The semantics are equivalent to `rm -r`.
+ *
+ * # Return Value
+ *
+ * On success, this function returns 0.
+ *
+ * If an error occurs, this function will return a negative error code. To
+ * retrieve information about the error (such as a string describing the error,
+ * the system errno(7) value associated with the error, etc), use
+ * pathrs_errorinfo().
+ */
+int pathrs_remove_all(int root_fd, const char *path);
+
+/**
  * Create a new regular file within the rootfs referenced by root_fd. This is
  * effectively an O_CREAT operation, and so (unlike pathrs_resolve()), this
  * function can be used on non-existent paths.

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -228,6 +228,42 @@ int pathrs_rename(int root_fd,
                   uint32_t flags);
 
 /**
+ * Remove the empty directory at path within the rootfs referenced by root_fd.
+ *
+ * The semantics are effectively equivalent to unlinkat(..., AT_REMOVEDIR).
+ * This function will return an error if the path doesn't exist, was not a
+ * directory, or was a non-empty directory.
+ *
+ * # Return Value
+ *
+ * On success, this function returns 0.
+ *
+ * If an error occurs, this function will return a negative error code. To
+ * retrieve information about the error (such as a string describing the error,
+ * the system errno(7) value associated with the error, etc), use
+ * pathrs_errorinfo().
+ */
+int pathrs_rmdir(int root_fd, const char *path);
+
+/**
+ * Remove the file (a non-directory inode) at path within the rootfs referenced
+ * by root_fd.
+ *
+ * The semantics are effectively equivalent to unlinkat(..., 0). This function
+ * will return an error if the path doesn't exist or was a directory.
+ *
+ * # Return Value
+ *
+ * On success, this function returns 0.
+ *
+ * If an error occurs, this function will return a negative error code. To
+ * retrieve information about the error (such as a string describing the error,
+ * the system errno(7) value associated with the error, etc), use
+ * pathrs_errorinfo().
+ */
+int pathrs_unlink(int root_fd, const char *path);
+
+/**
  * Create a new regular file within the rootfs referenced by root_fd. This is
  * effectively an O_CREAT operation, and so (unlike pathrs_resolve()), this
  * function can be used on non-existent paths.

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -222,6 +222,48 @@ pub extern "C" fn pathrs_rename(
     })
 }
 
+/// Remove the empty directory at path within the rootfs referenced by root_fd.
+///
+/// The semantics are effectively equivalent to unlinkat(..., AT_REMOVEDIR).
+/// This function will return an error if the path doesn't exist, was not a
+/// directory, or was a non-empty directory.
+///
+/// # Return Value
+///
+/// On success, this function returns 0.
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_rmdir(root_fd: RawFd, path: *const c_char) -> c_int {
+    ret::with_fd(root_fd, |root: &mut Root| {
+        root.remove_dir(utils::parse_path(path)?)
+    })
+}
+
+/// Remove the file (a non-directory inode) at path within the rootfs referenced
+/// by root_fd.
+///
+/// The semantics are effectively equivalent to unlinkat(..., 0). This function
+/// will return an error if the path doesn't exist or was a directory.
+///
+/// # Return Value
+///
+/// On success, this function returns 0.
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_unlink(root_fd: RawFd, path: *const c_char) -> c_int {
+    ret::with_fd(root_fd, |root: &mut Root| {
+        root.remove_file(utils::parse_path(path)?)
+    })
+}
+
 // Within the root, create an inode at the path with the given mode. If the
 // path already exists, an error is returned (effectively acting as though
 // O_EXCL is always set). Each pathrs_* corresponds to the matching syscall.

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -264,6 +264,24 @@ pub extern "C" fn pathrs_unlink(root_fd: RawFd, path: *const c_char) -> c_int {
     })
 }
 
+/// Recursively delete the path and any children it contains if it is a
+/// directory. The semantics are equivalent to `rm -r`.
+///
+/// # Return Value
+///
+/// On success, this function returns 0.
+///
+/// If an error occurs, this function will return a negative error code. To
+/// retrieve information about the error (such as a string describing the error,
+/// the system errno(7) value associated with the error, etc), use
+/// pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_remove_all(root_fd: RawFd, path: *const c_char) -> c_int {
+    ret::with_fd(root_fd, |root: &mut Root| {
+        root.remove_all(utils::parse_path(path)?)
+    })
+}
+
 // Within the root, create an inode at the path with the given mode. If the
 // path already exists, an error is returned (effectively acting as though
 // O_EXCL is always set). Each pathrs_* corresponds to the matching syscall.

--- a/src/root.rs
+++ b/src/root.rs
@@ -728,6 +728,7 @@ impl Root {
     ///
     /// [`Root`]: struct.Root.html
     /// [`Handle`]: trait.Handle.html
+    #[doc(alias = "pathrs_rmdir")]
     #[inline]
     pub fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
         self.remove_inode(path.as_ref(), RemoveInodeType::Directory)
@@ -747,6 +748,7 @@ impl Root {
     ///
     /// [`Root`]: struct.Root.html
     /// [`Handle`]: trait.Handle.html
+    #[doc(alias = "pathrs_unlink")]
     #[inline]
     pub fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
         self.remove_inode(path.as_ref(), RemoveInodeType::Regular)

--- a/src/root.rs
+++ b/src/root.rs
@@ -326,8 +326,10 @@ impl Root {
     /// inode), an error is returned.
     ///
     /// [`Root`]: struct.Root.html
-    #[doc(alias = "pathrs_creat")]
-    #[doc(alias = "pathrs_create")]
+    #[doc(alias = "pathrs_mkdir")]
+    #[doc(alias = "pathrs_mknod")]
+    #[doc(alias = "pathrs_symlink")]
+    #[doc(alias = "pathrs_hardlink")]
     pub fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Error> {
         // Get a handle for the lexical parent of the target path. It must
         // already exist, and once we have it we're safe from rename races in
@@ -421,10 +423,8 @@ impl Root {
     /// [`Root::create_file`]: struct.Root.html#method.create_file
     /// [`InodeType::File`]: enum.InodeType.html#variant.File
     /// [`O_CREAT`]: http://man7.org/linux/man-pages/man2/open.2.html
-    #[doc(alias = "pathrs_mkdir")]
-    #[doc(alias = "pathrs_mknod")]
-    #[doc(alias = "pathrs_symlink")]
-    #[doc(alias = "pathrs_hardlink")]
+    #[doc(alias = "pathrs_creat")]
+    #[doc(alias = "pathrs_create")]
     pub fn create_file<P: AsRef<Path>>(
         &self,
         path: P,

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -132,10 +132,18 @@ macro_rules! root_op_tests {
         }
     };
 
-    (@impl remove $test_name:ident ($path:expr) => $expected_result:expr) => {
+    (@impl remove_dir $test_name:ident ($path:expr) => $expected_result:expr) => {
         root_op_tests!{
             fn $test_name(root) {
-                utils::check_root_remove(&root, $path, $expected_result)
+                utils::check_root_remove_dir(&root, $path, $expected_result)
+            }
+        }
+    };
+
+    (@impl remove_file $test_name:ident ($path:expr) => $expected_result:expr) => {
+        root_op_tests!{
+            fn $test_name(root) {
+                utils::check_root_remove_file(&root, $path, $expected_result)
             }
         }
     };
@@ -222,10 +230,26 @@ root_op_tests! {
     oexcl_symlink: create_file("b-file", O_EXCL|O_RDONLY, 0o100) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
     oexcl_dangling_symlink: create_file("a-fake1", O_EXCL|O_RDONLY, 0o100) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
 
-    plain: remove("a") => Ok(());
-    enoent: remove("abc") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-    symlink: remove("b-file") => Ok(());
-    dangling_symlink: remove("a-fake1") => Ok(());
+    empty_dir: remove_dir("a") => Ok(());
+    empty_dir: remove_file("a") => Err(ErrorKind::OsError(Some(libc::EISDIR)));
+    nonempty_dir: remove_dir("b") => Err(ErrorKind::OsError(Some(libc::ENOTEMPTY)));
+    nonempty_dir: remove_file("b") => Err(ErrorKind::OsError(Some(libc::EISDIR)));
+    file: remove_dir("b/c/file") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    file: remove_file("b/c/file") => Ok(());
+    fifo: remove_dir("b/fifo") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    fifo: remove_file("b/fifo") => Ok(());
+    sock: remove_dir("b/sock") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    sock: remove_file("b/sock") => Ok(());
+    enoent: remove_dir("abc") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
+    enoent: remove_file("abc") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
+    symlink: remove_dir("b-file") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    symlink: remove_file("b-file") => Ok(());
+    dangling_symlink: remove_dir("a-fake1") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling_symlink: remove_file("a-fake1") => Ok(());
+    dir_trailing_slash: remove_dir("a/") => Err(ErrorKind::InvalidArgument);
+    dir_trailing_slash: remove_file("a/") => Err(ErrorKind::InvalidArgument);
+    file_trailing_slash: remove_dir("b/c/file/") => Err(ErrorKind::InvalidArgument);
+    file_trailing_slash: remove_file("b/c/file/") => Err(ErrorKind::InvalidArgument);
 
     plain: rename("a", "aa", RenameFlags::empty()) => Ok(());
     noreplace_plain: rename("a", "aa", RenameFlags::RENAME_NOREPLACE) => Ok(());
@@ -455,18 +479,20 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_remove<P: AsRef<Path>>(
+    fn check_root_remove<F>(
         root: &Root,
-        path: P,
+        path: &Path,
+        remove_fn: F,
         expected_result: Result<(), ErrorKind>,
-    ) -> Result<(), Error> {
-        let path = path.as_ref();
-
+    ) -> Result<(), Error>
+    where
+        F: FnOnce(&Root, &Path) -> Result<(), PathrsError>,
+    {
         // Get a handle before we remove the path, to make sure the actual inode
         // was unlinked.
         let handle = root.resolve_nofollow(path); // do not unwrap
 
-        let res = root.remove(path);
+        let res = remove_fn(root, path);
         assert_eq!(
             res.as_ref().err().map(PathrsError::kind),
             expected_result.err(),
@@ -488,6 +514,32 @@ mod utils {
             );
         }
         Ok(())
+    }
+
+    pub(super) fn check_root_remove_dir<P: AsRef<Path>>(
+        root: &Root,
+        path: P,
+        expected_result: Result<(), ErrorKind>,
+    ) -> Result<(), Error> {
+        check_root_remove(
+            root,
+            path.as_ref(),
+            |root, path| root.remove_dir(path),
+            expected_result,
+        )
+    }
+
+    pub(super) fn check_root_remove_file<P: AsRef<Path>>(
+        root: &Root,
+        path: P,
+        expected_result: Result<(), ErrorKind>,
+    ) -> Result<(), Error> {
+        check_root_remove(
+            root,
+            path.as_ref(),
+            |root, path| root.remove_file(path),
+            expected_result,
+        )
     }
 
     pub(super) fn check_root_rename<P1: AsRef<Path>, P2: AsRef<Path>>(

--- a/src/utils/dir.rs
+++ b/src/utils/dir.rs
@@ -1,0 +1,132 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::{Error, ErrorExt, ErrorImpl},
+    syscalls,
+};
+
+use std::{
+    ffi::OsStr,
+    os::unix::{
+        ffi::OsStrExt,
+        io::{AsFd, AsRawFd},
+    },
+    path::Path,
+};
+
+use rustix::fs::Dir;
+
+fn remove_inode<Fd: AsFd>(dirfd: Fd, name: &Path) -> Result<(), Error> {
+    let dirfd = dirfd.as_fd();
+
+    // To ensure we return a useful error, we try both unlink and rmdir and
+    // try to avoid returning EISDIR/ENOTDIR if both failed.
+    syscalls::unlinkat(dirfd.as_raw_fd(), name, 0)
+        .or_else(|unlink_err| {
+            syscalls::unlinkat(dirfd.as_raw_fd(), name, libc::AT_REMOVEDIR).map_err(|rmdir_err| {
+                if rmdir_err.root_cause().raw_os_error() == Some(libc::ENOTDIR) {
+                    unlink_err
+                } else {
+                    rmdir_err
+                }
+            })
+        })
+        .map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "remove inode".into(),
+                source: err,
+            }
+            .into()
+        })
+}
+
+pub(crate) fn remove_all<Fd: AsFd>(dirfd: Fd, name: &Path) -> Result<(), Error> {
+    let dirfd = dirfd.as_fd();
+
+    if name.as_os_str().as_bytes().contains(&b'/') {
+        Err(ErrorImpl::SafetyViolation {
+            description: "remove_all reached a component containing '/'".into(),
+        })?;
+    }
+
+    // Fast path -- try to remove it with unlink/rmdir.
+    if remove_inode(dirfd, name).is_ok() {
+        return Ok(());
+    }
+
+    // Try to delete all children. We need to re-do the iteration until there
+    // are no components left because deleting entries while iterating over a
+    // directory can lead to the iterator skipping components. An attacker could
+    // try to make this loop forever by consistently creating inodes, but
+    // there's not much we can do about it and I suspect they would eventually
+    // lose the race.
+    let subdir =
+        syscalls::openat(dirfd.as_raw_fd(), name, libc::O_DIRECTORY, 0).map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "open directory to scan entries".into(),
+                source: err,
+            }
+        })?;
+    loop {
+        // TODO: Dir creates a new file descriptor rather than re-using the one
+        //       we have, and RawDir can't be used as an Iterator yet (rustix
+        //       needs GAT to make that work). But this is okay for now...
+        let mut iter = Dir::read_from(&subdir)
+            // TODO: We probably want to just break out of the loop here, rather
+            //       than return an error? We can at least try to do
+            //       remove_inode() again in case the directory got swapped with
+            //       a non-directory.
+            .map_err(|err| ErrorImpl::OsError {
+                operation: "create directory iterator".into(),
+                source: err.into(),
+            })
+            .with_wrap(|| format!("scan directory {name:?} for deletion"))?
+            .filter(|res| {
+                !matches!(
+                    res.as_ref().map(|dentry| dentry.file_name().to_bytes()),
+                    Ok(b".") | Ok(b"..")
+                )
+            })
+            .peekable();
+
+        // We can stop iterating when a fresh directory iterator is empty.
+        if iter.peek().is_none() {
+            break;
+        }
+
+        // Recurse into all of the children and try to delete them.
+        for child in iter {
+            // TODO: We probably want to break out of the scan loop here if this
+            //       is an error as well.
+            let child = child.map_err(|err| ErrorImpl::OsError {
+                operation: format!("scan directory {name:?}").into(),
+                source: err.into(),
+            })?;
+            let name: &Path = OsStr::from_bytes(child.file_name().to_bytes()).as_ref();
+            remove_all(&subdir, name)?
+        }
+    }
+
+    // We have deleted all of the children of the directory, let's try to delete
+    // the inode again (it should be empty now -- an attacker could add things
+    // but we can just error out in that case, and if they swapped it to a file
+    // then remove_inode will take care of that).
+    remove_inode(dirfd, name).with_wrap(|| format!("deleting emptied directory {name:?}"))
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,6 +19,9 @@
 
 #![forbid(unsafe_code)]
 
+mod dir;
+pub(crate) use dir::*;
+
 mod path;
 pub(crate) use path::*;
 


### PR DESCRIPTION
Implement `Root::remove_all` and split `Root::remove` so that we don't have the unnecessary retry logic.

Fixes #11