### PR TITLE
capi: make opt-in via 'capi' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,13 @@ rust-version = "1.63"
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "openSUSE/libpathrs" }
 
 [lib]
-crate-type = ["rlib", "cdylib", "staticlib"]
+# When building the CAPI, our Makefile adds --crate-type={cdylib,staticlib}.
+crate-type = ["rlib"]
 
 [features]
+capi = ["dep:rand"]
 # Only used for tests.
 _test_as_root = []
 
@@ -55,7 +56,7 @@ itertools = "^0.13"
 lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
-rand = "^0.8"
+rand = { version = "^0.8", optional = true }
 # MSRV(1.65): Use regex >= 1.10.
 regex = "1.9.*"
 rustix = { version = "^0.38", features = ["fs"] }
@@ -72,5 +73,9 @@ pretty_assertions = "^1"
 rustix = { version = "^0.38", features = ["process"] }
 
 [lints.rust]
-# We have special handling for coverage runs (which set cfg(coverage)).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+	# We have special handling for coverage runs (which set cfg(coverage)).
+	'cfg(coverage)',
+	# We set these cfgs when building with --features=capi.
+	'cfg(cdylib)', 'cfg(staticlib)'
+] }

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ lint-rust:
 
 .PHONY: test-rust-doctest
 test-rust-doctest:
-	$(CARGO_NIGHTLY) llvm-cov --no-report --branch --doc
+	$(CARGO_NIGHTLY) llvm-cov --no-report --branch --all-features --doc
 
 .PHONY: test-rust-unpriv
 test-rust-unpriv:
-	$(CARGO_NIGHTLY) llvm-cov --no-report --branch nextest --no-fail-fast
+	$(CARGO_NIGHTLY) llvm-cov --no-report --branch --features capi nextest --no-fail-fast
 
 .PHONY: test-rust-root
 test-rust-root:
@@ -73,7 +73,7 @@ test-rust-root:
 #       support cfg(feature=...) for target runner configs.
 #       See <https://github.com/rust-lang/cargo/issues/14306>.
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \
-		$(CARGO_NIGHTLY) llvm-cov --no-report --branch --features _test_as_root nextest --no-fail-fast
+		$(CARGO_NIGHTLY) llvm-cov --no-report --branch --features capi,_test_as_root nextest --no-fail-fast
 
 .PHONY: test-rust
 test-rust:

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,26 @@ CARGO_NIGHTLY ?= cargo +nightly
 
 SRC_FILES = $(shell find . -name '*.rs')
 
+.DEFAULT: debug
 .PHONY: debug
 debug: target/debug
 
 target/debug: $(SRC_FILES)
-	$(CARGO) build
+	# For some reason, --crate-types needs separate invocations. We can't use
+	# #![crate_type] unfortunately, as using it with #![cfg_attr] has been
+	# deprecated. <https://github.com/rust-lang/rust/issues/91632>
+	$(CARGO) rustc --features=capi --crate-type=cdylib
+	$(CARGO) rustc --features=capi --crate-type=staticlib
 
 .PHONY: release
 release: target/release
 
 target/release: $(SRC_FILES)
-	$(CARGO) build --release
+	# For some reason, --crate-types needs separate invocations. We can't use
+	# #![crate_type] unfortunately, as using it with #![cfg_attr] has been
+	# deprecated. <https://github.com/rust-lang/rust/issues/91632>
+	$(CARGO) rustc --features=capi --crate-type=cdylib --release
+	$(CARGO) rustc --features=capi --crate-type=staticlib --release
 
 .PHONY: smoke-test
 smoke-test:
@@ -78,7 +87,7 @@ test: test-rust
 
 .PHONY: docs
 docs:
-	$(CARGO) doc --document-private-items --open
+	$(CARGO) doc --all-features --document-private-items --open
 
 .PHONY: install
 install: release

--- a/build.rs
+++ b/build.rs
@@ -20,11 +20,15 @@
 use std::env;
 
 fn main() {
-    // Add DT_SONAME to our cdylibs.
-    let name = "pathrs";
-    let major = env::var("CARGO_PKG_VERSION_MAJOR").unwrap();
-    println!(
-        "cargo:rustc-cdylib-link-arg=-Wl,-soname,lib{}.so.{}",
-        name, major
-    );
+    // Add DT_SONAME to our cdylibs. We can't check the crate-type here
+    // directly, but we can at least avoid needless warnings for "cargo build"
+    // by only emitting this when the capi feature is enabled.
+    if cfg!(feature = "capi") {
+        let name = "pathrs";
+        let major = env::var("CARGO_PKG_VERSION_MAJOR").unwrap();
+        println!(
+            "cargo:rustc-cdylib-link-arg=-Wl,-soname,lib{}.so.{}",
+            name, major
+        );
+    }
 }

--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,12 @@ includedir="${includedir:-$prefix/include}"
 libdir="${libdir:-$(find_libdir "$exec_prefix")}"
 pkgconfigdir="${pkgconfigdir:-$libdir/pkgconfig}"
 
+# TODO: These flags come from RUSTFLAGS="--print=native-static-libs".
+# Unfortunately, getting this information from cargo is incredibly unergonomic
+# and will hopefully be fixed at some point.
+# <https://github.com/rust-lang/rust/pull/43067#issuecomment-330625316>
+native_static_libs="-lgcc_s -lutil -lrt -lpthread -lm -ldl -lc"
+
 echo "[pkg-config] generating pathrs pkg-config"
 cat >"pathrs.pc" <<EOF
 # libpathrs: safe path resolution on Linux
@@ -165,6 +171,7 @@ Description: Safe path resolution library for Linux
 URL: https://github.com/openSUSE/libpathrs
 Cflags: -I\${includedir}
 Libs: -L\${libdir} -lpathrs
+Libs.private: $native_static_libs
 EOF
 
 echo "[install] installing libpathrs into DESTDIR=${DESTDIR:-/}"

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -57,8 +57,10 @@ use libc::{c_char, c_int, c_uint, dev_t, size_t};
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_root_open(path: *const c_char) -> RawFd {
-    utils::parse_path(path).and_then(Root::open).into_c_return()
+pub unsafe extern "C" fn pathrs_root_open(path: *const c_char) -> RawFd {
+    unsafe { utils::parse_path(path) } // SAFETY: C caller says path is safe.
+        .and_then(Root::open)
+        .into_c_return()
 }
 
 /// "Upgrade" an O_PATH file descriptor to a usable fd, suitable for reading and
@@ -117,11 +119,12 @@ pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: c_int) -> RawFd {
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_resolve(root_fd: CBorrowedFd<'_>, path: *const c_char) -> RawFd {
+pub unsafe extern "C" fn pathrs_resolve(root_fd: CBorrowedFd<'_>, path: *const c_char) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        root.resolve(utils::parse_path(path)?)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        root.resolve(path)
     }()
     .into_c_return()
 }
@@ -141,11 +144,15 @@ pub extern "C" fn pathrs_resolve(root_fd: CBorrowedFd<'_>, path: *const c_char) 
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_resolve_nofollow(root_fd: CBorrowedFd<'_>, path: *const c_char) -> RawFd {
+pub unsafe extern "C" fn pathrs_resolve_nofollow(
+    root_fd: CBorrowedFd<'_>,
+    path: *const c_char,
+) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        root.resolve_nofollow(utils::parse_path(path)?)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        root.resolve_nofollow(path)
     }()
     .into_c_return()
 }
@@ -186,7 +193,7 @@ pub extern "C" fn pathrs_resolve_nofollow(root_fd: CBorrowedFd<'_>, path: *const
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_readlink(
+pub unsafe extern "C" fn pathrs_readlink(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     linkbuf: *mut c_char,
@@ -195,8 +202,11 @@ pub extern "C" fn pathrs_readlink(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        let link_target = root.readlink(utils::parse_path(path)?)?;
-        utils::copy_path_into_buffer(link_target, linkbuf, linkbuf_size)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        let link_target = root.readlink(path)?;
+        // SAFETY: C caller guarantees buffer is at least linkbuf_size and can
+        // be written to.
+        unsafe { utils::copy_path_into_buffer(link_target, linkbuf, linkbuf_size) }
     }()
     .into_c_return()
 }
@@ -213,7 +223,7 @@ pub extern "C" fn pathrs_readlink(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_rename(
+pub unsafe extern "C" fn pathrs_rename(
     root_fd: CBorrowedFd<'_>,
     src: *const c_char,
     dst: *const c_char,
@@ -222,8 +232,11 @@ pub extern "C" fn pathrs_rename(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
+        let src = unsafe { utils::parse_path(src) }?; // SAFETY: C caller guarantees path is safe.
+        let dst = unsafe { utils::parse_path(dst) }?; // SAFETY: C caller guarantees path is safe.
+
         let rflags = RenameFlags::from_bits_retain(flags);
-        root.rename(utils::parse_path(src)?, utils::parse_path(dst)?, rflags)
+        root.rename(src, dst, rflags)
     }()
     .into_c_return()
 }
@@ -243,11 +256,12 @@ pub extern "C" fn pathrs_rename(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_rmdir(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
+pub unsafe extern "C" fn pathrs_rmdir(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        root.remove_dir(utils::parse_path(path)?)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        root.remove_dir(path)
     }()
     .into_c_return()
 }
@@ -267,11 +281,12 @@ pub extern "C" fn pathrs_rmdir(root_fd: CBorrowedFd<'_>, path: *const c_char) ->
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_unlink(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
+pub unsafe extern "C" fn pathrs_unlink(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        root.remove_file(utils::parse_path(path)?)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        root.remove_file(path)
     }()
     .into_c_return()
 }
@@ -288,11 +303,12 @@ pub extern "C" fn pathrs_unlink(root_fd: CBorrowedFd<'_>, path: *const c_char) -
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_remove_all(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
+pub unsafe extern "C" fn pathrs_remove_all(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        root.remove_all(utils::parse_path(path)?)
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
+        root.remove_all(path)
     }()
     .into_c_return()
 }
@@ -331,7 +347,7 @@ pub extern "C" fn pathrs_remove_all(root_fd: CBorrowedFd<'_>, path: *const c_cha
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_creat(
+pub unsafe extern "C" fn pathrs_creat(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     flags: c_int,
@@ -340,13 +356,10 @@ pub extern "C" fn pathrs_creat(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let mode = mode & !libc::S_IFMT;
         let perm = Permissions::from_mode(mode);
-        root.create_file(
-            utils::parse_path(path)?,
-            OpenFlags::from_bits_retain(flags),
-            &perm,
-        )
+        root.create_file(path, OpenFlags::from_bits_retain(flags), &perm)
     }()
     .into_c_return()
 }
@@ -364,7 +377,7 @@ pub extern "C" fn pathrs_creat(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_mkdir(
+pub unsafe extern "C" fn pathrs_mkdir(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     mode: c_uint,
@@ -386,7 +399,7 @@ pub extern "C" fn pathrs_mkdir(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_mkdir_all(
+pub unsafe extern "C" fn pathrs_mkdir_all(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     mode: c_uint,
@@ -394,8 +407,9 @@ pub extern "C" fn pathrs_mkdir_all(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
+        let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let perm = Permissions::from_mode(mode);
-        root.mkdir_all(utils::parse_path(path)?, &perm)
+        root.mkdir_all(path, &perm)
     }()
     .into_c_return()
 }
@@ -412,7 +426,7 @@ pub extern "C" fn pathrs_mkdir_all(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_mknod(
+pub unsafe extern "C" fn pathrs_mknod(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     mode: c_uint,
@@ -421,9 +435,10 @@ pub extern "C" fn pathrs_mknod(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
+        let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
+
         let fmt = mode & libc::S_IFMT;
         let perms = Permissions::from_mode(mode ^ fmt);
-        let path = utils::parse_path(path)?;
         let inode_type = match fmt {
             libc::S_IFREG => InodeType::File(perms),
             libc::S_IFDIR => InodeType::Directory(perms),
@@ -455,7 +470,7 @@ pub extern "C" fn pathrs_mknod(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_symlink(
+pub unsafe extern "C" fn pathrs_symlink(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     target: *const c_char,
@@ -463,8 +478,8 @@ pub extern "C" fn pathrs_symlink(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        let path = utils::parse_path(path)?;
-        let target = utils::parse_path(target)?;
+        let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
+        let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
         root.create(path, &InodeType::Symlink(target.into()))
     }()
     .into_c_return()
@@ -482,7 +497,7 @@ pub extern "C" fn pathrs_symlink(
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_hardlink(
+pub unsafe extern "C" fn pathrs_hardlink(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
     target: *const c_char,
@@ -490,8 +505,8 @@ pub extern "C" fn pathrs_hardlink(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        let path = utils::parse_path(path)?;
-        let target = utils::parse_path(target)?;
+        let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
+        let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
         root.create(path, &InodeType::Hardlink(target.into()))
     }()
     .into_c_return()

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -398,7 +398,6 @@ pub extern "C" fn pathrs_mkdir_all(
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd_unchecked(root_fd);
-        let mode = mode & !libc::S_IFMT;
         let perm = Permissions::from_mode(mode);
         root.mkdir_all(utils::parse_path(path)?, &perm)
     }()

--- a/src/capi/error.rs
+++ b/src/capi/error.rs
@@ -167,7 +167,7 @@ impl Drop for CError {
 /// returned describing the error. Use pathrs_errorinfo_free() to free the
 /// associated memory once you are done with the error.
 #[no_mangle]
-pub extern "C" fn pathrs_errorinfo(err_id: c_int) -> Option<&'static mut CError> {
+pub unsafe extern "C" fn pathrs_errorinfo(err_id: c_int) -> Option<&'static mut CError> {
     let mut err_map = ERROR_MAP.lock().unwrap();
 
     err_map
@@ -179,7 +179,7 @@ pub extern "C" fn pathrs_errorinfo(err_id: c_int) -> Option<&'static mut CError>
 
 /// Free the pathrs_error_t object returned by pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_errorinfo_free(ptr: *mut CError) {
+pub unsafe extern "C" fn pathrs_errorinfo_free(ptr: *mut CError) {
     if ptr.is_null() {
         return;
     }

--- a/src/capi/error.rs
+++ b/src/capi/error.rs
@@ -1,0 +1,190 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi::{ret::CReturn, utils::Leakable},
+    error::{Error, ErrorKind},
+};
+
+use std::{
+    collections::{hash_map::Entry as HashMapEntry, HashMap},
+    error::Error as StdError,
+    ffi::CString,
+    ptr,
+    sync::Mutex,
+};
+
+use libc::{c_char, c_int};
+use rand::{self, Rng};
+
+// TODO: Switch this to using a slab or similar structure, possibly using a less
+// heavy-weight lock? Maybe sharded-slab?
+// MSRV(1.70): Use OnceLock.
+// MSRV(1.80): Use LazyLock.
+lazy_static! {
+    static ref ERROR_MAP: Mutex<HashMap<CReturn, Error>> = Mutex::new(HashMap::new());
+}
+
+pub(crate) fn store_error(err: Error) -> CReturn {
+    let mut err_map = ERROR_MAP.lock().unwrap();
+
+    // Try to find a negative error value we can use. We avoid using anything in
+    // 0..4096 to avoid users interpreting the return value as an -errno (at the
+    // moment, the largest errno is ~150 but the kernel currently reserves
+    // 4096 values as possible ERR_PTR values).
+    let mut g = rand::thread_rng();
+    loop {
+        let idx = g.gen_range(CReturn::MIN..=-4096);
+        match err_map.entry(idx) {
+            HashMapEntry::Occupied(_) => continue,
+            HashMapEntry::Vacant(slot) => {
+                slot.insert(err);
+                return idx;
+            }
+        }
+    }
+}
+
+/// Attempts to represent a Rust Error type in C. This structure must be freed
+/// using pathrs_errorinfo_free().
+// NOTE: This API is exposed to library users in a read-only manner with memory
+//       management done by libpathrs -- so you may only ever append to it.
+#[repr(align(8), C)]
+pub struct CError {
+    // TODO: Put a version or size here so that C users can tell what fields are
+    // valid if we add fields in the future.
+    /// Raw errno(3) value of the underlying error (or 0 if the source of the
+    /// error was not due to a syscall error).
+    // We can't call this field "errno" because glibc defines errno(3) as a
+    // macro, causing all sorts of problems if you have a struct with an "errno"
+    // field. Best to avoid those headaches.
+    pub saved_errno: u64,
+
+    /// Textual description of the error.
+    pub description: *const c_char,
+}
+
+impl Leakable for CError {}
+
+impl From<&Error> for CError {
+    /// Construct a new CError struct based on the given error. The description
+    /// is pretty-printed in a C-like manner (causes are appended to one another
+    /// with separating colons). In addition, if the root-cause of the error is
+    /// an IOError then errno is populated with that value.
+    fn from(err: &Error) -> Self {
+        // TODO: Switch to Error::chain() once it's stabilised.
+        //       <https://github.com/rust-lang/rust/issues/58520>
+        let desc = {
+            let mut desc = err.to_string();
+            let mut err: &(dyn StdError) = err;
+            while let Some(next) = err.source() {
+                desc.push_str(": ");
+                desc.push_str(&next.to_string());
+                err = next;
+            }
+            // Create a C-compatible string for CError.description.
+            CString::new(desc).expect("CString::new(description) failed in CError generation")
+        };
+
+        // TODO: We should probably convert some of our internal errors into
+        //       equivalent POSIX-style errors (InvalidArgument => -EINVAL, for
+        //       instance).
+        let errno = match err.kind() {
+            ErrorKind::OsError(Some(err)) => err.abs(),
+            _ => 0,
+        };
+
+        CError {
+            saved_errno: errno.try_into().unwrap_or(0),
+            description: desc.into_raw(),
+        }
+    }
+}
+
+impl Drop for CError {
+    fn drop(&mut self) {
+        if !self.description.is_null() {
+            let description = self.description as *mut c_char;
+            // Clear the pointer to avoid double-frees.
+            self.description = ptr::null_mut();
+            // SAFETY: CString::from_raw is safe because the C caller guarantees
+            //         that the pointer we get is the same one we gave them.
+            let _ = unsafe { CString::from_raw(description) };
+            // drop the CString
+        }
+    }
+}
+
+/// Retrieve error information about an error id returned by a pathrs operation.
+///
+/// Whenever an error occurs with libpathrs, a negative number describing that
+/// error (the error id) is returned. pathrs_errorinfo() is used to retrieve
+/// that information:
+///
+/// ```c
+/// fd = pathrs_resolve(root, "/foo/bar");
+/// if (fd < 0) {
+///     // fd is an error id
+///     pathrs_error_t *error = pathrs_errorinfo(fd);
+///     // ... print the error information ...
+///     pathrs_errorinfo_free(error);
+/// }
+/// ```
+///
+/// Once pathrs_errorinfo() is called for a particular error id, that error id
+/// is no longer valid and should not be used for subsequent pathrs_errorinfo()
+/// calls.
+///
+/// Error ids are only unique from one another until pathrs_errorinfo() is
+/// called, at which point the id can be re-used for subsequent errors. The
+/// precise format of error ids is completely opaque and they should never be
+/// compared directly or used for anything other than with pathrs_errorinfo().
+///
+/// Error ids are not thread-specific and thus pathrs_errorinfo() can be called
+/// on a different thread to the thread where the operation failed (this is of
+/// particular note to green-thread language bindings like Go, where this is
+/// important).
+///
+/// # Return Value
+///
+/// If there was a saved error with the provided id, a pathrs_error_t is
+/// returned describing the error. Use pathrs_errorinfo_free() to free the
+/// associated memory once you are done with the error.
+#[no_mangle]
+pub extern "C" fn pathrs_errorinfo(err_id: c_int) -> Option<&'static mut CError> {
+    let mut err_map = ERROR_MAP.lock().unwrap();
+
+    err_map
+        .remove(&err_id)
+        .as_ref()
+        .map(CError::from)
+        .map(Leakable::leak)
+}
+
+/// Free the pathrs_error_t object returned by pathrs_errorinfo().
+#[no_mangle]
+pub extern "C" fn pathrs_errorinfo_free(ptr: *mut CError) {
+    if ptr.is_null() {
+        return;
+    }
+
+    // SAFETY: The C caller guarantees that the pointer is of the correct type
+    // and that this isn't a double-free.
+    unsafe { (*ptr).free() }
+}

--- a/src/capi/mod.rs
+++ b/src/capi/mod.rs
@@ -20,10 +20,6 @@
 // We need to permit unsafe code because we are exposing C APIs over FFI and
 // thus need to interact with C callers.
 #![allow(unsafe_code)]
-// None of this code is reachable from rust, so including it in coverage doesn't
-// make sense.
-// TODO: We might want to test the cffi bindings from Rust at some point?
-#![cfg_attr(coverage, coverage(off))]
 
 /// Core pathrs function wrappers.
 pub mod core;

--- a/src/capi/mod.rs
+++ b/src/capi/mod.rs
@@ -31,7 +31,10 @@ pub mod core;
 /// procfs-related function wrappers.
 pub mod procfs;
 
-/// Helpers for converting Result<...> into C-style int returns.
+/// C-friendly [`Error`](crate::error::Error) representation and helpers.
+pub mod error;
+
+/// Helpers for converting [`Result`] into C-style int returns.
 pub mod ret;
 
 mod utils;

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -61,6 +61,15 @@ impl From<CProcfsBase> for ProcfsBase {
     }
 }
 
+impl From<ProcfsBase> for CProcfsBase {
+    fn from(base: ProcfsBase) -> Self {
+        match base {
+            ProcfsBase::ProcSelf => CProcfsBase::PATHRS_PROC_SELF,
+            ProcfsBase::ProcThreadSelf => CProcfsBase::PATHRS_PROC_THREAD_SELF,
+        }
+    }
+}
+
 /// Safely open a path inside a `/proc` handle.
 ///
 /// Any bind-mounts or other over-mounts will (depending on what kernel features

--- a/src/capi/ret.rs
+++ b/src/capi/ret.rs
@@ -17,53 +17,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::{
-    capi::utils::{CError, Leakable},
-    error::Error,
-    Handle, Root,
-};
+use crate::{capi::error as capi_error, error::Error, Handle, Root};
 
-use std::{
-    collections::{hash_map::Entry as HashMapEntry, HashMap},
-    os::unix::io::{IntoRawFd, OwnedFd},
-    sync::Mutex,
-};
+use std::os::unix::io::{IntoRawFd, OwnedFd};
 
 use libc::c_int;
-use rand::{self, Rng};
 
-type CReturn = c_int;
+pub(super) type CReturn = c_int;
 
 pub(super) trait IntoCReturn {
     fn into_c_return(self) -> CReturn;
-}
-
-// TODO: Switch this to using a slab or similar structure, possibly using a less
-// heavy-weight lock? Maybe sharded-slab?
-// MSRV(1.70): Use OnceLock.
-// MSRV(1.80): Use LazyLock.
-lazy_static! {
-    static ref ERROR_MAP: Mutex<HashMap<CReturn, Error>> = Mutex::new(HashMap::new());
-}
-
-fn store_error(err: Error) -> CReturn {
-    let mut err_map = ERROR_MAP.lock().unwrap();
-
-    // Try to find a negative error value we can use. We avoid using anything in
-    // 0..4096 to avoid users interpreting the return value as an -errno (at the
-    // moment, the largest errno is ~150 but the kernel currently reserves
-    // 4096 values as possible ERR_PTR values).
-    let mut g = rand::thread_rng();
-    loop {
-        let idx = g.gen_range(CReturn::MIN..=-4096);
-        match err_map.entry(idx) {
-            HashMapEntry::Occupied(_) => continue,
-            HashMapEntry::Vacant(slot) => {
-                slot.insert(err);
-                return idx;
-            }
-        }
-    }
 }
 
 // TODO: Is it possible for us to return an actual OwnedFd through FFI when we
@@ -109,65 +72,7 @@ where
         // self.map_or_else(store_error, IntoCReturn::into_c_return)
         match self {
             Ok(ok) => ok.into_c_return(),
-            Err(err) => store_error(err),
+            Err(err) => capi_error::store_error(err),
         }
     }
-}
-
-/// Retrieve error information about an error id returned by a pathrs operation.
-///
-/// Whenever an error occurs with libpathrs, a negative number describing that
-/// error (the error id) is returned. pathrs_errorinfo() is used to retrieve
-/// that information:
-///
-/// ```c
-/// fd = pathrs_resolve(root, "/foo/bar");
-/// if (fd < 0) {
-///     // fd is an error id
-///     pathrs_error_t *error = pathrs_errorinfo(fd);
-///     // ... print the error information ...
-///     pathrs_errorinfo_free(error);
-/// }
-/// ```
-///
-/// Once pathrs_errorinfo() is called for a particular error id, that error id
-/// is no longer valid and should not be used for subsequent pathrs_errorinfo()
-/// calls.
-///
-/// Error ids are only unique from one another until pathrs_errorinfo() is
-/// called, at which point the id can be re-used for subsequent errors. The
-/// precise format of error ids is completely opaque and they should never be
-/// compared directly or used for anything other than with pathrs_errorinfo().
-///
-/// Error ids are not thread-specific and thus pathrs_errorinfo() can be called
-/// on a different thread to the thread where the operation failed (this is of
-/// particular note to green-thread language bindings like Go, where this is
-/// important).
-///
-/// # Return Value
-///
-/// If there was a saved error with the provided id, a pathrs_error_t is
-/// returned describing the error. Use pathrs_errorinfo_free() to free the
-/// associated memory once you are done with the error.
-#[no_mangle]
-pub extern "C" fn pathrs_errorinfo(err_id: c_int) -> Option<&'static mut CError> {
-    let mut err_map = ERROR_MAP.lock().unwrap();
-
-    err_map
-        .remove(&err_id)
-        .as_ref()
-        .map(CError::from)
-        .map(Leakable::leak)
-}
-
-/// Free the pathrs_error_t object returned by pathrs_errorinfo().
-#[no_mangle]
-pub extern "C" fn pathrs_errorinfo_free(ptr: *mut CError) {
-    if ptr.is_null() {
-        return;
-    }
-
-    // SAFETY: The C caller guarantees that the pointer is of the correct type
-    // and that this isn't a double-free.
-    unsafe { (*ptr).free() }
 }

--- a/src/capi/ret.rs
+++ b/src/capi/ret.rs
@@ -49,10 +49,13 @@ lazy_static! {
 fn store_error(err: Error) -> CReturn {
     let mut err_map = ERROR_MAP.lock().unwrap();
 
-    // Try to find a negative error value we can use.
+    // Try to find a negative error value we can use. We avoid using anything in
+    // 0..4096 to avoid users interpreting the return value as an -errno (at the
+    // moment, the largest errno is ~150 but the kernel currently reserves
+    // 4096 values as possible ERR_PTR values).
     let mut g = rand::thread_rng();
     loop {
-        let idx = g.gen_range(CReturn::MIN..=-1);
+        let idx = g.gen_range(CReturn::MIN..=-4096);
         match err_map.entry(idx) {
             HashMapEntry::Occupied(_) => continue,
             HashMapEntry::Vacant(slot) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@
 
 use crate::{resolvers::opath::SymlinkStackError, syscalls::Error as SyscallError};
 
-use std::{borrow::Cow, error::Error as StdError, io::Error as IOError};
+use std::{borrow::Cow, io::Error as IOError};
 
 // TODO: Add a backtrace to Error. We would just need to add an automatic
 //       Backtrace::capture() in From. But it's not clear whether we want to
@@ -167,37 +167,5 @@ impl<T, E: ErrorExt> ErrorExt for Result<T, E> {
         F: FnOnce() -> String,
     {
         self.map_err(|err| err.with_wrap(context_fn))
-    }
-}
-
-/// A backport of the nightly-only [`Chain`]. This method
-/// will be removed as soon as that is stabilised.
-///
-/// [`Chain`]: https://doc.rust-lang.org/nightly/std/error/struct.Chain.html
-// XXX: https://github.com/rust-lang/rust/issues/58520
-pub(crate) struct Chain<'a> {
-    current: Option<&'a (dyn StdError + 'static)>,
-}
-
-impl<'a> Iterator for Chain<'a> {
-    type Item = &'a (dyn StdError + 'static);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let current = self.current;
-        self.current = self.current.and_then(StdError::source);
-        current
-    }
-}
-
-impl Error {
-    /// A backport of the nightly-only [`Error::chain`]. This method
-    /// will be removed as soon as that is stabilised.
-    ///
-    /// [`Error::chain`]: https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.chain
-    // XXX: https://github.com/rust-lang/rust/issues/58520
-    pub(crate) fn iter_chain_hotfix(&self) -> Chain {
-        Chain {
-            current: Some(self),
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,7 @@ impl Error {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ErrorImpl {
+    #[allow(dead_code)]
     #[error("feature {feature} is not implemented")]
     NotImplemented { feature: Cow<'static, str> },
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -110,7 +110,7 @@ impl Handle {
     /// [`Root::create`]: crate::Root::create
     #[doc(alias = "pathrs_reopen")]
     #[inline]
-    pub fn reopen<Fd: Into<OpenFlags>>(&self, flags: Fd) -> Result<File, Error> {
+    pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
         self.as_ref().reopen(flags)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub use resolvers::{Resolver, ResolverBackend};
 pub mod procfs;
 
 // C API.
+#[cfg(feature = "capi")]
 mod capi;
 
 // Internally used helpers.

--- a/src/root.rs
+++ b/src/root.rs
@@ -44,7 +44,7 @@ use std::{
 };
 
 use libc::dev_t;
-use rustix::fs::{self, Dir, SeekFrom};
+use rustix::fs::{self as rustix_fs, Dir, SeekFrom};
 
 /// An inode type to be created with [`Root::create`].
 #[derive(Clone, Debug)]
@@ -927,7 +927,7 @@ impl RootRef<'_> {
             // half-read directory iterator. We have to do this manually rather
             // than using Dir::rewind() because Dir::rewind() just marks the
             // iterator so it is rewinded when the next iteration happens.
-            fs::seek(&next, SeekFrom::Start(0)).map_err(|err| ErrorImpl::OsError {
+            rustix_fs::seek(&next, SeekFrom::Start(0)).map_err(|err| ErrorImpl::OsError {
                 operation: "reset offset of directory handle".into(),
                 source: err.into(),
             })?;

--- a/src/tests/capi/handle.rs
+++ b/src/tests/capi/handle.rs
@@ -70,6 +70,9 @@ impl HandleImpl for CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
 
+    // C implementation *DOES NOT* set O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = false;
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)
     }
@@ -86,6 +89,9 @@ impl HandleImpl for CapiHandle {
 impl HandleImpl for &CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
+
+    // C implementation *DOES NOT* set O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = false;
 
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)

--- a/src/tests/capi/handle.rs
+++ b/src/tests/capi/handle.rs
@@ -1,0 +1,101 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi,
+    flags::OpenFlags,
+    tests::{
+        capi::utils::{self as capi_utils, CapiError},
+        traits::HandleImpl,
+    },
+};
+
+use std::{
+    fs::File,
+    os::unix::io::{AsFd, BorrowedFd, OwnedFd},
+};
+
+#[derive(Debug)]
+pub struct CapiHandle {
+    inner: OwnedFd,
+}
+
+impl CapiHandle {
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+        Self { inner: fd.into() }
+    }
+
+    fn try_clone(&self) -> Result<Self, anyhow::Error> {
+        Ok(Self::from_fd_unchecked(self.inner.try_clone()?))
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, CapiError> {
+        let fd = self.inner.as_fd();
+        let flags = flags.into();
+
+        capi_utils::call_capi_fd(|| capi::core::pathrs_reopen(fd.into(), flags.bits()))
+            .map(File::from)
+    }
+}
+
+impl AsFd for CapiHandle {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+impl From<CapiHandle> for OwnedFd {
+    fn from(handle: CapiHandle) -> Self {
+        handle.inner
+    }
+}
+
+impl HandleImpl for CapiHandle {
+    type Cloned = CapiHandle;
+    type Error = CapiError;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.try_clone().map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        self.reopen(flags)
+    }
+}
+
+impl HandleImpl for &CapiHandle {
+    type Cloned = CapiHandle;
+    type Error = CapiError;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        CapiHandle::try_clone(self).map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        CapiHandle::reopen(self, flags)
+    }
+}

--- a/src/tests/capi/mod.rs
+++ b/src/tests/capi/mod.rs
@@ -17,13 +17,15 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-pub(crate) mod common;
+#![allow(unsafe_code)]
 
-#[cfg(feature = "capi")]
-pub(in crate::tests) mod capi;
-pub(in crate::tests) mod traits;
+mod utils;
 
-mod test_procfs;
-mod test_resolve;
-mod test_resolve_partial;
-mod test_root_ops;
+mod root;
+pub(in crate::tests) use root::*;
+
+mod handle;
+pub(in crate::tests) use handle::*;
+
+mod procfs;
+pub(in crate::tests) use procfs::*;

--- a/src/tests/capi/procfs.rs
+++ b/src/tests/capi/procfs.rs
@@ -1,0 +1,104 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi::{self, procfs::CProcfsBase},
+    flags::OpenFlags,
+    procfs::ProcfsBase,
+    tests::{
+        capi::utils::{self as capi_utils, CapiError},
+        traits::ProcfsHandleImpl,
+    },
+};
+
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+// NOTE: The C API only lets us access the global PROCFS_HANDLE reference.
+#[derive(Debug)]
+pub struct CapiProcfsHandle;
+
+impl CapiProcfsHandle {
+    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        oflags: F,
+    ) -> Result<File, CapiError> {
+        let base: CProcfsBase = base.into();
+        let subpath = capi_utils::path_to_cstring(subpath);
+        let oflags = oflags.into();
+
+        capi_utils::call_capi_fd(|| unsafe {
+            capi::procfs::pathrs_proc_open(base, subpath.as_ptr(), oflags.bits())
+        })
+        .map(File::from)
+    }
+
+    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        oflags: F,
+    ) -> Result<File, CapiError> {
+        // The C API exposes ProcfsHandle::open using O_NOFOLLOW.
+        self.open_follow(base, subpath, oflags.into() | OpenFlags::O_NOFOLLOW)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, base: ProcfsBase, subpath: P) -> Result<PathBuf, CapiError> {
+        let base: CProcfsBase = base.into();
+        let subpath = capi_utils::path_to_cstring(subpath);
+
+        capi_utils::call_capi_readlink(|linkbuf, linkbuf_size| unsafe {
+            capi::procfs::pathrs_proc_readlink(base, subpath.as_ptr(), linkbuf, linkbuf_size)
+        })
+    }
+}
+
+impl ProcfsHandleImpl for CapiProcfsHandle {
+    type Error = CapiError;
+
+    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error> {
+        self.open_follow(base, subpath, flags)
+    }
+
+    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error> {
+        self.open(base, subpath, flags)
+    }
+
+    fn readlink<P: AsRef<Path>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+    ) -> Result<PathBuf, Self::Error> {
+        self.readlink(base, subpath)
+    }
+}

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -1,0 +1,382 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi,
+    flags::{OpenFlags, RenameFlags},
+    tests::{
+        capi::{
+            utils::{self as capi_utils, CapiError},
+            CapiHandle,
+        },
+        traits::{HandleImpl, RootImpl},
+    },
+    InodeType, Resolver,
+};
+
+use std::{
+    fs::Permissions,
+    os::unix::{
+        fs::PermissionsExt,
+        io::{AsFd, BorrowedFd, OwnedFd},
+    },
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug)]
+pub(in crate::tests) struct CapiRoot {
+    inner: OwnedFd,
+}
+
+impl CapiRoot {
+    pub(in crate::tests) fn open<P: AsRef<Path>>(path: P) -> Result<Self, CapiError> {
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_fd(|| unsafe { capi::core::pathrs_root_open(path.as_ptr()) })
+            .map(Self::from_fd_unchecked)
+    }
+
+    pub(in crate::tests) fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+        Self { inner: fd.into() }
+    }
+
+    fn try_clone(&self) -> Result<Self, anyhow::Error> {
+        Ok(Self::from_fd_unchecked(self.inner.try_clone()?))
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<CapiHandle, CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_fd(|| unsafe {
+            capi::core::pathrs_resolve(root_fd.into(), path.as_ptr())
+        })
+        .map(CapiHandle::from_fd_unchecked)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<CapiHandle, CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_fd(|| unsafe {
+            capi::core::pathrs_resolve_nofollow(root_fd.into(), path.as_ptr())
+        })
+        .map(CapiHandle::from_fd_unchecked)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_readlink(|linkbuf, linkbuf_size| unsafe {
+            capi::core::pathrs_readlink(root_fd.into(), path.as_ptr(), linkbuf, linkbuf_size)
+        })
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_zst(|| unsafe {
+            match inode_type {
+                InodeType::File(perm) => capi::core::pathrs_mknod(
+                    root_fd.into(),
+                    path.as_ptr(),
+                    libc::S_IFREG | perm.mode(),
+                    0,
+                ),
+                InodeType::Directory(perm) => {
+                    capi::core::pathrs_mkdir(root_fd.into(), path.as_ptr(), perm.mode())
+                }
+                InodeType::Symlink(target) => {
+                    let target = capi_utils::path_to_cstring(target);
+                    capi::core::pathrs_symlink(root_fd.into(), path.as_ptr(), target.as_ptr())
+                }
+                InodeType::Hardlink(target) => {
+                    let target = capi_utils::path_to_cstring(target);
+                    capi::core::pathrs_hardlink(root_fd.into(), path.as_ptr(), target.as_ptr())
+                }
+                InodeType::Fifo(perm) => capi::core::pathrs_mknod(
+                    root_fd.into(),
+                    path.as_ptr(),
+                    libc::S_IFIFO | perm.mode(),
+                    0,
+                ),
+                InodeType::CharacterDevice(perm, dev) => capi::core::pathrs_mknod(
+                    root_fd.into(),
+                    path.as_ptr(),
+                    libc::S_IFCHR | perm.mode(),
+                    *dev,
+                ),
+                InodeType::BlockDevice(perm, dev) => capi::core::pathrs_mknod(
+                    root_fd.into(),
+                    path.as_ptr(),
+                    libc::S_IFBLK | perm.mode(),
+                    *dev,
+                ),
+            }
+        })
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<CapiHandle, CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_fd(|| unsafe {
+            capi::core::pathrs_creat(root_fd.into(), path.as_ptr(), flags.bits(), perm.mode())
+        })
+        .map(CapiHandle::from_fd_unchecked)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<CapiHandle, CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_fd(|| unsafe {
+            capi::core::pathrs_mkdir_all(root_fd.into(), path.as_ptr(), perm.mode())
+        })
+        .map(CapiHandle::from_fd_unchecked)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_zst(|| unsafe {
+            capi::core::pathrs_rmdir(root_fd.into(), path.as_ptr())
+        })
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_zst(|| unsafe {
+            capi::core::pathrs_unlink(root_fd.into(), path.as_ptr())
+        })
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), CapiError> {
+        let root_fd = self.inner.as_fd();
+        let path = capi_utils::path_to_cstring(path);
+
+        capi_utils::call_capi_zst(|| unsafe {
+            capi::core::pathrs_remove_all(root_fd.into(), path.as_ptr())
+        })
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), CapiError> {
+        let root_fd = self.inner.as_fd();
+        let source = capi_utils::path_to_cstring(source);
+        let destination = capi_utils::path_to_cstring(destination);
+
+        capi_utils::call_capi_zst(|| unsafe {
+            capi::core::pathrs_rename(
+                root_fd.into(),
+                source.as_ptr(),
+                destination.as_ptr(),
+                rflags.bits(),
+            )
+        })
+    }
+}
+
+impl AsFd for CapiRoot {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+impl From<CapiRoot> for OwnedFd {
+    fn from(root: CapiRoot) -> Self {
+        root.inner
+    }
+}
+
+impl RootImpl for CapiRoot {
+    type Cloned = CapiRoot;
+    type Handle = CapiHandle;
+    // NOTE: We can't use anyhow::Error here.
+    // <https://github.com/dtolnay/anyhow/issues/25>
+    type Error = CapiError;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        assert_eq!(
+            resolver,
+            Resolver::default(),
+            "cannot use non-default Resolver with capi"
+        );
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn resolver(&self) -> Resolver {
+        Resolver::default()
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.try_clone()
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve(path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve_nofollow(path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        self.readlink(path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        self.create(path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.create_file(path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.mkdir_all(path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_dir(path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_file(path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_all(path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        self.rename(source, destination, rflags)
+    }
+}
+
+impl RootImpl for &CapiRoot {
+    type Cloned = CapiRoot;
+    type Handle = CapiHandle;
+    // NOTE: We can't use anyhow::Error here.
+    // <https://github.com/dtolnay/anyhow/issues/25>
+    type Error = CapiError;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        assert_eq!(
+            resolver,
+            Resolver::default(),
+            "cannot use non-default Resolver with capi"
+        );
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn resolver(&self) -> Resolver {
+        Resolver::default()
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        CapiRoot::try_clone(self)
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        CapiRoot::resolve(self, path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        CapiRoot::resolve_nofollow(self, path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        CapiRoot::readlink(self, path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        CapiRoot::create(self, path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        CapiRoot::create_file(self, path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        CapiRoot::mkdir_all(self, path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        CapiRoot::remove_dir(self, path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        CapiRoot::remove_file(self, path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        CapiRoot::remove_all(self, path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        CapiRoot::rename(self, source, destination, rflags)
+    }
+}

--- a/src/tests/capi/utils.rs
+++ b/src/tests/capi/utils.rs
@@ -1,0 +1,164 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi::error as capi_error,
+    error::{ErrorExt, ErrorKind},
+    tests::traits::ErrorImpl,
+};
+
+use std::{
+    ffi::{CStr, CString, OsStr},
+    fmt,
+    os::unix::{
+        ffi::OsStrExt,
+        io::{FromRawFd, OwnedFd},
+    },
+    path::{Path, PathBuf},
+};
+
+use errno::Errno;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub struct CapiError {
+    errno: Option<Errno>,
+    description: String,
+}
+
+impl fmt::Display for CapiError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}", self.description)?;
+        if let Some(errno) = self.errno {
+            write!(fmt, " ({errno})")?;
+        }
+        Ok(())
+    }
+}
+
+impl ErrorExt for CapiError {
+    fn with_wrap<F>(self, context_fn: F) -> Self
+    where
+        F: FnOnce() -> String,
+    {
+        Self {
+            errno: self.errno,
+            description: context_fn() + ": " + &self.description,
+        }
+    }
+}
+
+impl ErrorImpl for CapiError {
+    fn kind(&self) -> ErrorKind {
+        if let Some(errno) = self.errno {
+            ErrorKind::OsError(Some(errno.0))
+        } else {
+            // TODO TODO: We should probably expose the libpathrs internal
+            // ErrorKind types in the C API somehow?
+            ErrorKind::InvalidArgument
+        }
+    }
+}
+
+fn fetch_error(res: libc::c_int) -> Result<libc::c_int, CapiError> {
+    if res >= 0 {
+        Ok(res)
+    } else {
+        // SAFETY: pathrs_errorinfo is safe to call in general.
+        match unsafe { capi_error::pathrs_errorinfo(res) } {
+            Some(err) => {
+                let errno = match err.saved_errno as i32 {
+                    0 => None,
+                    errno => Some(Errno(errno)),
+                };
+                // SAFETY: pathrs_errorinfo returns a valid string pointer. We
+                // can't take ownership because pathrs_errorinfo_free() will do
+                // the freeing for us.
+                let description = unsafe { CStr::from_ptr(err.description) }
+                    .to_string_lossy()
+                    .to_string();
+
+                // Free the error from the error map, now that we copied the
+                // contents.
+                // SAFETY: We are the only ones holding a reference to the err
+                // pointer and don't touch it later, so we can free it freely.
+                unsafe { capi_error::pathrs_errorinfo_free(err as *mut _) }
+
+                Err(CapiError { errno, description })
+            }
+            None => panic!("unknown error id {res}"),
+        }
+    }
+}
+
+pub(in crate::tests) fn path_to_cstring<P: AsRef<Path>>(path: P) -> CString {
+    CString::new(path.as_ref().as_os_str().as_bytes())
+        .expect("normal path conversion shouldn't result in spurious nul bytes")
+}
+
+pub(in crate::tests) fn call_capi<Func>(func: Func) -> Result<libc::c_int, CapiError>
+where
+    Func: Fn() -> libc::c_int,
+{
+    fetch_error(func())
+}
+
+pub(in crate::tests) fn call_capi_zst<Func>(func: Func) -> Result<(), CapiError>
+where
+    Func: Fn() -> libc::c_int,
+{
+    call_capi(func).map(|val| {
+        assert_eq!(
+            val, 0,
+            "call_capi_zst must only be called on methods that return <= 0: got {val}"
+        );
+    })
+}
+
+pub(in crate::tests) fn call_capi_fd<Func>(func: Func) -> Result<OwnedFd, CapiError>
+where
+    Func: Fn() -> libc::c_int,
+{
+    // SAFETY: The caller has guaranteed us that the closure will return an fd.
+    call_capi(func).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+pub(in crate::tests) fn call_capi_readlink<Func>(func: Func) -> Result<PathBuf, CapiError>
+where
+    Func: Fn(*mut libc::c_char, libc::size_t) -> libc::c_int,
+{
+    // Start with a small buffer so we can exercise the retry logic.
+    let mut linkbuf: Vec<u8> = Vec::with_capacity(0);
+    let mut realsize = 8;
+    while realsize > linkbuf.capacity() {
+        linkbuf.reserve(realsize);
+        realsize = fetch_error(func(
+            linkbuf.as_mut_ptr() as *mut libc::c_char,
+            linkbuf.capacity(),
+        ))? as usize;
+    }
+    // SAFETY: The C code guarantees that realsize is how many bytes are filled.
+    unsafe { linkbuf.set_len(realsize) };
+
+    Ok(PathBuf::from(OsStr::from_bytes(
+        // readlink does *not* append a null terminator!
+        CString::new(linkbuf)
+            .expect("constructing a CString from the C API's copied CString should work")
+            .to_bytes(),
+    )))
+}

--- a/src/tests/common/handle.rs
+++ b/src/tests/common/handle.rs
@@ -1,0 +1,88 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::ErrorKind,
+    flags::OpenFlags,
+    tests::{
+        common as tests_common,
+        traits::{ErrorImpl, HandleImpl},
+    },
+    utils::FdExt,
+};
+
+use anyhow::Error;
+use errno::Errno;
+use pretty_assertions::assert_eq;
+
+pub type LookupResult<'a> = (&'a str, libc::mode_t);
+
+pub(in crate::tests) fn errno_description(err: ErrorKind) -> String {
+    match err {
+        ErrorKind::OsError(Some(errno)) => format!("{err:?} ({})", Errno(errno)),
+        _ => format!("{err:?}"),
+    }
+}
+
+pub(in crate::tests) fn check_reopen<H: HandleImpl>(
+    handle: H,
+    flags: OpenFlags,
+    expected_error: Option<i32>,
+) -> Result<(), Error> {
+    let expected_error = expected_error.map(|errno| ErrorKind::OsError(Some(errno)));
+    let file = match (handle.reopen(flags), expected_error) {
+        (Ok(f), None) => f,
+        (Err(e), None) => anyhow::bail!("unexpected error '{}'", e),
+        (Ok(f), Some(want_err)) => anyhow::bail!(
+            "expected to get io::Error {} but instead got file {}",
+            tests_common::errno_description(want_err),
+            f.as_unsafe_path_unchecked()?.display(),
+        ),
+        (Err(err), Some(want_err)) => {
+            assert_eq!(
+                err.kind(),
+                want_err,
+                "expected io::Error {}, got '{}'",
+                errno_description(want_err),
+                err,
+            );
+            return Ok(());
+        }
+    };
+
+    let real_handle_path = handle.as_unsafe_path_unchecked()?;
+    let real_reopen_path = file.as_unsafe_path_unchecked()?;
+
+    assert_eq!(
+        real_handle_path, real_reopen_path,
+        "reopened handle should be equivalent to old handle",
+    );
+
+    let clone_handle = handle.try_clone()?;
+    let clone_handle_path = clone_handle.as_unsafe_path_unchecked()?;
+
+    assert_eq!(
+        real_handle_path, clone_handle_path,
+        "cloned handle should be equivalent to old handle",
+    );
+
+    // TODO: Check fd flags.
+
+    Ok(())
+}

--- a/src/tests/common/mntns.rs
+++ b/src/tests/common/mntns.rs
@@ -59,7 +59,7 @@ pub(crate) enum MountType {
     Bind { src: PathBuf },
 }
 
-pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> {
+pub(in crate::tests) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> {
     let dst = dst.as_ref();
     let dst_file = syscalls::openat(syscalls::AT_FDCWD, dst, libc::O_NOFOLLOW | libc::O_PATH, 0)?;
     let dst_path = CString::new(format!("/proc/self/fd/{}", dst_file.as_raw_fd()))?;
@@ -100,7 +100,7 @@ pub(crate) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> 
     }
 }
 
-pub(crate) fn in_mnt_ns<F, T>(func: F) -> Result<T, Error>
+pub(in crate::tests) fn in_mnt_ns<F, T>(func: F) -> Result<T, Error>
 where
     F: FnOnce() -> Result<T, Error>,
 {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,6 +19,9 @@
 
 pub(crate) mod common;
 
+pub(in crate::tests) mod traits;
+
 mod test_procfs;
 mod test_resolve;
+mod test_resolve_partial;
 mod test_root_ops;

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -481,16 +481,49 @@ mod utils {
             libc::S_IFDIR => {
                 tests_common::check_reopen(&handle, OpenFlags::O_RDONLY, None)?;
                 tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, None)?;
+                // Forcefully set O_CLOEXEC.
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_RDONLY | OpenFlags::O_CLOEXEC,
+                    None,
+                )?;
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_DIRECTORY | OpenFlags::O_CLOEXEC,
+                    None,
+                )?;
             }
             libc::S_IFREG => {
                 tests_common::check_reopen(&handle, OpenFlags::O_RDWR, None)?;
                 tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, Some(libc::ENOTDIR))?;
+                // Forcefully set O_CLOEXEC.
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_RDWR | OpenFlags::O_CLOEXEC,
+                    None,
+                )?;
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_DIRECTORY | OpenFlags::O_CLOEXEC,
+                    Some(libc::ENOTDIR),
+                )?;
             }
             _ => {
                 tests_common::check_reopen(&handle, OpenFlags::O_PATH, None)?;
                 tests_common::check_reopen(
                     &handle,
                     OpenFlags::O_PATH | OpenFlags::O_DIRECTORY,
+                    Some(libc::ENOTDIR),
+                )?;
+                // Forcefully set O_CLOEXEC.
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_PATH | OpenFlags::O_CLOEXEC,
+                    None,
+                )?;
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_PATH | OpenFlags::O_DIRECTORY | OpenFlags::O_CLOEXEC,
                     Some(libc::ENOTDIR),
                 )?;
             }

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -17,12 +17,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::path::Path;
-
 use crate::{
-    error::ErrorKind, flags::ResolverFlags, resolvers::PartialLookup,
-    tests::common as tests_common, ResolverBackend, Root,
+    error::ErrorKind, flags::ResolverFlags, tests::common as tests_common, ResolverBackend, Root,
 };
+
+use std::path::Path;
 
 use anyhow::Error;
 
@@ -31,14 +30,12 @@ macro_rules! resolve_tests {
     //      [create_root_path] {
     //          test_ok: resolve(...) => Ok(("path", libc::S_IF...))
     //          test_err: resolve(...) => Err(ErrorKind::...)
-    //          test_ok: resolve_partial(...) => Ok(("path", Some("remaining", ErrorKind::...)), libc::S_IF...))
-    //          test_err: resolve_partial(...) => Err(ErrorKind::...)
     //      }
     // }
     ([$root_dir:expr] fn $test_name:ident (mut $root_var:ident : Root) $body:block => $expected:expr) => {
         paste::paste! {
             #[test]
-            fn [<$test_name _default>]() -> Result<(), Error> {
+            fn [<root_ $test_name _default>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
 
@@ -50,10 +47,27 @@ macro_rules! resolve_tests {
             }
 
             #[test]
-            fn [<$test_name _openat2>]() -> Result<(), Error> {
+            fn [<rootref_ $test_name _default>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let root = Root::open(&root_dir)?;
+                let mut $root_var = root.as_ref();
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+
+            #[test]
+            fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
                 $root_var.resolver.backend = ResolverBackend::KernelOpenat2;
+                if !$root_var.resolver.backend.supported() {
+                    // Skip if not supported.
+                    return Ok(());
+                }
 
                 { $body }
 
@@ -63,10 +77,52 @@ macro_rules! resolve_tests {
             }
 
             #[test]
-            fn [<$test_name _opath>]() -> Result<(), Error> {
+            fn [<rootref_ $test_name _openat2>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let root = Root::open(&root_dir)?;
+                let mut $root_var = root.as_ref();
+                $root_var.resolver.backend = ResolverBackend::KernelOpenat2;
+                if !$root_var.resolver.backend.supported() {
+                    // Skip if not supported.
+                    return Ok(());
+                }
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+
+            #[test]
+            fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
                 $root_var.resolver.backend = ResolverBackend::EmulatedOpath;
+                // EmulatedOpath is always supported.
+                assert!(
+                    $root_var.resolver.backend.supported(),
+                    "emulated opath is always supported",
+                );
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+
+            #[test]
+            fn [<rootref_ $test_name _opath>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let root = Root::open(&root_dir)?;
+                let mut $root_var = root.as_ref();
+                $root_var.resolver.backend = ResolverBackend::EmulatedOpath;
+                // EmulatedOpath is always supported.
+                assert!(
+                    $root_var.resolver.backend.supported(),
+                    "emulated opath is always supported",
+                );
 
                 { $body }
 
@@ -81,12 +137,8 @@ macro_rules! resolve_tests {
         paste::paste! {
             resolve_tests! {
                 [$root_dir]
-                fn [<root_ $op_name _ $test_name>](mut root: Root) {
+                fn [<$op_name _ $test_name>](mut root: Root) {
                     root.resolver.flags = $rflags;
-                    if !root.resolver.backend.supported() {
-                        // Skip if not supported.
-                        return Ok(());
-                    }
 
                     let expected = $expected;
                     utils::[<check_root_ $op_name>](
@@ -149,880 +201,183 @@ resolve_tests! {
     // Complete lookups.
     [tests_common::create_basic_tree()?] {
         complete_root1: resolve("/") => Ok(("/", libc::S_IFDIR));
-        complete_root1: resolve_partial("/") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
         complete_root2: resolve("/../../../../../..") => Ok(("/", libc::S_IFDIR));
-        complete_root2: resolve_partial("/../../../../../..") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
         complete_root_link1: resolve("root-link1") => Ok(("/", libc::S_IFDIR));
-        complete_root_link1: resolve_partial("root-link1") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
         complete_root_link2: resolve("root-link2") => Ok(("/", libc::S_IFDIR));
-        complete_root_link2: resolve_partial("root-link2") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
         complete_root_link3: resolve("root-link3") => Ok(("/", libc::S_IFDIR));
-        complete_root_link3: resolve_partial("root-link3") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
         complete_dir1: resolve("a") => Ok(("/a", libc::S_IFDIR));
-        complete_dir1: resolve_partial("a") => Ok(PartialLookup::Complete(("/a", libc::S_IFDIR)));
         complete_dir2: resolve("b/c/d/e/f") => Ok(("/b/c/d/e/f", libc::S_IFDIR));
-        complete_dir2: resolve_partial("b/c/d/e/f") => Ok(PartialLookup::Complete(("/b/c/d/e/f", libc::S_IFDIR)));
         complete_dir3: resolve("b///././c////.//d/./././///e////.//./f//././././") => Ok(("/b/c/d/e/f", libc::S_IFDIR));
-        complete_dir3: resolve_partial("b///././c////.//d/./././///e////.//./f//././././") => Ok(PartialLookup::Complete(("/b/c/d/e/f", libc::S_IFDIR)));
         complete_file: resolve("b/c/file") => Ok(("/b/c/file", libc::S_IFREG));
-        complete_file: resolve_partial("b/c/file") => Ok(PartialLookup::Complete(("/b/c/file", libc::S_IFREG)));
         complete_file_link: resolve("b-file") => Ok(("/b/c/file", libc::S_IFREG));
-        complete_file_link: resolve_partial("b-file") => Ok(PartialLookup::Complete(("/b/c/file", libc::S_IFREG)));
         complete_fifo: resolve("b/fifo") => Ok(("/b/fifo", libc::S_IFIFO));
-        complete_fifo: resolve_partial("b/fifo") => Ok(PartialLookup::Complete(("/b/fifo", libc::S_IFIFO)));
         complete_sock: resolve("b/sock") => Ok(("/b/sock", libc::S_IFSOCK));
-        complete_sock: resolve_partial("b/sock") => Ok(PartialLookup::Complete(("/b/sock", libc::S_IFSOCK)));
         // Partial lookups.
         partial_dir_basic: resolve("a/b/c/d/e/f/g/h") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        partial_dir_basic: resolve_partial("a/b/c/d/e/f/g/h") => Ok(PartialLookup::Partial {
-            handle: ("a", libc::S_IFDIR),
-            remaining: "b/c/d/e/f/g/h".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         partial_dir_dotdot: resolve("a/foo/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        partial_dir_dotdot: resolve_partial("a/foo/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("a", libc::S_IFDIR),
-            remaining: "foo/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         // Non-lexical symlinks.
         nonlexical_basic_complete: resolve("target") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_basic_complete: resolve_partial("target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_basic_complete1: resolve("target/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_basic_complete1: resolve_partial("target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_basic_complete2: resolve("target//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_basic_complete2: resolve_partial("target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_basic_partial: resolve("target/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_basic_partial: resolve_partial("target/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_basic_partial_dotdot: resolve("target/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_basic_partial_dotdot: resolve_partial("target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level1_abs_complete1: resolve("link1/target_abs") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_abs_complete1: resolve_partial("link1/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_abs_complete2: resolve("link1/target_abs/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_abs_complete2: resolve_partial("link1/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_abs_complete3: resolve("link1/target_abs//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_abs_complete3: resolve_partial("link1/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_abs_partial: resolve("link1/target_abs/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level1_abs_partial: resolve_partial("link1/target_abs/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level1_abs_partial_dotdot: resolve("link1/target_abs/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level1_abs_partial_dotdot: resolve_partial("link1/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level1_rel_complete1: resolve("link1/target_rel") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_rel_complete1: resolve_partial("link1/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_rel_complete2: resolve("link1/target_rel/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_rel_complete2: resolve_partial("link1/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_rel_complete3: resolve("link1/target_rel//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level1_rel_complete3: resolve_partial("link1/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level1_rel_partial: resolve("link1/target_rel/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level1_rel_partial: resolve_partial("link1/target_rel/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level1_rel_partial_dotdot: resolve("link1/target_rel/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level1_rel_partial_dotdot: resolve_partial("link1/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_abs_complete1: resolve("link2/link1_abs/target_abs") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_abs_complete1: resolve_partial("link2/link1_abs/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_abs_complete2: resolve("link2/link1_abs/target_abs/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_abs_complete2: resolve_partial("link2/link1_abs/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_abs_complete3: resolve("link2/link1_abs/target_abs//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_abs_complete3: resolve_partial("link2/link1_abs/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_abs_partial: resolve("link2/link1_abs/target_abs/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_abs_partial: resolve_partial("link2/link1_abs/target_abs/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_abs_partial_dotdot: resolve("link2/link1_abs/target_abs/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_abs_partial_dotdot: resolve_partial("link2/link1_abs/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_rel_complete1: resolve("link2/link1_abs/target_rel") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_rel_complete1: resolve_partial("link2/link1_abs/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_rel_complete2: resolve("link2/link1_abs/target_rel/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_rel_complete2: resolve_partial("link2/link1_abs/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_rel_complete3: resolve("link2/link1_abs/target_rel//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_rel_complete3: resolve_partial("link2/link1_abs/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_rel_partial: resolve("link2/link1_abs/target_rel/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_rel_partial: resolve_partial("link2/link1_abs/target_rel/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_rel_partial_dotdot: resolve("link2/link1_abs/target_rel/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_rel_partial_dotdot: resolve_partial("link2/link1_abs/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_open_complete1: resolve("link2/link1_abs/../target") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_open_complete1: resolve_partial("link2/link1_abs/../target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_open_complete2: resolve("link2/link1_abs/../target/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_open_complete2: resolve_partial("link2/link1_abs/../target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_open_complete3: resolve("link2/link1_abs/../target//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_abs_open_complete3: resolve_partial("link2/link1_abs/../target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_abs_open_partial: resolve("link2/link1_abs/../target/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_open_partial: resolve_partial("link2/link1_abs/../target/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_abs_open_partial_dotdot: resolve("link2/link1_abs/../target/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_abs_open_partial_dotdot: resolve_partial("link2/link1_abs/../target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_abs_complete1: resolve("link2/link1_rel/target_abs") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_abs_complete1: resolve_partial("link2/link1_rel/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_abs_complete2: resolve("link2/link1_rel/target_abs/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_abs_complete2: resolve_partial("link2/link1_rel/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_abs_complete3: resolve("link2/link1_rel/target_abs//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_abs_complete3: resolve_partial("link2/link1_rel/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_abs_partial: resolve("link2/link1_rel/target_abs/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_abs_partial: resolve_partial("link2/link1_rel/target_abs/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_abs_partial_dotdot: resolve("link2/link1_rel/target_abs/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_abs_partial_dotdot: resolve_partial("link2/link1_rel/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_rel_complete1: resolve("link2/link1_rel/target_rel") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_rel_complete1: resolve_partial("link2/link1_rel/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_rel_complete2: resolve("link2/link1_rel/target_rel/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_rel_complete2: resolve_partial("link2/link1_rel/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_rel_complete3: resolve("link2/link1_rel/target_rel//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_rel_complete3: resolve_partial("link2/link1_rel/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_rel_partial: resolve("link2/link1_rel/target_rel/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_rel_partial: resolve_partial("link2/link1_rel/target_rel/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_rel_partial_dotdot: resolve("link2/link1_rel/target_rel/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_rel_partial_dotdot: resolve_partial("link2/link1_rel/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_open_complete1: resolve("link2/link1_rel/../target") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_open_complete1: resolve_partial("link2/link1_rel/../target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_open_complete2: resolve("link2/link1_rel/../target/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_open_complete2: resolve_partial("link2/link1_rel/../target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_open_complete3: resolve("link2/link1_rel/../target//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level2_rel_open_complete3: resolve_partial("link2/link1_rel/../target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level2_rel_open_partial: resolve("link2/link1_rel/../target/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_open_partial: resolve_partial("link2/link1_rel/../target/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level2_rel_open_partial_dotdot: resolve("link2/link1_rel/../target/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level2_rel_open_partial_dotdot: resolve_partial("link2/link1_rel/../target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level3_abs_complete1: resolve("link3/target_abs") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level3_abs_complete1: resolve_partial("link3/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level3_abs_complete2: resolve("link3/target_abs/") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level3_abs_complete2: resolve_partial("link3/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level3_abs_complete3: resolve("link3/target_abs//") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level3_abs_complete3: resolve_partial("link3/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level3_abs_partial: resolve("link3/target_abs/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level3_abs_partial: resolve_partial("link3/target_abs/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level3_abs_partial_dotdot: resolve("link3/target_abs/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level3_abs_partial_dotdot: resolve_partial("link3/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level3_rel_complete: resolve("link3/target_rel") => Ok(("/target", libc::S_IFDIR));
-        nonlexical_level3_rel_complete: resolve_partial("link3/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         nonlexical_level3_rel_partial: resolve("link3/target_rel/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level3_rel_partial: resolve_partial("link3/target_rel/foo") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         nonlexical_level3_rel_partial_dotdot: resolve("link3/target_rel/../target/foo/bar/../baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        nonlexical_level3_rel_partial_dotdot: resolve_partial("link3/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
-            handle: ("target", libc::S_IFDIR),
-            remaining: "foo/bar/../baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         // Partial lookups due to hitting a non_directory.
         partial_nondir_slash1: resolve("b/c/file/") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_slash1: resolve_partial("b/c/file/") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_slash2: resolve("b/c/file//") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_slash2: resolve_partial("b/c/file//") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "/".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_dot: resolve("b/c/file/.") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_dot: resolve_partial("b/c/file/.") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: ".".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_dotdot1: resolve("b/c/file/..") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_dotdot1: resolve_partial("b/c/file/..") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_dotdot2: resolve("b/c/file/../foo/bar") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_dotdot2: resolve_partial("b/c/file/../foo/bar") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "../foo/bar".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_symlink_slash1: resolve("b-file/") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_symlink_slash1: resolve_partial("b-file/") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_symlink_slash2: resolve("b-file//") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_symlink_slash2: resolve_partial("b-file//") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "/".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_symlink_dot: resolve("b-file/.") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_symlink_dot: resolve_partial("b-file/.") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: ".".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_symlink_dotdot1: resolve("b-file/..") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_symlink_dotdot1: resolve_partial("b-file/..") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_nondir_symlink_dotdot2: resolve("b-file/../foo/bar") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_nondir_symlink_dotdot2: resolve_partial("b-file/../foo/bar") => Ok(PartialLookup::Partial {
-            handle: ("b/c/file", libc::S_IFREG),
-            remaining: "../foo/bar".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_fifo_slash1: resolve("b/fifo/") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_fifo_slash1: resolve_partial("b/fifo/") => Ok(PartialLookup::Partial {
-            handle: ("b/fifo", libc::S_IFIFO),
-            remaining: "".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_fifo_slash2: resolve("b/fifo//") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_fifo_slash2: resolve_partial("b/fifo//") => Ok(PartialLookup::Partial {
-            handle: ("b/fifo", libc::S_IFIFO),
-            remaining: "/".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_fifo_dot: resolve("b/fifo/.") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_fifo_dot: resolve_partial("b/fifo/.") => Ok(PartialLookup::Partial {
-            handle: ("b/fifo", libc::S_IFIFO),
-            remaining: ".".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_fifo_dotdot1: resolve("b/fifo/..") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_fifo_dotdot1: resolve_partial("b/fifo/..") => Ok(PartialLookup::Partial {
-            handle: ("b/fifo", libc::S_IFIFO),
-            remaining: "..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_fifo_dotdot2: resolve("b/fifo/../foo/bar") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_fifo_dotdot2: resolve_partial("b/fifo/../foo/bar") => Ok(PartialLookup::Partial {
-            handle: ("b/fifo", libc::S_IFIFO),
-            remaining: "../foo/bar".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_sock_slash1: resolve("b/sock/") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_sock_slash1: resolve_partial("b/sock/") => Ok(PartialLookup::Partial {
-            handle: ("b/sock", libc::S_IFSOCK),
-            remaining: "".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_sock_slash2: resolve("b/sock//") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_sock_slash2: resolve_partial("b/sock//") => Ok(PartialLookup::Partial {
-            handle: ("b/sock", libc::S_IFSOCK),
-            remaining: "/".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_sock_dot: resolve("b/sock/.") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_sock_dot: resolve_partial("b/sock/.") => Ok(PartialLookup::Partial {
-            handle: ("b/sock", libc::S_IFSOCK),
-            remaining: ".".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_sock_dotdot1: resolve("b/sock/..") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_sock_dotdot1: resolve_partial("b/sock/..") => Ok(PartialLookup::Partial {
-            handle: ("b/sock", libc::S_IFSOCK),
-            remaining: "..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         partial_sock_dotdot2: resolve("b/sock/../foo/bar") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        partial_sock_dotdot2: resolve_partial("b/sock/../foo/bar") => Ok(PartialLookup::Partial {
-            handle: ("b/sock", libc::S_IFSOCK),
-            remaining: "../foo/bar".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         // O_NOFOLLOW doesn't matter for trailing-slash paths.
         partial_symlink_nofollow_slash1: resolve("link3/target_abs/", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_slash1: resolve_partial("link3/target_abs/", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         partial_symlink_nofollow_slash2: resolve("link3/target_abs//", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_slash2: resolve_partial("link3/target_abs//", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         partial_symlink_nofollow_dot: resolve("link3/target_abs/.", no_follow_trailing = true) => Ok(("/target", libc::S_IFDIR));
-        partial_symlink_nofollow_dot: resolve_partial("link3/target_abs/.", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
         // Dangling symlinks are treated as though they are non_existent.
         dangling1_inroot_trailing: resolve("a-fake1") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_inroot_trailing: resolve_partial("a-fake1") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake1".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling1_inroot_partial: resolve("a-fake1/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_inroot_partial: resolve_partial("a-fake1/foo") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake1/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling1_inroot_partial_dotdot: resolve("a-fake1/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_inroot_partial_dotdot: resolve_partial("a-fake1/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake1/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling1_sub_trailing: resolve("c/a-fake1") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_sub_trailing: resolve_partial("c/a-fake1") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake1".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling1_sub_partial: resolve("c/a-fake1/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_sub_partial: resolve_partial("c/a-fake1/foo") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake1/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling1_sub_partial_dotdot: resolve("c/a-fake1/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling1_sub_partial_dotdot: resolve_partial("c/a-fake1/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake1/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_inroot_trailing: resolve("a-fake2") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_inroot_trailing: resolve_partial("a-fake2") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake2".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_inroot_partial: resolve("a-fake2/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_inroot_partial: resolve_partial("a-fake2/foo") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake2/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_inroot_partial_dotdot: resolve("a-fake2/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_inroot_partial_dotdot: resolve_partial("a-fake2/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake2/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_sub_trailing: resolve("c/a-fake2") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_sub_trailing: resolve_partial("c/a-fake2") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake2".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_sub_partial: resolve("c/a-fake2/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_sub_partial: resolve_partial("c/a-fake2/foo") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake2/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling2_sub_partial_dotdot: resolve("c/a-fake2/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling2_sub_partial_dotdot: resolve_partial("c/a-fake2/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake2/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_inroot_trailing: resolve("a-fake3") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_inroot_trailing: resolve_partial("a-fake3") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake3".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_inroot_partial: resolve("a-fake3/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_inroot_partial: resolve_partial("a-fake3/foo") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake3/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_inroot_partial_dotdot: resolve("a-fake3/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_inroot_partial_dotdot: resolve_partial("a-fake3/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "a-fake3/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_sub_trailing: resolve("c/a-fake3") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_sub_trailing: resolve_partial("c/a-fake3") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake3".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_sub_partial: resolve("c/a-fake3/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_sub_partial: resolve_partial("c/a-fake3/foo") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake3/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling3_sub_partial_dotdot: resolve("c/a-fake3/../bar/baz") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling3_sub_partial_dotdot: resolve_partial("c/a-fake3/../bar/baz") => Ok(PartialLookup::Partial {
-            handle: ("c", libc::S_IFDIR),
-            remaining: "a-fake3/../bar/baz".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         // Tricky dangling symlinks.
         dangling_tricky1_trailing: resolve("link3/deep_dangling1") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky1_trailing: resolve_partial("link3/deep_dangling1") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling1".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling_tricky1_partial: resolve("link3/deep_dangling1/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky1_partial: resolve_partial("link3/deep_dangling1/foo") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling1/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling_tricky1_partial_dotdot: resolve("link3/deep_dangling1/..") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky1_partial_dotdot: resolve_partial("link3/deep_dangling1/..") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling1/..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling_tricky2_trailing: resolve("link3/deep_dangling2") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky2_trailing: resolve_partial("link3/deep_dangling2") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling2".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling_tricky2_partial: resolve("link3/deep_dangling2/foo") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky2_partial: resolve_partial("link3/deep_dangling2/foo") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling2/foo".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         dangling_tricky2_partial_dotdot: resolve("link3/deep_dangling2/..") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        dangling_tricky2_partial_dotdot: resolve_partial("link3/deep_dangling2/..") => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "deep_dangling2/..".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         // Really deep dangling links.
         deep_dangling1: resolve("dangling/a") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling1: resolve_partial("dangling/a") => Ok(PartialLookup::Partial {
-            handle: ("dangling", libc::S_IFDIR),
-            remaining: "a".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling2: resolve("dangling/b/c") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling2: resolve_partial("dangling/b/c") => Ok(PartialLookup::Partial {
-            handle: ("dangling/b", libc::S_IFDIR),
-            remaining: "c".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling3: resolve("dangling/c") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling3: resolve_partial("dangling/c") => Ok(PartialLookup::Partial {
-            handle: ("dangling", libc::S_IFDIR),
-            remaining: "c".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling4: resolve("dangling/d/e") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling4: resolve_partial("dangling/d/e") => Ok(PartialLookup::Partial {
-            handle: ("dangling/d", libc::S_IFDIR),
-            remaining: "e".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling5: resolve("dangling/e") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling5: resolve_partial("dangling/e") => Ok(PartialLookup::Partial {
-            handle: ("dangling", libc::S_IFDIR),
-            remaining: "e".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling6: resolve("dangling/g") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-        deep_dangling6: resolve_partial("dangling/g") => Ok(PartialLookup::Partial {
-            handle: ("dangling", libc::S_IFDIR),
-            remaining: "g".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
-        });
         deep_dangling_fileasdir1: resolve("dangling-file/a") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir1: resolve_partial("dangling-file/a") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file", libc::S_IFDIR),
-            remaining: "a".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         deep_dangling_fileasdir2: resolve("dangling-file/b/c") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir2: resolve_partial("dangling-file/b/c") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file/b", libc::S_IFDIR),
-            remaining: "c".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         deep_dangling_fileasdir3: resolve("dangling-file/c") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir3: resolve_partial("dangling-file/c") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file", libc::S_IFDIR),
-            remaining: "c".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         deep_dangling_fileasdir4: resolve("dangling-file/d/e") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir4: resolve_partial("dangling-file/d/e") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file/d", libc::S_IFDIR),
-            remaining: "e".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         deep_dangling_fileasdir5: resolve("dangling-file/e") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir5: resolve_partial("dangling-file/e") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file", libc::S_IFDIR),
-            remaining: "e".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         deep_dangling_fileasdir6: resolve("dangling-file/g") => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
-        deep_dangling_fileasdir6: resolve_partial("dangling-file/g") => Ok(PartialLookup::Partial {
-            handle: ("dangling-file", libc::S_IFDIR),
-            remaining: "g".into(),
-            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
-        });
         // Symlink loops.
         loop1: resolve("loop/link") => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop1: resolve_partial("loop/link") => Ok(PartialLookup::Partial {
-            handle: ("loop", libc::S_IFDIR),
-            remaining: "link".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         loop_basic1: resolve("loop/basic-loop1") => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop_basic1: resolve_partial("loop/basic-loop1") => Ok(PartialLookup::Partial {
-            handle: ("loop", libc::S_IFDIR),
-            remaining: "basic-loop1".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         loop_basic2: resolve("loop/basic-loop2") => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop_basic2: resolve_partial("loop/basic-loop2") => Ok(PartialLookup::Partial {
-            handle: ("loop", libc::S_IFDIR),
-            remaining: "basic-loop2".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         loop_basic3: resolve("loop/basic-loop3") => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop_basic3: resolve_partial("loop/basic-loop3") => Ok(PartialLookup::Partial {
-            handle: ("loop", libc::S_IFDIR),
-            remaining: "basic-loop3".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         // NO_FOLLOW.
         symlink_nofollow: resolve("link3/target_abs", no_follow_trailing = true) => Ok(("link3/target_abs", libc::S_IFLNK));
-        symlink_nofollow: resolve_partial("link3/target_abs", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link3/target_abs", libc::S_IFLNK)));
         symlink_component_nofollow1: resolve("e/f", no_follow_trailing = true) => Ok(("b/c/d/e/f", libc::S_IFDIR));
-        symlink_component_nofollow1: resolve_partial("e/f", no_follow_trailing = true) => Ok(PartialLookup::Complete(("b/c/d/e/f", libc::S_IFDIR)));
         symlink_component_nofollow2: resolve("link2/link1_abs/target_rel", no_follow_trailing = true) => Ok(("link1/target_rel", libc::S_IFLNK));
-        symlink_component_nofollow2: resolve_partial("link2/link1_abs/target_rel", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link1/target_rel", libc::S_IFLNK)));
         loop_nofollow: resolve("loop/link", no_follow_trailing = true) => Ok(("loop/link", libc::S_IFLNK));
-        loop_nofollow: resolve_partial("loop/link", no_follow_trailing = true) => Ok(PartialLookup::Complete(("loop/link", libc::S_IFLNK)));
         // RESOLVE_NO_SYMLINKS.
         dir_nosym: resolve("b/c/d/e", rflags = NO_SYMLINKS) => Ok(("b/c/d/e", libc::S_IFDIR));
-        dir_nosym: resolve_partial("b/c/d/e", rflags = NO_SYMLINKS) => Ok(PartialLookup::Complete(("b/c/d/e", libc::S_IFDIR)));
         symlink_nosym: resolve("link3/target_abs", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_nosym: resolve_partial("link3/target_abs", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
-            handle: ("link3", libc::S_IFDIR),
-            remaining: "target_abs".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         symlink_component_nosym1: resolve("e/f", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_component_nosym1: resolve_partial("e/f", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
-            handle: ("", libc::S_IFDIR),
-            remaining: "e/f".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         symlink_component_nosym2: resolve("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        symlink_component_nosym2: resolve_partial("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
-            handle: ("link2", libc::S_IFDIR),
-            remaining: "link1_abs/target_rel".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
         loop_nosym: resolve("loop/link", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
-        loop_nosym: resolve_partial("loop/link", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
-            handle: ("loop", libc::S_IFDIR),
-            remaining: "link".into(),
-            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
-        });
     }
 }
 
 mod utils {
     use crate::{
-        error::ErrorKind, flags::OpenFlags, resolvers::PartialLookup, syscalls, utils::FdExt,
-        Handle, Root,
+        error::ErrorKind,
+        flags::OpenFlags,
+        syscalls,
+        tests::{
+            common::{self as tests_common, LookupResult},
+            traits::{ErrorImpl, HandleImpl, RootImpl},
+        },
+        utils::FdExt,
     };
 
     use std::{os::unix::fs::MetadataExt, path::Path};
 
     use anyhow::Error;
-    use errno::Errno;
     use pretty_assertions::assert_eq;
 
-    pub(super) type LookupResult<'a> = (&'a str, libc::mode_t);
-
-    impl<H, E> PartialEq for PartialLookup<H, E>
-    where
-        H: PartialEq,
-        E: PartialEq,
-    {
-        fn eq(&self, other: &Self) -> bool {
-            match (self, other) {
-                (Self::Complete(left), Self::Complete(right)) => left == right,
-                (
-                    Self::Partial {
-                        handle: left_handle,
-                        remaining: left_remaining,
-                        last_error: left_last_error,
-                    },
-                    Self::Partial {
-                        handle: right_handle,
-                        remaining: right_remaining,
-                        last_error: right_last_error,
-                    },
-                ) => {
-                    left_handle == right_handle
-                        && left_remaining == right_remaining
-                        && left_last_error == right_last_error
-                }
-                _ => false,
-            }
-        }
-    }
-
-    impl<H, E> PartialLookup<H, E> {
-        fn as_inner_handle(&self) -> &H {
-            match self {
-                PartialLookup::Complete(handle) => handle,
-                PartialLookup::Partial { handle, .. } => handle,
-            }
-        }
-    }
-
-    fn errno_description(err: ErrorKind) -> String {
-        match err {
-            ErrorKind::OsError(Some(errno)) => format!("{err:?} ({})", Errno(errno)),
-            _ => format!("{err:?}"),
-        }
-    }
-
-    fn check_reopen(
-        handle: &Handle,
-        flags: OpenFlags,
-        expected_error: Option<i32>,
-    ) -> Result<(), Error> {
-        let expected_error = expected_error.map(|errno| ErrorKind::OsError(Some(errno)));
-        let file = match (handle.reopen(flags), expected_error) {
-            (Ok(f), None) => f,
-            (Err(e), None) => anyhow::bail!("unexpected error '{}'", e),
-            (Ok(f), Some(want_err)) => anyhow::bail!(
-                "expected to get io::Error {} but instead got file {}",
-                errno_description(want_err),
-                f.as_unsafe_path_unchecked()?.display(),
-            ),
-            (Err(err), Some(want_err)) => {
-                assert_eq!(
-                    err.kind(),
-                    want_err,
-                    "expected io::Error {}, got '{}'",
-                    errno_description(want_err),
-                    err,
-                );
-                return Ok(());
-            }
-        };
-
-        let real_handle_path = handle.as_unsafe_path_unchecked()?;
-        let real_reopen_path = file.as_unsafe_path_unchecked()?;
-
-        assert_eq!(
-            real_handle_path, real_reopen_path,
-            "reopened handle should be equivalent to old handle",
-        );
-
-        let clone_handle = handle.try_clone()?;
-        let clone_handle_path = clone_handle.as_unsafe_path_unchecked()?;
-
-        assert_eq!(
-            real_handle_path, clone_handle_path,
-            "cloned handle should be equivalent to old handle",
-        );
-
-        // TODO: Check fd flags.
-
-        Ok(())
-    }
-
-    pub(super) fn check_root_resolve_partial<P: AsRef<Path>>(
-        root: &Root,
-        unsafe_path: P,
-        no_follow_trailing: bool,
-        expected: Result<PartialLookup<LookupResult, ErrorKind>, ErrorKind>,
-    ) -> Result<(), Error> {
-        let root_dir = root.as_unsafe_path_unchecked()?;
-        let unsafe_path = unsafe_path.as_ref();
-
-        let result = root
-            .resolver
-            .resolve_partial(root, unsafe_path, no_follow_trailing)
-            .map(|lookup_result| {
-                let (path, file_type) = {
-                    let file = lookup_result.as_inner_handle();
-                    (
-                        file.as_unsafe_path_unchecked()
-                            .expect("should be able to get real path of handle"),
-                        file.metadata()
-                            .expect("should be able to fstat handle")
-                            .mode()
-                            & libc::S_IFMT,
-                    )
-                };
-
-                match lookup_result {
-                    PartialLookup::Complete(handle) => {
-                        (handle, PartialLookup::Complete((path, file_type)))
-                    }
-                    PartialLookup::Partial {
-                        handle,
-                        remaining,
-                        last_error,
-                    } => (
-                        handle,
-                        PartialLookup::Partial {
-                            handle: (path, file_type),
-                            remaining,
-                            last_error: last_error.kind(),
-                        },
-                    ),
-                }
-            });
-
-        let ((handle, lookup_result), expected_lookup_result) = match (result, expected) {
-            (Ok((handle, lookup_result)), Ok(expected_lookup_result)) => {
-                let (path, file_type) = {
-                    let (path, file_type) = expected_lookup_result.as_inner_handle();
-                    (root_dir.join(path.trim_start_matches('/')), *file_type)
-                };
-                let expected_lookup_result = match expected_lookup_result {
-                    PartialLookup::Complete(_) => PartialLookup::Complete((path, file_type)),
-                    PartialLookup::Partial {
-                        handle: _,
-                        remaining,
-                        last_error,
-                    } => PartialLookup::Partial {
-                        handle: (path, file_type),
-                        remaining,
-                        last_error,
-                    },
-                };
-
-                ((handle, lookup_result), expected_lookup_result)
-            }
-
-            (Err(err), Ok(expected)) => {
-                anyhow::bail!(
-                    "unexpected error '{}', expected successful {:?}",
-                    err,
-                    expected,
-                )
-            }
-
-            (Ok((_, lookup_result)), Err(want_err)) => anyhow::bail!(
-                "expected to get io::Error {} but instead got result {:?}",
-                errno_description(want_err),
-                lookup_result,
-            ),
-
-            (Err(err), Err(want_err)) => {
-                assert_eq!(
-                    err.kind(),
-                    want_err,
-                    "expected io::Error {}, got '{}'",
-                    errno_description(want_err),
-                    err,
-                );
-                return Ok(());
-            }
-        };
-
-        assert_eq!(
-            lookup_result, expected_lookup_result,
-            "partial_lookup({unsafe_path:?}, {no_follow_trailing}) result mismatch",
-        );
-
-        let (_, real_file_type) = lookup_result.as_inner_handle();
-        match *real_file_type {
-            libc::S_IFDIR => {
-                check_reopen(&handle, OpenFlags::O_RDONLY, None)?;
-                check_reopen(&handle, OpenFlags::O_DIRECTORY, None)?;
-            }
-            libc::S_IFREG => {
-                check_reopen(&handle, OpenFlags::O_RDWR, None)?;
-                check_reopen(&handle, OpenFlags::O_DIRECTORY, Some(libc::ENOTDIR))?;
-            }
-            _ => {
-                check_reopen(&handle, OpenFlags::O_PATH, None)?;
-                check_reopen(
-                    &handle,
-                    OpenFlags::O_PATH | OpenFlags::O_DIRECTORY,
-                    Some(libc::ENOTDIR),
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    pub(super) fn check_root_resolve<P: AsRef<Path>>(
-        root: &Root,
+    pub(super) fn check_root_resolve<R: RootImpl, P: AsRef<Path>>(
+        root: R,
         unsafe_path: P,
         no_follow_trailing: bool,
         expected: Result<LookupResult, ErrorKind>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        for<'a> &'a R::Handle: HandleImpl,
+    {
         let root_dir = root.as_unsafe_path_unchecked()?;
         let unsafe_path = unsafe_path.as_ref();
 
@@ -1049,7 +404,7 @@ mod utils {
 
             (Ok(handle), Err(want_err)) => anyhow::bail!(
                 "expected to get io::Error {} but instead got file {}",
-                errno_description(want_err),
+                tests_common::errno_description(want_err),
                 handle.as_unsafe_path_unchecked()?.display(),
             ),
 
@@ -1058,7 +413,7 @@ mod utils {
                     err.kind(),
                     want_err,
                     "expected io::Error {}, got '{}'",
-                    errno_description(want_err),
+                    tests_common::errno_description(want_err),
                     err,
                 );
                 return Ok(());
@@ -1079,16 +434,16 @@ mod utils {
 
         match real_file_type {
             libc::S_IFDIR => {
-                check_reopen(&handle, OpenFlags::O_RDONLY, None)?;
-                check_reopen(&handle, OpenFlags::O_DIRECTORY, None)?;
+                tests_common::check_reopen(&handle, OpenFlags::O_RDONLY, None)?;
+                tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, None)?;
             }
             libc::S_IFREG => {
-                check_reopen(&handle, OpenFlags::O_RDWR, None)?;
-                check_reopen(&handle, OpenFlags::O_DIRECTORY, Some(libc::ENOTDIR))?;
+                tests_common::check_reopen(&handle, OpenFlags::O_RDWR, None)?;
+                tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, Some(libc::ENOTDIR))?;
             }
             _ => {
-                check_reopen(&handle, OpenFlags::O_PATH, None)?;
-                check_reopen(
+                tests_common::check_reopen(&handle, OpenFlags::O_PATH, None)?;
+                tests_common::check_reopen(
                     &handle,
                     OpenFlags::O_PATH | OpenFlags::O_DIRECTORY,
                     Some(libc::ENOTDIR),

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -1,0 +1,809 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::ErrorKind, flags::ResolverFlags, resolvers::PartialLookup,
+    tests::common as tests_common, ResolverBackend, Root,
+};
+
+use anyhow::Error;
+
+macro_rules! resolve_tests {
+    // resolve_tests! {
+    //      [create_root_path] {
+    //          test_ok: resolve_partial(...) => Ok(("path", Some("remaining", ErrorKind::...)), libc::S_IF...))
+    //          test_err: resolve_partial(...) => Err(ErrorKind::...)
+    //      }
+    // }
+    ([$root_dir:expr] fn $test_name:ident (mut $root_var:ident : Root) $body:block => $expected:expr) => {
+        paste::paste! {
+            #[test]
+            fn [<root_ $test_name _default>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let mut $root_var = Root::open(&root_dir)?;
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+
+            #[test]
+            fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let mut $root_var = Root::open(&root_dir)?;
+                $root_var.resolver.backend = ResolverBackend::KernelOpenat2;
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+
+            #[test]
+            fn [<root_ $test_name _opath>]() -> Result<(), Error> {
+                let root_dir = $root_dir;
+                let mut $root_var = Root::open(&root_dir)?;
+                $root_var.resolver.backend = ResolverBackend::EmulatedOpath;
+
+                { $body }
+
+                // Make sure root_dir is not dropped earlier.
+                let _root_dir = root_dir;
+                Ok(())
+            }
+        }
+    };
+
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, $rflags:expr, $no_follow_trailing:expr) => $expected:expr) => {
+        paste::paste! {
+            resolve_tests! {
+                [$root_dir]
+                fn [<$op_name _ $test_name>](mut root: Root) {
+                    root.resolver.flags = $rflags;
+                    if !root.resolver.backend.supported() {
+                        // Skip if not supported.
+                        return Ok(());
+                    }
+
+                    let expected = $expected;
+                    utils::[<check_root_ $op_name>](
+                        &root,
+                        $path,
+                        $no_follow_trailing,
+                        expected,
+                    )?;
+                } => $expected
+            }
+        }
+    };
+
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, rflags = $($rflag:ident)|+) => $expected:expr ) => {
+        resolve_tests! {
+            [$root_dir]
+            @impl $test_name $op_name($path, $(ResolverFlags::$rflag)|*, false) => $expected
+        }
+    };
+
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, no_follow_trailing = $no_follow_trailing:expr) => $expected:expr ) => {
+        resolve_tests! {
+            [$root_dir]
+            @impl $test_name $op_name($path, ResolverFlags::empty(), $no_follow_trailing) => $expected
+        }
+    };
+
+    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr) => $expected:expr ) => {
+        resolve_tests! {
+            [$root_dir]
+            @impl $test_name $op_name($path, ResolverFlags::empty(), false) => $expected
+        }
+    };
+
+    ($([$root_dir:expr] { $($test_name:ident : $op_name:ident ($($args:tt)*) => $expected:expr);* $(;)? });* $(;)?) => {
+        $( $(
+            resolve_tests! {
+                [$root_dir]
+                @impl $test_name $op_name ($($args)*) => $expected
+            }
+        )* )*
+    }
+}
+
+resolve_tests! {
+    // Complete lookups.
+    [tests_common::create_basic_tree()?] {
+        complete_root1: resolve_partial("/") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
+        complete_root2: resolve_partial("/../../../../../..") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
+        complete_root_link1: resolve_partial("root-link1") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
+        complete_root_link2: resolve_partial("root-link2") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
+        complete_root_link3: resolve_partial("root-link3") => Ok(PartialLookup::Complete(("/", libc::S_IFDIR)));
+        complete_dir1: resolve_partial("a") => Ok(PartialLookup::Complete(("/a", libc::S_IFDIR)));
+        complete_dir2: resolve_partial("b/c/d/e/f") => Ok(PartialLookup::Complete(("/b/c/d/e/f", libc::S_IFDIR)));
+        complete_dir3: resolve_partial("b///././c////.//d/./././///e////.//./f//././././") => Ok(PartialLookup::Complete(("/b/c/d/e/f", libc::S_IFDIR)));
+        complete_file: resolve_partial("b/c/file") => Ok(PartialLookup::Complete(("/b/c/file", libc::S_IFREG)));
+        complete_file_link: resolve_partial("b-file") => Ok(PartialLookup::Complete(("/b/c/file", libc::S_IFREG)));
+        complete_fifo: resolve_partial("b/fifo") => Ok(PartialLookup::Complete(("/b/fifo", libc::S_IFIFO)));
+        complete_sock: resolve_partial("b/sock") => Ok(PartialLookup::Complete(("/b/sock", libc::S_IFSOCK)));
+        // Partial lookups.
+        partial_dir_basic: resolve_partial("a/b/c/d/e/f/g/h") => Ok(PartialLookup::Partial {
+            handle: ("a", libc::S_IFDIR),
+            remaining: "b/c/d/e/f/g/h".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        partial_dir_dotdot: resolve_partial("a/foo/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("a", libc::S_IFDIR),
+            remaining: "foo/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        // Non-lexical symlinks.
+        nonlexical_basic_complete: resolve_partial("target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_basic_complete1: resolve_partial("target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_basic_complete2: resolve_partial("target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_basic_partial: resolve_partial("target/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_basic_partial_dotdot: resolve_partial("target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level1_abs_complete1: resolve_partial("link1/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_abs_complete2: resolve_partial("link1/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_abs_complete3: resolve_partial("link1/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_abs_partial: resolve_partial("link1/target_abs/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level1_abs_partial_dotdot: resolve_partial("link1/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level1_rel_complete1: resolve_partial("link1/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_rel_complete2: resolve_partial("link1/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_rel_complete3: resolve_partial("link1/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level1_rel_partial: resolve_partial("link1/target_rel/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level1_rel_partial_dotdot: resolve_partial("link1/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_abs_complete1: resolve_partial("link2/link1_abs/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_abs_complete2: resolve_partial("link2/link1_abs/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_abs_complete3: resolve_partial("link2/link1_abs/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_abs_partial: resolve_partial("link2/link1_abs/target_abs/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_abs_partial_dotdot: resolve_partial("link2/link1_abs/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_rel_complete1: resolve_partial("link2/link1_abs/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_rel_complete2: resolve_partial("link2/link1_abs/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_rel_complete3: resolve_partial("link2/link1_abs/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_rel_partial: resolve_partial("link2/link1_abs/target_rel/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_rel_partial_dotdot: resolve_partial("link2/link1_abs/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_open_complete1: resolve_partial("link2/link1_abs/../target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_open_complete2: resolve_partial("link2/link1_abs/../target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_open_complete3: resolve_partial("link2/link1_abs/../target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_abs_open_partial: resolve_partial("link2/link1_abs/../target/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_abs_open_partial_dotdot: resolve_partial("link2/link1_abs/../target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_abs_complete1: resolve_partial("link2/link1_rel/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_abs_complete2: resolve_partial("link2/link1_rel/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_abs_complete3: resolve_partial("link2/link1_rel/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_abs_partial: resolve_partial("link2/link1_rel/target_abs/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_abs_partial_dotdot: resolve_partial("link2/link1_rel/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_rel_complete1: resolve_partial("link2/link1_rel/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_rel_complete2: resolve_partial("link2/link1_rel/target_rel/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_rel_complete3: resolve_partial("link2/link1_rel/target_rel//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_rel_partial: resolve_partial("link2/link1_rel/target_rel/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_rel_partial_dotdot: resolve_partial("link2/link1_rel/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_open_complete1: resolve_partial("link2/link1_rel/../target") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_open_complete2: resolve_partial("link2/link1_rel/../target/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_open_complete3: resolve_partial("link2/link1_rel/../target//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level2_rel_open_partial: resolve_partial("link2/link1_rel/../target/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level2_rel_open_partial_dotdot: resolve_partial("link2/link1_rel/../target/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level3_abs_complete1: resolve_partial("link3/target_abs") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level3_abs_complete2: resolve_partial("link3/target_abs/") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level3_abs_complete3: resolve_partial("link3/target_abs//") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level3_abs_partial: resolve_partial("link3/target_abs/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level3_abs_partial_dotdot: resolve_partial("link3/target_abs/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level3_rel_complete: resolve_partial("link3/target_rel") => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        nonlexical_level3_rel_partial: resolve_partial("link3/target_rel/foo") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        nonlexical_level3_rel_partial_dotdot: resolve_partial("link3/target_rel/../target/foo/bar/../baz") => Ok(PartialLookup::Partial {
+            handle: ("target", libc::S_IFDIR),
+            remaining: "foo/bar/../baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        // Partial lookups due to hitting a non_directory.
+        partial_nondir_slash1: resolve_partial("b/c/file/") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_slash2: resolve_partial("b/c/file//") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "/".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_dot: resolve_partial("b/c/file/.") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: ".".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_dotdot1: resolve_partial("b/c/file/..") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_dotdot2: resolve_partial("b/c/file/../foo/bar") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "../foo/bar".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_symlink_slash1: resolve_partial("b-file/") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_symlink_slash2: resolve_partial("b-file//") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "/".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_symlink_dot: resolve_partial("b-file/.") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: ".".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_symlink_dotdot1: resolve_partial("b-file/..") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_nondir_symlink_dotdot2: resolve_partial("b-file/../foo/bar") => Ok(PartialLookup::Partial {
+            handle: ("b/c/file", libc::S_IFREG),
+            remaining: "../foo/bar".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_fifo_slash1: resolve_partial("b/fifo/") => Ok(PartialLookup::Partial {
+            handle: ("b/fifo", libc::S_IFIFO),
+            remaining: "".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_fifo_slash2: resolve_partial("b/fifo//") => Ok(PartialLookup::Partial {
+            handle: ("b/fifo", libc::S_IFIFO),
+            remaining: "/".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_fifo_dot: resolve_partial("b/fifo/.") => Ok(PartialLookup::Partial {
+            handle: ("b/fifo", libc::S_IFIFO),
+            remaining: ".".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_fifo_dotdot1: resolve_partial("b/fifo/..") => Ok(PartialLookup::Partial {
+            handle: ("b/fifo", libc::S_IFIFO),
+            remaining: "..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_fifo_dotdot2: resolve_partial("b/fifo/../foo/bar") => Ok(PartialLookup::Partial {
+            handle: ("b/fifo", libc::S_IFIFO),
+            remaining: "../foo/bar".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_sock_slash1: resolve_partial("b/sock/") => Ok(PartialLookup::Partial {
+            handle: ("b/sock", libc::S_IFSOCK),
+            remaining: "".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_sock_slash2: resolve_partial("b/sock//") => Ok(PartialLookup::Partial {
+            handle: ("b/sock", libc::S_IFSOCK),
+            remaining: "/".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_sock_dot: resolve_partial("b/sock/.") => Ok(PartialLookup::Partial {
+            handle: ("b/sock", libc::S_IFSOCK),
+            remaining: ".".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_sock_dotdot1: resolve_partial("b/sock/..") => Ok(PartialLookup::Partial {
+            handle: ("b/sock", libc::S_IFSOCK),
+            remaining: "..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        partial_sock_dotdot2: resolve_partial("b/sock/../foo/bar") => Ok(PartialLookup::Partial {
+            handle: ("b/sock", libc::S_IFSOCK),
+            remaining: "../foo/bar".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        // O_NOFOLLOW doesn't matter for trailing-slash paths.
+        partial_symlink_nofollow_slash1: resolve_partial("link3/target_abs/", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        partial_symlink_nofollow_slash2: resolve_partial("link3/target_abs//", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        partial_symlink_nofollow_dot: resolve_partial("link3/target_abs/.", no_follow_trailing = true) => Ok(PartialLookup::Complete(("/target", libc::S_IFDIR)));
+        // Dangling symlinks are treated as though they are non_existent.
+        dangling1_inroot_trailing: resolve_partial("a-fake1") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake1".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling1_inroot_partial: resolve_partial("a-fake1/foo") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake1/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling1_inroot_partial_dotdot: resolve_partial("a-fake1/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake1/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling1_sub_trailing: resolve_partial("c/a-fake1") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake1".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling1_sub_partial: resolve_partial("c/a-fake1/foo") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake1/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling1_sub_partial_dotdot: resolve_partial("c/a-fake1/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake1/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_inroot_trailing: resolve_partial("a-fake2") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake2".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_inroot_partial: resolve_partial("a-fake2/foo") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake2/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_inroot_partial_dotdot: resolve_partial("a-fake2/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake2/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_sub_trailing: resolve_partial("c/a-fake2") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake2".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_sub_partial: resolve_partial("c/a-fake2/foo") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake2/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling2_sub_partial_dotdot: resolve_partial("c/a-fake2/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake2/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_inroot_trailing: resolve_partial("a-fake3") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake3".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_inroot_partial: resolve_partial("a-fake3/foo") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake3/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_inroot_partial_dotdot: resolve_partial("a-fake3/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "a-fake3/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_sub_trailing: resolve_partial("c/a-fake3") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake3".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_sub_partial: resolve_partial("c/a-fake3/foo") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake3/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling3_sub_partial_dotdot: resolve_partial("c/a-fake3/../bar/baz") => Ok(PartialLookup::Partial {
+            handle: ("c", libc::S_IFDIR),
+            remaining: "a-fake3/../bar/baz".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        // Tricky dangling symlinks.
+        dangling_tricky1_trailing: resolve_partial("link3/deep_dangling1") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling1".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling_tricky1_partial: resolve_partial("link3/deep_dangling1/foo") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling1/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling_tricky1_partial_dotdot: resolve_partial("link3/deep_dangling1/..") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling1/..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling_tricky2_trailing: resolve_partial("link3/deep_dangling2") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling2".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling_tricky2_partial: resolve_partial("link3/deep_dangling2/foo") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling2/foo".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        dangling_tricky2_partial_dotdot: resolve_partial("link3/deep_dangling2/..") => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "deep_dangling2/..".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        // Really deep dangling links.
+        deep_dangling1: resolve_partial("dangling/a") => Ok(PartialLookup::Partial {
+            handle: ("dangling", libc::S_IFDIR),
+            remaining: "a".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling2: resolve_partial("dangling/b/c") => Ok(PartialLookup::Partial {
+            handle: ("dangling/b", libc::S_IFDIR),
+            remaining: "c".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling3: resolve_partial("dangling/c") => Ok(PartialLookup::Partial {
+            handle: ("dangling", libc::S_IFDIR),
+            remaining: "c".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling4: resolve_partial("dangling/d/e") => Ok(PartialLookup::Partial {
+            handle: ("dangling/d", libc::S_IFDIR),
+            remaining: "e".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling5: resolve_partial("dangling/e") => Ok(PartialLookup::Partial {
+            handle: ("dangling", libc::S_IFDIR),
+            remaining: "e".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling6: resolve_partial("dangling/g") => Ok(PartialLookup::Partial {
+            handle: ("dangling", libc::S_IFDIR),
+            remaining: "g".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOENT)),
+        });
+        deep_dangling_fileasdir1: resolve_partial("dangling-file/a") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file", libc::S_IFDIR),
+            remaining: "a".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        deep_dangling_fileasdir2: resolve_partial("dangling-file/b/c") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file/b", libc::S_IFDIR),
+            remaining: "c".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        deep_dangling_fileasdir3: resolve_partial("dangling-file/c") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file", libc::S_IFDIR),
+            remaining: "c".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        deep_dangling_fileasdir4: resolve_partial("dangling-file/d/e") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file/d", libc::S_IFDIR),
+            remaining: "e".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        deep_dangling_fileasdir5: resolve_partial("dangling-file/e") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file", libc::S_IFDIR),
+            remaining: "e".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        deep_dangling_fileasdir6: resolve_partial("dangling-file/g") => Ok(PartialLookup::Partial {
+            handle: ("dangling-file", libc::S_IFDIR),
+            remaining: "g".into(),
+            last_error: ErrorKind::OsError(Some(libc::ENOTDIR)),
+        });
+        // Symlink loops.
+        loop1: resolve_partial("loop/link") => Ok(PartialLookup::Partial {
+            handle: ("loop", libc::S_IFDIR),
+            remaining: "link".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        loop_basic1: resolve_partial("loop/basic-loop1") => Ok(PartialLookup::Partial {
+            handle: ("loop", libc::S_IFDIR),
+            remaining: "basic-loop1".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        loop_basic2: resolve_partial("loop/basic-loop2") => Ok(PartialLookup::Partial {
+            handle: ("loop", libc::S_IFDIR),
+            remaining: "basic-loop2".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        loop_basic3: resolve_partial("loop/basic-loop3") => Ok(PartialLookup::Partial {
+            handle: ("loop", libc::S_IFDIR),
+            remaining: "basic-loop3".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        // NO_FOLLOW.
+        symlink_nofollow: resolve_partial("link3/target_abs", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link3/target_abs", libc::S_IFLNK)));
+        symlink_component_nofollow1: resolve_partial("e/f", no_follow_trailing = true) => Ok(PartialLookup::Complete(("b/c/d/e/f", libc::S_IFDIR)));
+        symlink_component_nofollow2: resolve_partial("link2/link1_abs/target_rel", no_follow_trailing = true) => Ok(PartialLookup::Complete(("link1/target_rel", libc::S_IFLNK)));
+        loop_nofollow: resolve_partial("loop/link", no_follow_trailing = true) => Ok(PartialLookup::Complete(("loop/link", libc::S_IFLNK)));
+        // RESOLVE_NO_SYMLINKS.
+        dir_nosym: resolve_partial("b/c/d/e", rflags = NO_SYMLINKS) => Ok(PartialLookup::Complete(("b/c/d/e", libc::S_IFDIR)));
+        symlink_nosym: resolve_partial("link3/target_abs", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
+            handle: ("link3", libc::S_IFDIR),
+            remaining: "target_abs".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        symlink_component_nosym1: resolve_partial("e/f", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
+            handle: ("", libc::S_IFDIR),
+            remaining: "e/f".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        symlink_component_nosym2: resolve_partial("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
+            handle: ("link2", libc::S_IFDIR),
+            remaining: "link1_abs/target_rel".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+        loop_nosym: resolve_partial("loop/link", rflags = NO_SYMLINKS) => Ok(PartialLookup::Partial {
+            handle: ("loop", libc::S_IFDIR),
+            remaining: "link".into(),
+            last_error: ErrorKind::OsError(Some(libc::ELOOP)),
+        });
+    }
+}
+
+mod utils {
+    use crate::{
+        error::ErrorKind,
+        flags::OpenFlags,
+        resolvers::PartialLookup,
+        tests::common::{self as tests_common, LookupResult},
+        utils::FdExt,
+        Root,
+    };
+
+    use std::{os::unix::fs::MetadataExt, path::Path};
+
+    use anyhow::Error;
+    use pretty_assertions::assert_eq;
+
+    impl<H, E> PartialEq for PartialLookup<H, E>
+    where
+        H: PartialEq,
+        E: PartialEq,
+    {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (Self::Complete(left), Self::Complete(right)) => left == right,
+                (
+                    Self::Partial {
+                        handle: left_handle,
+                        remaining: left_remaining,
+                        last_error: left_last_error,
+                    },
+                    Self::Partial {
+                        handle: right_handle,
+                        remaining: right_remaining,
+                        last_error: right_last_error,
+                    },
+                ) => {
+                    left_handle == right_handle
+                        && left_remaining == right_remaining
+                        && left_last_error == right_last_error
+                }
+                _ => false,
+            }
+        }
+    }
+
+    impl<H, E> PartialLookup<H, E> {
+        fn as_inner_handle(&self) -> &H {
+            match self {
+                PartialLookup::Complete(handle) => handle,
+                PartialLookup::Partial { handle, .. } => handle,
+            }
+        }
+    }
+
+    pub(super) fn check_root_resolve_partial<P: AsRef<Path>>(
+        root: &Root,
+        unsafe_path: P,
+        no_follow_trailing: bool,
+        expected: Result<PartialLookup<LookupResult, ErrorKind>, ErrorKind>,
+    ) -> Result<(), Error> {
+        let root_dir = root.as_unsafe_path_unchecked()?;
+        let unsafe_path = unsafe_path.as_ref();
+
+        let result = root
+            .resolver
+            .resolve_partial(root, unsafe_path, no_follow_trailing)
+            .map(|lookup_result| {
+                let (path, file_type) = {
+                    let file = lookup_result.as_inner_handle();
+                    (
+                        file.as_unsafe_path_unchecked()
+                            .expect("should be able to get real path of handle"),
+                        file.metadata()
+                            .expect("should be able to fstat handle")
+                            .mode()
+                            & libc::S_IFMT,
+                    )
+                };
+
+                match lookup_result {
+                    PartialLookup::Complete(handle) => {
+                        (handle, PartialLookup::Complete((path, file_type)))
+                    }
+                    PartialLookup::Partial {
+                        handle,
+                        remaining,
+                        last_error,
+                    } => (
+                        handle,
+                        PartialLookup::Partial {
+                            handle: (path, file_type),
+                            remaining,
+                            last_error: last_error.kind(),
+                        },
+                    ),
+                }
+            });
+
+        let ((handle, lookup_result), expected_lookup_result) = match (result, expected) {
+            (Ok((handle, lookup_result)), Ok(expected_lookup_result)) => {
+                let (path, file_type) = {
+                    let (path, file_type) = expected_lookup_result.as_inner_handle();
+                    (root_dir.join(path.trim_start_matches('/')), *file_type)
+                };
+                let expected_lookup_result = match expected_lookup_result {
+                    PartialLookup::Complete(_) => PartialLookup::Complete((path, file_type)),
+                    PartialLookup::Partial {
+                        handle: _,
+                        remaining,
+                        last_error,
+                    } => PartialLookup::Partial {
+                        handle: (path, file_type),
+                        remaining,
+                        last_error,
+                    },
+                };
+
+                ((handle, lookup_result), expected_lookup_result)
+            }
+
+            (Err(err), Ok(expected)) => {
+                anyhow::bail!(
+                    "unexpected error '{}', expected successful {:?}",
+                    err,
+                    expected,
+                )
+            }
+
+            (Ok((_, lookup_result)), Err(want_err)) => anyhow::bail!(
+                "expected to get io::Error {} but instead got result {:?}",
+                tests_common::errno_description(want_err),
+                lookup_result,
+            ),
+
+            (Err(err), Err(want_err)) => {
+                assert_eq!(
+                    err.kind(),
+                    want_err,
+                    "expected io::Error {}, got '{}'",
+                    tests_common::errno_description(want_err),
+                    err,
+                );
+                return Ok(());
+            }
+        };
+
+        assert_eq!(
+            lookup_result, expected_lookup_result,
+            "partial_lookup({unsafe_path:?}, {no_follow_trailing}) result mismatch",
+        );
+
+        let (_, real_file_type) = lookup_result.as_inner_handle();
+        match *real_file_type {
+            libc::S_IFDIR => {
+                tests_common::check_reopen(&handle, OpenFlags::O_RDONLY, None)?;
+                tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, None)?;
+            }
+            libc::S_IFREG => {
+                tests_common::check_reopen(&handle, OpenFlags::O_RDWR, None)?;
+                tests_common::check_reopen(&handle, OpenFlags::O_DIRECTORY, Some(libc::ENOTDIR))?;
+            }
+            _ => {
+                tests_common::check_reopen(&handle, OpenFlags::O_PATH, None)?;
+                tests_common::check_reopen(
+                    &handle,
+                    OpenFlags::O_PATH | OpenFlags::O_DIRECTORY,
+                    Some(libc::ENOTDIR),
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -17,6 +17,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#[cfg(feature = "capi")]
+use crate::tests::capi;
 use crate::{
     error::ErrorKind,
     flags::{OpenFlags, RenameFlags},
@@ -106,6 +108,16 @@ macro_rules! root_op_tests {
                     $root_var.resolver.backend.supported(),
                     "emulated opath is always supported",
                 );
+
+                $body
+            }
+
+            $(#[$meta])*
+            #[cfg(feature = "capi")]
+            #[test]
+            fn [<capi_root_ $test_name>]() -> Result<(), Error> {
+                let root_dir = tests_common::create_basic_tree()?;
+                let $root_var = capi::CapiRoot::open(&root_dir)?;
 
                 $body
             }

--- a/src/tests/traits/error.rs
+++ b/src/tests/traits/error.rs
@@ -17,11 +17,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-mod root;
-pub(crate) use root::*;
+use crate::error::{Error, ErrorExt, ErrorKind};
 
-mod mntns;
-pub(in crate::tests) use mntns::*;
+pub(in crate::tests) trait ErrorImpl:
+    std::error::Error + ErrorExt + Send + Sync + 'static
+{
+    fn kind(&self) -> ErrorKind;
+}
 
-mod handle;
-pub(in crate::tests) use handle::*;
+impl ErrorImpl for Error {
+    fn kind(&self) -> ErrorKind {
+        self.kind()
+    }
+}

--- a/src/tests/traits/handle.rs
+++ b/src/tests/traits/handle.rs
@@ -28,6 +28,10 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
     type Cloned: HandleImpl<Error = Self::Error> + Into<OwnedFd>;
     type Error: ErrorImpl;
 
+    // Does the implementation force O_CLOEXEC for reopen() even if the user
+    // didn't ask for it?
+    const FORCED_CLOEXEC: bool;
+
     // NOTE: We return Self::Cloned so that we can share types with HandleRef.
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
 
@@ -39,6 +43,9 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
 impl HandleImpl for Handle {
     type Cloned = Handle;
     type Error = Error;
+
+    // Rust impl forces O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = true;
 
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)
@@ -57,6 +64,9 @@ impl HandleImpl for &Handle {
     type Cloned = Handle;
     type Error = Error;
 
+    // Rust impl forces O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = true;
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)
     }
@@ -74,6 +84,9 @@ impl HandleImpl for HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
 
+    // Rust impl forces O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = true;
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)
     }
@@ -90,6 +103,9 @@ impl HandleImpl for HandleRef<'_> {
 impl HandleImpl for &HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
+
+    // Rust impl forces O_CLOEXEC by default.
+    const FORCED_CLOEXEC: bool = true;
 
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd_unchecked(fd)

--- a/src/tests/traits/handle.rs
+++ b/src/tests/traits/handle.rs
@@ -1,0 +1,105 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{error::Error, flags::OpenFlags, tests::traits::ErrorImpl, Handle, HandleRef};
+
+use std::{
+    fs::File,
+    os::unix::io::{AsFd, OwnedFd},
+};
+
+pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
+    type Cloned: HandleImpl<Error = Self::Error> + Into<OwnedFd>;
+    type Error: ErrorImpl;
+
+    // NOTE: We return Self::Cloned so that we can share types with HandleRef.
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
+
+    fn reopen<Fd: Into<OpenFlags>>(&self, flags: Fd) -> Result<File, Self::Error>;
+}
+
+impl HandleImpl for Handle {
+    type Cloned = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.as_ref().try_clone().map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        self.as_ref().reopen(flags)
+    }
+}
+
+impl HandleImpl for &Handle {
+    type Cloned = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        Handle::try_clone(self).map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        Handle::reopen(self, flags)
+    }
+}
+
+impl HandleImpl for HandleRef<'_> {
+    type Cloned = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.try_clone().map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        self.reopen(flags)
+    }
+}
+
+impl HandleImpl for &HandleRef<'_> {
+    type Cloned = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd_unchecked(fd)
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        HandleRef::try_clone(self).map_err(From::from)
+    }
+
+    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+        HandleRef::reopen(self, flags)
+    }
+}

--- a/src/tests/traits/mod.rs
+++ b/src/tests/traits/mod.rs
@@ -26,5 +26,8 @@ pub(in crate::tests) use root::*;
 mod handle;
 pub(in crate::tests) use handle::*;
 
+mod procfs;
+pub(in crate::tests) use procfs::*;
+
 mod error;
 pub(in crate::tests) use error::*;

--- a/src/tests/traits/mod.rs
+++ b/src/tests/traits/mod.rs
@@ -17,11 +17,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-mod root;
-pub(crate) use root::*;
+// TODO: Unless we can figure out a way to get Deref working, we might want to
+//       have these traits be included in the actual library...
 
-mod mntns;
-pub(in crate::tests) use mntns::*;
+mod root;
+pub(in crate::tests) use root::*;
 
 mod handle;
 pub(in crate::tests) use handle::*;
+
+mod error;
+pub(in crate::tests) use error::*;

--- a/src/tests/traits/procfs.rs
+++ b/src/tests/traits/procfs.rs
@@ -1,0 +1,84 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::Error,
+    flags::OpenFlags,
+    procfs::{ProcfsBase, ProcfsHandle},
+    tests::traits::ErrorImpl,
+};
+
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+pub(in crate::tests) trait ProcfsHandleImpl: std::fmt::Debug {
+    type Error: ErrorImpl;
+
+    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error>;
+
+    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error>;
+
+    fn readlink<P: AsRef<Path>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+    ) -> Result<PathBuf, Self::Error>;
+}
+
+impl ProcfsHandleImpl for ProcfsHandle {
+    type Error = Error;
+
+    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error> {
+        self.open_follow(base, subpath, flags)
+    }
+
+    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+        flags: F,
+    ) -> Result<File, Self::Error> {
+        self.open(base, subpath, flags)
+    }
+
+    fn readlink<P: AsRef<Path>>(
+        &self,
+        base: ProcfsBase,
+        subpath: P,
+    ) -> Result<PathBuf, Self::Error> {
+        self.readlink(base, subpath)
+    }
+}

--- a/src/tests/traits/root.rs
+++ b/src/tests/traits/root.rs
@@ -1,0 +1,374 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::Error,
+    flags::{OpenFlags, RenameFlags},
+    tests::traits::{ErrorImpl, HandleImpl},
+    Handle, InodeType, Resolver, Root, RootRef,
+};
+
+use std::{
+    fs::Permissions,
+    os::unix::io::{AsFd, OwnedFd},
+    path::{Path, PathBuf},
+};
+
+pub(in crate::tests) trait RootImpl: AsFd + std::fmt::Debug + Sized {
+    type Cloned: RootImpl<Error = Self::Error> + Into<OwnedFd>;
+    type Handle: HandleImpl<Error = Self::Error> + Into<OwnedFd>;
+    type Error: ErrorImpl;
+
+    // NOTE: We return Self::Cloned so that we can share types with RootRef.
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned;
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
+
+    fn resolver(&self) -> Resolver;
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error>;
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error>;
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error>;
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error>;
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error>;
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error>;
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error>;
+}
+
+impl RootImpl for Root {
+    type Cloned = Root;
+    type Handle = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        let mut root = Self::Cloned::from_fd_unchecked(fd);
+        root.resolver = resolver;
+        root
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.try_clone().map_err(From::from)
+    }
+
+    fn resolver(&self) -> Resolver {
+        self.resolver
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve(path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve_nofollow(path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        self.readlink(path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        self.create(path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.create_file(path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.mkdir_all(path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_dir(path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_file(path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_all(path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        self.rename(source, destination, rflags)
+    }
+}
+
+impl RootImpl for &Root {
+    type Cloned = Root;
+    type Handle = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        let mut root = Self::Cloned::from_fd_unchecked(fd);
+        root.resolver = resolver;
+        root
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        Root::try_clone(self).map_err(From::from)
+    }
+
+    fn resolver(&self) -> Resolver {
+        self.resolver
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        Root::resolve(self, path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        Root::resolve_nofollow(self, path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        Root::readlink(self, path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        Root::create(self, path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        Root::create_file(self, path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        Root::mkdir_all(self, path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        Root::remove_dir(self, path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        Root::remove_file(self, path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        Root::remove_all(self, path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        Root::rename(self, source, destination, rflags)
+    }
+}
+
+impl RootImpl for RootRef<'_> {
+    type Cloned = Root;
+    type Handle = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        let mut root = Self::Cloned::from_fd_unchecked(fd);
+        root.resolver = resolver;
+        root
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        self.try_clone().map_err(From::from)
+    }
+
+    fn resolver(&self) -> Resolver {
+        self.resolver
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve(path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        self.resolve_nofollow(path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        self.readlink(path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        self.create(path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.create_file(path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        self.mkdir_all(path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_dir(path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_file(path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.remove_all(path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        self.rename(source, destination, rflags)
+    }
+}
+
+impl RootImpl for &RootRef<'_> {
+    type Cloned = Root;
+    type Handle = Handle;
+    type Error = Error;
+
+    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        let mut root = Self::Cloned::from_fd_unchecked(fd);
+        root.resolver = resolver;
+        root
+    }
+
+    fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
+        RootRef::try_clone(self).map_err(From::from)
+    }
+
+    fn resolver(&self) -> Resolver {
+        self.resolver
+    }
+
+    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        RootRef::resolve(self, path)
+    }
+
+    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+        RootRef::resolve_nofollow(self, path)
+    }
+
+    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+        RootRef::readlink(self, path)
+    }
+
+    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+        RootRef::create(self, path, inode_type)
+    }
+
+    fn create_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        flags: OpenFlags,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        RootRef::create_file(self, path, flags, perm)
+    }
+
+    fn mkdir_all<P: AsRef<Path>>(
+        &self,
+        path: P,
+        perm: &Permissions,
+    ) -> Result<Self::Handle, Self::Error> {
+        RootRef::mkdir_all(self, path, perm)
+    }
+
+    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        RootRef::remove_dir(self, path)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        RootRef::remove_file(self, path)
+    }
+
+    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        RootRef::remove_all(self, path)
+    }
+
+    fn rename<P: AsRef<Path>>(
+        &self,
+        source: P,
+        destination: P,
+        rflags: RenameFlags,
+    ) -> Result<(), Self::Error> {
+        RootRef::rename(self, source, destination, rflags)
+    }
+}


### PR DESCRIPTION
There's no need to include the capi code for Rust crates. This also
matches what cargo-c does, so we can easily switch without too many
changes, though for now we can just keep using our own scripts.

Part of making this opt-in means we only add the cdylib and staticlib
crate types if building with that feature enabled.

Fixes #53 
Fixes #46
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>