### PR TITLE
*: migrate to OwnedFd/BorrowedFd

### DIFF
--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -24,7 +24,7 @@ use crate::{
     procfs::{ProcfsBase, PROCFS_HANDLE},
 };
 
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{OwnedFd, RawFd};
 
 use libc::{c_char, c_int, size_t};
 
@@ -108,6 +108,7 @@ pub extern "C" fn pathrs_proc_open(base: CProcfsBase, path: *const c_char, flags
             false => PROCFS_HANDLE.open_follow(base.into(), path, oflags),
         }
     }()
+    .map(OwnedFd::from)
     .into_c_return()
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -23,10 +23,13 @@ use crate::{
     error::{Error, ErrorImpl},
     flags::OpenFlags,
     procfs::PROCFS_HANDLE,
-    utils::RawFdExt,
+    utils::FdExt,
 };
 
-use std::fs::File;
+use std::{
+    fs::File,
+    os::unix::io::{AsFd, BorrowedFd, OwnedFd},
+};
 
 /// A handle to an existing inode within a [`Root`].
 ///
@@ -37,18 +40,167 @@ use std::fs::File;
 /// # Safety
 ///
 /// It is critical for the safety of this library that **at no point** do you
-/// use interfaces like [`libc::openat`] directly on any [`RawFd`]s you might
-/// extract from the [`File`] you get from this [`Handle`]. **You must always do
-/// operations through a valid [`Root`].**
+/// use interfaces like [`libc::openat`] directly on the [`OwnedFd`] you can
+/// extract from this [`Handle`]. **You must always do operations through a
+/// valid [`Root`].**
 ///
 /// [`RawFd`]: std::os::unix::io::RawFd
 /// [`Root`]: crate::Root
 #[derive(Debug)]
 pub struct Handle {
-    inner: File,
+    inner: OwnedFd,
 }
 
 impl Handle {
+    /// Wrap an [`OwnedFd`] into a [`Handle`].
+    ///
+    /// # Safety
+    ///
+    /// The caller guarantees that the provided file is an `O_PATH` file
+    /// descriptor with exactly the same semantics as one created through
+    /// [`Root::resolve`]. This means that this function should usually be used
+    /// to convert an [`OwnedFd`] returned from [`OwnedFd::from`] (possibly from
+    /// another process) into a [`Handle`].
+    ///
+    /// While this function is not marked as `unsafe` (because the safety
+    /// guarantee required is not related to memory-safety), users should still
+    /// take great care when using this method because it can cause other kinds
+    /// of unsafety.
+    ///
+    /// [`Root::resolve`]: crate::Root::resolve
+    #[inline]
+    pub fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+        Self { inner: fd.into() }
+    }
+
+    /// Borrow this [`Handle`] as a [`HandleRef`].
+    // XXX: We can't use Borrow/Deref for this because HandleRef takes a
+    //      lifetime rather than being a pure reference. Ideally we would use
+    //      Deref but it seems that won't be possible in standard Rust for a
+    //      long time, if ever...
+    #[inline]
+    pub fn as_ref(&self) -> HandleRef<'_> {
+        HandleRef {
+            inner: self.as_fd(),
+        }
+    }
+
+    /// Create a copy of an existing [`Handle`].
+    ///
+    /// The new handle is completely independent from the original, but
+    /// references the same underlying file.
+    #[inline]
+    pub fn try_clone(&self) -> Result<Self, Error> {
+        self.as_ref().try_clone()
+    }
+
+    /// "Upgrade" the handle to a usable [`File`] handle.
+    ///
+    /// This new [`File`] handle is suitable for reading and writing. This does
+    /// not consume the original handle (allowing for it to be used many times).
+    ///
+    /// The [`File`] handle will be opened with `O_NOCTTY` and `O_CLOEXEC` set,
+    /// regardless of whether those flags are present in the `flags` argument.
+    /// You can correct these yourself if these defaults are not ideal for you:
+    ///
+    /// 1. `fcntl(fd, F_SETFD, 0)` will let you unset `O_CLOEXEC`.
+    /// 2. `ioctl(fd, TIOCSCTTY, 0)` will set the fd as the controlling terminal
+    ///    (if you don't have one already, and the fd references a TTY).
+    ///
+    /// [`Root::create`]: crate::Root::create
+    #[doc(alias = "pathrs_reopen")]
+    #[inline]
+    pub fn reopen<Fd: Into<OpenFlags>>(&self, flags: Fd) -> Result<File, Error> {
+        self.as_ref().reopen(flags)
+    }
+}
+
+impl From<Handle> for OwnedFd {
+    /// Unwrap a [`Handle`] to reveal the underlying [`OwnedFd`].
+    ///
+    /// **Note**: This method is primarily intended to allow for file descriptor
+    /// passing or otherwise transmitting file descriptor information. If you
+    /// want to get a [`File`] handle for general use, please use
+    /// [`Handle::reopen`] instead.
+    #[inline]
+    fn from(handle: Handle) -> Self {
+        handle.inner
+    }
+}
+
+impl AsFd for Handle {
+    /// Access the underlying file descriptor for a [`Handle`].
+    ///
+    /// **Note**: This method is primarily intended to allow for tests and other
+    /// code to check the status of the underlying [`OwnedFd`] without having to
+    /// use [`OwnedFd::from`]. It is not safe to use this [`BorrowedFd`]
+    /// directly to do filesystem operations. Please use the provided
+    /// [`HandleRef`] methods.
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+/// Borrowed version of [`Handle`].
+///
+/// Unlike [`Handle`], when [`HandleRef`] is dropped the underlying file
+/// descriptor is *not* closed. This is mainly useful for programs and libraries
+/// that have to do operations on [`&File`][File]s and [`BorrowedFd`]s passed
+/// from elsewhere.
+///
+/// [File]: std::fs::File
+// TODO: Is there any way we can restructure this to use Deref so that we don't
+//       need to copy all of the methods into Handle? Probably not... Maybe GATs
+//       will eventually support this but we'd still need a GAT-friendly Deref.
+#[derive(Copy, Clone, Debug)]
+pub struct HandleRef<'fd> {
+    inner: BorrowedFd<'fd>,
+}
+
+impl HandleRef<'_> {
+    /// Wrap a [`BorrowedFd`] into a [`HandleRef`]. The lifetime is tied to the
+    /// [`BorrowedFd`].
+    ///
+    /// # Safety
+    ///
+    /// The caller guarantees that the provided file is an `O_PATH` file
+    /// descriptor with exactly the same semantics as one created through
+    /// [`Root::resolve`]. This means that this function should usually be used
+    /// to convert a [`BorrowedFd`] returned from [`AsFd::as_fd`] (possibly from
+    /// another process) into a [`HandleRef`].
+    ///
+    /// While this function is not marked as `unsafe` (because the safety
+    /// guarantee required is not related to memory-safety), users should still
+    /// take great care when using this method because it can cause other kinds
+    /// of unsafety.
+    ///
+    /// [`Root::resolve`]: crate::Root::resolve
+    pub fn from_fd_unchecked(inner: BorrowedFd<'_>) -> HandleRef<'_> {
+        HandleRef { inner }
+    }
+
+    /// Create a copy of a [`HandleRef`].
+    ///
+    /// Note that (unlike [`BorrowedFd::clone`]) this method creates a full copy
+    /// of the underlying file descriptor and thus is more equivalent to
+    /// [`BorrowedFd::try_clone_to_owned`].
+    ///
+    /// To create a shallow copy of a [`HandleRef`], you can use
+    /// [`Clone::clone`] (or just [`Copy`]).
+    pub fn try_clone(&self) -> Result<Handle, Error> {
+        self.as_fd()
+            .try_clone_to_owned()
+            .map_err(|err| {
+                ErrorImpl::OsError {
+                    operation: "clone underlying handle file".into(),
+                    source: err,
+                }
+                .into()
+            })
+            .map(Handle::from_fd_unchecked)
+    }
+
     /// "Upgrade" the handle to a usable [`File`] handle.
     ///
     /// This new [`File`] handle is suitable for reading and writing. This does
@@ -65,66 +217,9 @@ impl Handle {
     /// [`Root::create`]: crate::Root::create
     #[doc(alias = "pathrs_reopen")]
     pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
-        self.inner.reopen(&PROCFS_HANDLE, flags.into())
-    }
-
-    /// Create a copy of an existing [`Handle`].
-    ///
-    /// The new handle is completely independent from the original, but
-    /// references the same underlying file.
-    pub fn try_clone(&self) -> Result<Self, Error> {
-        self.as_file()
-            .try_clone()
-            .map_err(|err| {
-                ErrorImpl::OsError {
-                    operation: "clone underlying handle file".into(),
-                    source: err,
-                }
-                .into()
-            })
-            .map(Self::from_file_unchecked)
-    }
-
-    /// Unwrap a [`Handle`] to reveal the underlying [`File`].
-    ///
-    /// **Note**: This method is primarily intended to allow for file descriptor
-    /// passing or otherwise transmitting file descriptor information. If you
-    /// want to get a [`File`] handle for general use, please use
-    /// [`Handle::reopen`] instead.
-    #[inline]
-    pub fn into_file(self) -> File {
         self.inner
-    }
-
-    /// Access the underlying [`File`] for a [`Handle`].
-    ///
-    /// **Note**: This method is primarily intended to allow for tests and other
-    /// code to check the status of the underlying [`File`] without having to
-    /// use [`Handle::into_file`]. If you want to get a [`File`] handle for
-    /// general use, please use [`Handle::reopen`] instead.
-    #[inline]
-    pub fn as_file(&self) -> &File {
-        &self.inner
-    }
-
-    /// Wrap a [`File`] into a [`Handle`].
-    ///
-    /// # Safety
-    ///
-    /// The caller guarantees that the provided file is an `O_PATH` file
-    /// descriptor with exactly the same semantics as one created through
-    /// [`Root::resolve`]. This means that this function should usually be used
-    /// to convert a [`File`] returned from [`Handle::into_file`] (possibly from
-    /// another process) into a [`Handle`].
-    ///
-    /// While this function is not marked as `unsafe` (because the safety
-    /// guarantee required is not related to memory-safety), users should still
-    /// take great care when using this method because it can cause other kinds
-    /// of unsafety.
-    ///
-    /// [`Root::resolve`]: crate::Root::resolve
-    pub fn from_file_unchecked(inner: File) -> Self {
-        Self { inner }
+            .reopen(&PROCFS_HANDLE, flags.into())
+            .map(File::from)
     }
 
     // TODO: All the different stat* interfaces?
@@ -132,4 +227,47 @@ impl Handle {
     // TODO: bind(). This might be safe to do (set the socket path to
     //       /proc/self/fd/...) but I'm a bit sad it'd be separate from
     //       Handle::reopen().
+}
+
+impl AsFd for HandleRef<'_> {
+    /// Access the underlying file descriptor for a [`HandleRef`].
+    ///
+    /// **Note**: This method is primarily intended to allow for tests and other
+    /// code to check the status of the underlying file descriptor. It is not
+    /// safe to use this [`BorrowedFd`] directly to do filesystem operations.
+    /// Please use the provided [`HandleRef`] methods.
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{HandleRef, Root};
+
+    use std::os::unix::io::{AsFd, AsRawFd};
+
+    use anyhow::Error;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn from_fd_unchecked() -> Result<(), Error> {
+        let handle = Root::open(".")?.resolve(".")?;
+        let handle_ref1 = handle.as_ref();
+        let handle_ref2 = HandleRef::from_fd_unchecked(handle.as_fd());
+
+        assert_eq!(
+            handle.as_fd().as_raw_fd(),
+            handle_ref1.as_fd().as_raw_fd(),
+            "Handle::as_ref should have the same underlying fd"
+        );
+        assert_eq!(
+            handle.as_fd().as_raw_fd(),
+            handle_ref2.as_fd().as_raw_fd(),
+            "HandleRef::from_fd_unchecked should have the same underlying fd"
+        );
+
+        Ok(())
+    }
 }

--- a/src/resolvers/opath/symlink_stack.rs
+++ b/src/resolvers/opath/symlink_stack.rs
@@ -21,9 +21,9 @@
 //! dangling symlinks.
 //!
 //! If we hit a non-existent path while resolving a symlink, we need to return
-//! the `(current: Rc<File>, remaining_components: PathBuf)` we had when we hit
-//! the symlink (effectively making the symlink resolution all-or-nothing). The
-//! set of `(current, remaining_components)` set is stored within the
+//! the `(current: Rc<OwnedFd>, remaining_components: PathBuf)` we had when we
+//! hit the symlink (effectively making the symlink resolution all-or-nothing).
+//! The set of `(current, remaining_components)` set is stored within the
 //! SymlinkStack and we add and or remove parts when we hit symlink and
 //! non-symlink components respectively. This needs to be implemented as a stack
 //! because of nested symlinks (if there is a dangling symlink 10 levels deep
@@ -72,7 +72,7 @@ pub(crate) struct SymlinkStack<F: fmt::Debug>(VecDeque<SymlinkStackEntry<F>>);
 
 impl<F: fmt::Debug> SymlinkStack<F> {
     fn do_push(&mut self, (dir, remaining): (&Rc<F>, PathBuf), link_target: PathBuf) {
-        // Get a proper Rc<File>.
+        // Get a proper Rc<OwnedFd>.
         let dir = Rc::clone(dir);
 
         // Split the link target and clean up any "" parts.

--- a/src/tests/common/mntns.rs
+++ b/src/tests/common/mntns.rs
@@ -61,7 +61,7 @@ pub(crate) enum MountType {
 
 pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> {
     let dst = dst.as_ref();
-    let dst_file = syscalls::openat(libc::AT_FDCWD, dst, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
+    let dst_file = syscalls::openat(syscalls::AT_FDCWD, dst, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
     let dst_path = CString::new(format!("/proc/self/fd/{}", dst_file.as_raw_fd()))?;
 
     let ret = match ty {
@@ -78,7 +78,7 @@ pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> 
         },
         MountType::Bind { src } => {
             let src_file =
-                syscalls::openat(libc::AT_FDCWD, src, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
+                syscalls::openat(syscalls::AT_FDCWD, src, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
             let src_path = CString::new(format!("/proc/self/fd/{}", src_file.as_raw_fd()))?;
             unsafe {
                 libc::mount(

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -233,3 +233,57 @@ pub(crate) fn fetch_mnt_id<Fd: AsFd, P: AsRef<Path>>(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{procfs::PROCFS_HANDLE, syscalls, utils::FdExt};
+
+    use std::{fs::File, os::unix::io::AsFd, path::Path};
+
+    use anyhow::Error;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    fn check_as_unsafe_path<Fd: AsFd, P: AsRef<Path>>(fd: Fd, want_path: P) -> Result<(), Error> {
+        let want_path = want_path.as_ref();
+
+        // Plain /proc/... lookup.
+        let got_path = fd.as_unsafe_path_unchecked()?;
+        assert_eq!(
+            got_path, want_path,
+            "expected as_unsafe_path_unchecked to give the correct path"
+        );
+        // ProcfsHandle-based lookup.
+        let got_path = fd.as_unsafe_path(&PROCFS_HANDLE)?;
+        assert_eq!(
+            got_path, want_path,
+            "expected as_unsafe_path to give the correct path"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn as_unsafe_path_cwd() -> Result<(), Error> {
+        let real_cwd = syscalls::getcwd()?;
+        check_as_unsafe_path(syscalls::AT_FDCWD, real_cwd)
+    }
+
+    #[test]
+    fn as_unsafe_path_fd() -> Result<(), Error> {
+        let real_tmpdir = TempDir::new()?;
+        let file = File::open(&real_tmpdir)?;
+        check_as_unsafe_path(&file, real_tmpdir)
+    }
+
+    #[test]
+    fn as_unsafe_path_badfd() {
+        assert!(
+            syscalls::BADFD.as_unsafe_path_unchecked().is_err(),
+            "as_unsafe_path_unchecked should fail for bad file descriptor"
+        );
+        assert!(
+            syscalls::BADFD.as_unsafe_path(&PROCFS_HANDLE).is_err(),
+            "as_unsafe_path should fail for bad file descriptor"
+        );
+    }
+}


### PR DESCRIPTION
This ensures we encode all of the lifetime rules we care about for file
descriptors in a much cleaner way. Most of this was a fairly
straightforward migration from File/RawFd -> AsFd, but there were a few
other notable things:

 * We now have RootRef and HandleRef to represent borrowed versions of
   Root and Handle. This was needed for our C FFI (which takes a
   BorrowedFd now), but is also an improvement in usability for library
   users. Previously we used ManuallyDrop to avoid closing the passed
   file descriptors in C FFI. This is much more ergonomic.

   Unfortunately, we would like to be able to implement Deref (to allow
   Root and Handle to share methods of RootRef and HandleRef).
   Unfortunately, because they are structures that take lifetimes rather
   than plain references it seems it is not possible to implement this
   (same goes for Borrow/AsRef).

   So we have to create our own AsRef-like method instead, and create
   dummy wrappers for every method. Thankfully our tests use the owned
   versions (which are wrappers for the borrowed versions) while the C
   API uses the borrowed versions, so it should be easy to catch cases
   where we forget to add a method to one of them.

 * File::metadata() is used in quite a few places but we can't use it
   anymore because we switched to AsFd. At the moment we created our own
   (internal) Metadata type that just provides what we need, but this
   seems very unfortunate. There is no way to manually construct a
   std::fs::Metadata structure AFAICS.

 * The C FFI doesn't return an OwnedFd because OwnedFd cannot have the
   value -1, but it's possible for our errors to be -1. This means we
   need to keep that part of CReturn for now...

Fixes #40
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>