### PR TITLE
opath resolver: implement fs.protected_symlinks emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `mkdir_all` so that Go users can switch from `os.MkdirAll`. This is based
     on similar work done in [filepath-securejoin][].
 
+- opath resolver: We now emulate `fs.protected_symlinks` when resolving
+  symlinks using the emulated opath resolver. This is only done if
+  `fs.protected_symlinks` is enabled on the system (to mirror the behaviour of
+  `openat2`).
+
 - tests: Add a large number of integration tests, mainly based on the test
   suite in [filepath-securejoin][]. This test suite tests all of the Rust code
   and the C FFI code from within Rust, giving us ~89% test coverage.

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -61,6 +61,7 @@ impl From<CProcfsBase> for ProcfsBase {
     }
 }
 
+#[cfg(test)]
 impl From<ProcfsBase> for CProcfsBase {
     fn from(base: ProcfsBase) -> Self {
         match base {

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -34,9 +34,10 @@ macro_rules! resolve_tests {
     //          test_err: resolve(...) => Err(ErrorKind::...)
     //      }
     // }
-    ([$root_dir:expr] rust-fn $test_name:ident (mut $root_var:ident : Root) $body:block => $expected:expr) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* rust-fn $test_name:ident (mut $root_var:ident : Root) $body:block => $expected:expr) => {
         paste::paste! {
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _default>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
@@ -49,6 +50,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<rootref_ $test_name _default>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let root = Root::open(&root_dir)?;
@@ -62,6 +64,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
@@ -79,6 +82,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<rootref_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let root = Root::open(&root_dir)?;
@@ -97,6 +101,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let mut $root_var = Root::open(&root_dir)?;
@@ -115,6 +120,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<rootref_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let root = Root::open(&root_dir)?;
@@ -135,10 +141,11 @@ macro_rules! resolve_tests {
         }
     };
 
-    ([$root_dir:expr] capi-fn $test_name:ident ($root_var:ident : CapiRoot) $body:block => $expected:expr) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* capi-fn $test_name:ident ($root_var:ident : CapiRoot) $body:block => $expected:expr) => {
         paste::paste! {
             #[cfg(feature = "capi")]
             #[test]
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<capi_root_ $test_name>]() -> Result<(), Error> {
                 let root_dir = $root_dir;
                 let $root_var = CapiRoot::open(&root_dir)?;
@@ -152,10 +159,11 @@ macro_rules! resolve_tests {
         }
     };
 
-    ([$root_dir:expr] @rust-impl $test_name:ident $op_name:ident ($path:expr, $rflags:expr, $no_follow_trailing:expr) => $expected:expr) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* @rust-impl $test_name:ident $op_name:ident ($path:expr, $rflags:expr, $no_follow_trailing:expr) => $expected:expr) => {
         paste::paste! {
             resolve_tests! {
                 [$root_dir]
+                $(#[cfg($ignore_meta)])*
                 rust-fn [<$op_name _ $test_name>](mut root: Root) {
                     root.resolver.flags = $rflags;
 
@@ -171,10 +179,11 @@ macro_rules! resolve_tests {
         }
     };
 
-    ([$root_dir:expr] @capi-impl $test_name:ident $op_name:ident ($path:expr, $no_follow_trailing:expr) => $expected:expr) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* @capi-impl $test_name:ident $op_name:ident ($path:expr, $no_follow_trailing:expr) => $expected:expr) => {
         paste::paste! {
             resolve_tests! {
                 [$root_dir]
+                $(#[cfg($ignore_meta)])*
                 capi-fn [<$op_name _ $test_name>](root: CapiRoot) {
                     let expected = $expected;
                     utils::[<check_root_ $op_name>](
@@ -188,40 +197,46 @@ macro_rules! resolve_tests {
         }
     };
 
-    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, rflags = $($rflag:ident)|+) => $expected:expr ) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* @impl $test_name:ident $op_name:ident ($path:expr, rflags = $($rflag:ident)|+) => $expected:expr ) => {
         resolve_tests! {
             [$root_dir]
+            $(#[cfg($ignore_meta)])*
             @rust-impl $test_name $op_name($path, $(ResolverFlags::$rflag)|*, false) => $expected
         }
         // The C API doesn't support custom ResolverFlags.
     };
 
-    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr, no_follow_trailing = $no_follow_trailing:expr) => $expected:expr ) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* @impl $test_name:ident $op_name:ident ($path:expr, no_follow_trailing = $no_follow_trailing:expr) => $expected:expr ) => {
         resolve_tests! {
             [$root_dir]
+            $(#[cfg($ignore_meta)])*
             @rust-impl $test_name $op_name($path, ResolverFlags::empty(), $no_follow_trailing) => $expected
         }
         resolve_tests! {
             [$root_dir]
+            $(#[cfg($ignore_meta)])*
             @capi-impl $test_name $op_name($path, $no_follow_trailing) => $expected
         }
     };
 
-    ([$root_dir:expr] @impl $test_name:ident $op_name:ident ($path:expr) => $expected:expr ) => {
+    ([$root_dir:expr] $(#[cfg($ignore_meta:meta)])* @impl $test_name:ident $op_name:ident ($path:expr) => $expected:expr ) => {
         resolve_tests! {
             [$root_dir]
+            $(#[cfg($ignore_meta)])*
             @rust-impl $test_name $op_name($path, ResolverFlags::empty(), false) => $expected
         }
         resolve_tests! {
             [$root_dir]
+            $(#[cfg($ignore_meta)])*
             @capi-impl $test_name $op_name($path, false) => $expected
         }
     };
 
-    ($([$root_dir:expr] { $($test_name:ident : $op_name:ident ($($args:tt)*) => $expected:expr);* $(;)? });* $(;)?) => {
+    ($([$root_dir:expr] { $($(#[cfg($ignore_meta:meta)])* $test_name:ident : $op_name:ident ($($args:tt)*) => $expected:expr);* $(;)? });* $(;)?) => {
         $( $(
             resolve_tests! {
                 [$root_dir]
+                $(#[cfg($ignore_meta)])*
                 @impl $test_name $op_name ($($args)*) => $expected
             }
         )* )*
@@ -394,6 +409,46 @@ resolve_tests! {
         symlink_component_nosym1: resolve("e/f", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
         symlink_component_nosym2: resolve("link2/link1_abs/target_rel", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
         loop_nosym: resolve("loop/link", rflags = NO_SYMLINKS) => Err(ErrorKind::OsError(Some(libc::ELOOP)));
+        // fs.protected_symlinks for a directory owned by us.
+        protected_symlinks_selfdir_selfsym: resolve("tmpfs-self/link-self") => Ok(("tmpfs-self/file", libc::S_IFREG));
+        protected_symlinks_selfdir_selfsym_nofollow: resolve("tmpfs-self/link-self", no_follow_trailing = true) => Ok(("tmpfs-self/link-self", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_otheruidsym: resolve("tmpfs-self/link-otheruid") => Err(ErrorKind::OsError(Some(libc::EACCES)));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_otheruidsym_nofollow: resolve("tmpfs-self/link-otheruid", no_follow_trailing = true) => Ok(("tmpfs-self/link-otheruid", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_othergidsym: resolve("tmpfs-self/link-othergid") => Ok(("tmpfs-self/file", libc::S_IFREG));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_othergidsym_nofollow: resolve("tmpfs-self/link-othergid", no_follow_trailing = true) => Ok(("tmpfs-self/link-othergid", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_othersym: resolve("tmpfs-self/link-other") => Err(ErrorKind::OsError(Some(libc::EACCES)));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_selfdir_othersym_nofollow: resolve("tmpfs-self/link-other", no_follow_trailing = true) => Ok(("tmpfs-self/link-other", libc::S_IFLNK));
+        // fs.protected_symlinks for a directory owned by someone else.
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_selfsym: resolve("tmpfs-other/link-self") => Ok(("tmpfs-other/file", libc::S_IFREG));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_selfsym_nofollow: resolve("tmpfs-other/link-self", no_follow_trailing = true) => Ok(("tmpfs-other/link-self", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_selfuidsym: resolve("tmpfs-other/link-selfuid") => Ok(("tmpfs-other/file", libc::S_IFREG));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_selfuidsym_nofollow: resolve("tmpfs-other/link-selfuid", no_follow_trailing = true) => Ok(("tmpfs-other/link-selfuid", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_ownersym: resolve("tmpfs-other/link-owner") => Ok(("tmpfs-other/file", libc::S_IFREG));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_ownersym_nofollow: resolve("tmpfs-other/link-owner", no_follow_trailing = true) => Ok(("tmpfs-other/link-owner", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_otheruidsym: resolve("tmpfs-other/link-otheruid") => Err(ErrorKind::OsError(Some(libc::EACCES)));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_otheruidsym_nofollow: resolve("tmpfs-other/link-otheruid", no_follow_trailing = true) => Ok(("tmpfs-other/link-otheruid", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_othergidsym: resolve("tmpfs-other/link-othergid") => Ok(("tmpfs-other/file", libc::S_IFREG));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_othergidsym_nofollow: resolve("tmpfs-other/link-othergid", no_follow_trailing = true) => Ok(("tmpfs-other/link-othergid", libc::S_IFLNK));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_othersym: resolve("tmpfs-other/link-other") => Err(ErrorKind::OsError(Some(libc::EACCES)));
+        #[cfg(feature = "_test_as_root")]
+        protected_symlinks_otherdir_othersym_nofollow: resolve("tmpfs-other/link-other", no_follow_trailing = true) => Ok(("tmpfs-other/link-other", libc::S_IFLNK));
     }
 }
 
@@ -440,11 +495,7 @@ mod utils {
             ),
 
             (Err(err), Ok((expected_path, _))) => {
-                anyhow::bail!(
-                    "unexpected error '{}', expected file {}",
-                    err,
-                    expected_path
-                )
+                anyhow::bail!("unexpected error '{err:?}', expected file {expected_path:?}",)
             }
 
             (Ok(handle), Err(want_err)) => anyhow::bail!(
@@ -457,9 +508,8 @@ mod utils {
                 assert_eq!(
                     err.kind(),
                     want_err,
-                    "expected io::Error {}, got '{}'",
+                    "expected io::Error {}, got '{err:?}'",
                     tests_common::errno_description(want_err),
-                    err,
                 );
                 return Ok(());
             }

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -754,26 +754,20 @@ mod utils {
             }
 
             (Err(err), Ok(expected)) => {
-                anyhow::bail!(
-                    "unexpected error '{}', expected successful {:?}",
-                    err,
-                    expected,
-                )
+                anyhow::bail!("unexpected error '{err:?}', expected successful {expected:?}",)
             }
 
             (Ok((_, lookup_result)), Err(want_err)) => anyhow::bail!(
-                "expected to get io::Error {} but instead got result {:?}",
+                "expected to get io::Error {} but instead got result {lookup_result:?}",
                 tests_common::errno_description(want_err),
-                lookup_result,
             ),
 
             (Err(err), Err(want_err)) => {
                 assert_eq!(
                     err.kind(),
                     want_err,
-                    "expected io::Error {}, got '{}'",
+                    "expected io::Error {}, got '{err:?}'",
                     tests_common::errno_description(want_err),
-                    err,
                 );
                 return Ok(());
             }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,3 +30,6 @@ pub(crate) use fd::*;
 
 mod umask;
 pub(crate) use umask::*;
+
+mod sysctl;
+pub(crate) use sysctl::*;

--- a/src/utils/sysctl.rs
+++ b/src/utils/sysctl.rs
@@ -1,0 +1,132 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    error::{Error, ErrorExt, ErrorImpl},
+    flags::OpenFlags,
+    procfs::ProcfsHandle,
+};
+
+use std::{
+    io::{BufRead, BufReader},
+    path::PathBuf,
+    str::FromStr,
+};
+
+pub(crate) fn sysctl_read_line(procfs: &ProcfsHandle, sysctl: &str) -> Result<String, Error> {
+    // "/proc/sys"
+    let mut sysctl_path = PathBuf::from("sys");
+    // Convert "foo.bar.baz" to "foo/bar/baz".
+    sysctl_path.push(sysctl.replace(".", "/"));
+
+    let sysctl_file = procfs.open_raw(sysctl_path, OpenFlags::O_RDONLY)?;
+
+    // Just read the first line.
+    let mut reader = BufReader::new(sysctl_file);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|err| ErrorImpl::OsError {
+            operation: format!("read first line of {sysctl:?} sysctl").into(),
+            source: err,
+        })?;
+
+    // Strip newlines.
+    Ok(line.trim_end_matches("\n").into())
+}
+
+pub(crate) fn sysctl_read_parse<T>(procfs: &ProcfsHandle, sysctl: &str) -> Result<T, Error>
+where
+    T: FromStr,
+    Error: From<T::Err>,
+{
+    sysctl_read_line(procfs, sysctl).and_then(|s| {
+        s.parse()
+            .map_err(Error::from)
+            .with_wrap(|| format!("could not parse int sysctl {sysctl:?}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        error::{Error, ErrorKind},
+        procfs::GLOBAL_PROCFS_HANDLE,
+    };
+
+    #[test]
+    fn bad_sysctl_file_noexist() {
+        assert!(matches!(
+            super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "nonexistent.dummy.sysctl.path")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::OsError(Some(libc::ENOENT)))
+        ));
+        assert!(matches!(
+            super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "nonexistent.sysctl.path")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::OsError(Some(libc::ENOENT)))
+        ));
+    }
+
+    #[test]
+    fn bad_sysctl_file_noread() {
+        assert!(matches!(
+            super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "vm.drop_caches")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::OsError(Some(libc::EACCES)))
+        ));
+        assert!(matches!(
+            super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "vm.drop_caches")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::OsError(Some(libc::EACCES)))
+        ));
+    }
+
+    #[test]
+    fn bad_sysctl_parse_invalid_multinumber() {
+        assert!(super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "kernel.printk").is_ok());
+        assert!(matches!(
+            super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.printk")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::ParseError)
+        ));
+    }
+
+    #[test]
+    fn bad_sysctl_parse_invalid_nonnumber() {
+        assert!(super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "kernel.random.uuid").is_ok());
+        assert!(matches!(
+            super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.random.uuid")
+                .as_ref()
+                .map_err(Error::kind),
+            Err(ErrorKind::ParseError)
+        ));
+    }
+
+    #[test]
+    fn sysctl_parse_int() {
+        assert!(super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "kernel.pid_max").is_ok());
+        assert!(super::sysctl_read_parse::<u64>(&GLOBAL_PROCFS_HANDLE, "kernel.pid_max").is_ok());
+    }
+}


### PR DESCRIPTION
Because we resolve symlinks in userspace, fs.protected_symlinks doesn't
get applied by the kernel to our lookups. While it's not really clear
whether this is really necessary for scoped lookups, for consistency we
should just emulate may_follow_link().

Unfortunately, checking fs.protected_symlinks requires looking at
/proc/sys which can't be done with the currently-exposed ProcfsHandle
API so we have to create a private API for that (until we come up with a
nicer one for users to use). This also means that we can no longer apply
"subset=pid" to fsopen-based procfs handles.

Fixes #58
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>