### PR TITLE
root: move to get/set model for configuring resolver flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `mkdir_all` so that Go users can switch from `os.MkdirAll`. This is based
     on similar work done in [filepath-securejoin][].
 
+- root: The method for configuring the resolver has changed to be more akin to
+  a getter-setter style. This allows for more ergonomic usage (see the
+  `RootRef::with_resolver_flags` examples) and also lets us avoid exposing
+  internal types needlessly.
+
+  As part of this change, the ability to choose the resolver backend was
+  removed (because the C API also no longer supports it). This will probably be
+  re-added in the future, but for now it seems best to not add extra APIs that
+  aren't necessary until someone asks.
+
 - opath resolver: We now emulate `fs.protected_symlinks` when resolving
   symlinks using the emulated opath resolver. This is only done if
   `fs.protected_symlinks` is enabled on the system (to mirror the behaviour of

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -17,6 +17,10 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#![forbid(unsafe_code)]
+
+//! Bit-flags for modifying the behaviour of libpathrs.
+
 use crate::syscalls;
 
 bitflags! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,9 @@ pub use root::*;
 pub mod error;
 pub mod flags;
 pub mod procfs;
-pub mod resolvers;
+
+// Resolver backend implementations.
+mod resolvers;
 
 // C API.
 #[cfg(feature = "capi")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,6 @@ extern crate lazy_static;
 extern crate libc;
 extern crate regex;
 
-/// Bit-flags for controlling various operations.
-pub mod flags;
-
 // `Handle` implementation.
 mod handle;
 #[doc(inline)]
@@ -144,16 +141,10 @@ mod root;
 #[doc(inline)]
 pub use root::*;
 
-// `Error` definitions.
 pub mod error;
-
-// Backend resolver implementations.
-mod resolvers;
-#[doc(inline)]
-pub use resolvers::{Resolver, ResolverBackend};
-
-/// Safe procfs handles.
+pub mod flags;
 pub mod procfs;
+pub mod resolvers;
 
 // C API.
 #[cfg(feature = "capi")]

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -19,6 +19,8 @@
 
 #![forbid(unsafe_code)]
 
+//! Helpers to operate on `procfs` safely.
+
 use crate::{
     error::{Error, ErrorExt, ErrorImpl},
     flags::{OpenFlags, ResolverFlags},

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -19,6 +19,8 @@
 
 #![forbid(unsafe_code)]
 
+//! Resolver implementations for libpathrs.
+
 use crate::{
     error::{Error, ErrorKind},
     flags::ResolverFlags,
@@ -32,9 +34,9 @@ use std::{
 };
 
 /// `O_PATH`-based userspace resolver.
-pub mod opath;
+pub(crate) mod opath;
 /// `openat2(2)`-based in-kernel resolver.
-pub mod openat2;
+pub(crate) mod openat2;
 /// A limited resolver only used for `/proc` lookups in `ProcfsHandle`.
 pub(crate) mod procfs;
 

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -53,7 +53,7 @@ const MAX_SYMLINK_TRAVERSALS: usize = 128;
 /// [`Handle`]: crate::Handle
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum ResolverBackend {
+pub(crate) enum ResolverBackend {
     /// Use the native `openat2(2)` backend (requires kernel support).
     KernelOpenat2,
     /// Use the userspace "emulated" backend.
@@ -81,7 +81,8 @@ impl Default for ResolverBackend {
 
 impl ResolverBackend {
     /// Checks if the resolver is supported on the current platform.
-    pub fn supported(self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn supported(self) -> bool {
         match self {
             ResolverBackend::KernelOpenat2 => *syscalls::OPENAT2_IS_SUPPORTED,
             ResolverBackend::EmulatedOpath => true,
@@ -92,14 +93,13 @@ impl ResolverBackend {
 /// Resolover backend and its associated flags.
 ///
 /// This is the primary structure used to configure how a given [`Root`] will
-/// conduct path resolutions. It's not recommended to change the
-/// [`ResolverBackend`] but it wouldn't hurt.
+/// conduct path resolutions.
 ///
 /// [`Root`]: crate::Root
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Resolver {
     /// Underlying resolution backend used.
-    pub backend: ResolverBackend,
+    pub(crate) backend: ResolverBackend,
     /// Flags to pass to the resolution backend.
     pub flags: ResolverFlags,
 }

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -17,11 +17,13 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-//! `procfs_beneath::resolve` is a very minimal resolver that doesn't allow:
 //!
-//!  1. Any ".." components.
+//! [`ProcfsResolver`](crate::resolvers::procfs::ProcfsResolver) is a very
+//! minimal resolver that doesn't allow:
+//!
+//!  1. Any ".." components (with `openat2` this is slightly relaxed).
 //!  2. Any absolute symlinks.
-//!  3. (If `statx` is supported), any mount-point crossings are disallowed.
+//!  3. (If `statx` or `openat2` is supported), any mount-point crossings.
 //!
 //! This allows us to avoid using any `/proc` checks, and thus this resolver can
 //! be used within the `pathrs::procfs` helpers that are used by other parts of
@@ -94,6 +96,9 @@ impl ProcfsResolver {
     }
 }
 
+/// [`openat2`][openat2.2]-based implementation of [`ProcfsResolver`].
+///
+/// [openat2.2]: https://www.man7.org/linux/man-pages/man2/openat2.2.html
 fn openat2_resolve<F: AsFd, P: AsRef<Path>>(
     root: F,
     path: P,
@@ -129,6 +134,7 @@ fn openat2_resolve<F: AsFd, P: AsRef<Path>>(
     })
 }
 
+/// `O_PATH`-based implementation of [`ProcfsResolver`].
 fn opath_resolve<F: AsFd, P: AsRef<Path>>(
     root: F,
     path: P,

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -20,6 +20,7 @@
 use crate::{
     capi,
     flags::{OpenFlags, RenameFlags},
+    resolvers::Resolver,
     tests::{
         capi::{
             utils::{self as capi_utils, CapiError},
@@ -27,7 +28,7 @@ use crate::{
         },
         traits::{HandleImpl, RootImpl},
     },
-    InodeType, Resolver,
+    InodeType,
 };
 
 use std::{

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -20,7 +20,8 @@
 #[cfg(feature = "capi")]
 use crate::tests::capi::CapiRoot;
 use crate::{
-    error::ErrorKind, flags::ResolverFlags, tests::common as tests_common, ResolverBackend, Root,
+    error::ErrorKind, flags::ResolverFlags, resolvers::ResolverBackend,
+    tests::common as tests_common, Root,
 };
 
 use std::path::Path;

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -18,8 +18,8 @@
  */
 
 use crate::{
-    error::ErrorKind, flags::ResolverFlags, resolvers::PartialLookup,
-    tests::common as tests_common, ResolverBackend, Root,
+    error::ErrorKind, flags::ResolverFlags, resolvers::PartialLookup, resolvers::ResolverBackend,
+    tests::common as tests_common, Root,
 };
 
 use anyhow::Error;

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -22,8 +22,9 @@ use crate::tests::capi;
 use crate::{
     error::ErrorKind,
     flags::{OpenFlags, RenameFlags},
+    resolvers::ResolverBackend,
     tests::common as tests_common,
-    InodeType, ResolverBackend, Root,
+    InodeType, Root,
 };
 
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -57,9 +57,9 @@ macro_rules! root_op_tests {
             #[test]
             fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
-                let mut $root_var = Root::open(&root_dir)?;
-                $root_var.resolver.backend = ResolverBackend::KernelOpenat2;
-                if !$root_var.resolver.backend.supported() {
+                let $root_var = Root::open(&root_dir)?
+                    .with_resolver_backend(ResolverBackend::KernelOpenat2);
+                if !$root_var.resolver_backend().supported() {
                     // Skip if not supported.
                     return Ok(());
                 }
@@ -72,9 +72,10 @@ macro_rules! root_op_tests {
             fn [<rootref_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let root = Root::open(&root_dir)?;
-                let mut $root_var = root.as_ref();
-                $root_var.resolver.backend = ResolverBackend::KernelOpenat2;
-                if !$root_var.resolver.backend.supported() {
+                let $root_var = root
+                    .as_ref()
+                    .with_resolver_backend(ResolverBackend::KernelOpenat2);
+                if !$root_var.resolver_backend().supported() {
                     // Skip if not supported.
                     return Ok(());
                 }
@@ -86,11 +87,11 @@ macro_rules! root_op_tests {
             #[test]
             fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
-                let mut $root_var = Root::open(&root_dir)?;
-                $root_var.resolver.backend = ResolverBackend::EmulatedOpath;
+                let $root_var = Root::open(&root_dir)?
+                    .with_resolver_backend(ResolverBackend::EmulatedOpath);
                 // EmulatedOpath is always supported.
                 assert!(
-                    $root_var.resolver.backend.supported(),
+                    $root_var.resolver_backend().supported(),
                     "emulated opath is always supported",
                 );
 
@@ -102,11 +103,12 @@ macro_rules! root_op_tests {
             fn [<rootref_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let root = Root::open(&root_dir)?;
-                let mut $root_var = root.as_ref();
-                $root_var.resolver.backend = ResolverBackend::EmulatedOpath;
+                let $root_var = root
+                    .as_ref()
+                    .with_resolver_backend(ResolverBackend::EmulatedOpath);
                 // EmulatedOpath is always supported.
                 assert!(
-                    $root_var.resolver.backend.supported(),
+                    $root_var.resolver_backend().supported(),
                     "emulated opath is always supported",
                 );
 

--- a/src/tests/traits/root.rs
+++ b/src/tests/traits/root.rs
@@ -20,8 +20,9 @@
 use crate::{
     error::Error,
     flags::{OpenFlags, RenameFlags},
+    resolvers::Resolver,
     tests::traits::{ErrorImpl, HandleImpl},
-    Handle, InodeType, Resolver, Root, RootRef,
+    Handle, InodeType, Root, RootRef,
 };
 
 use std::{

--- a/src/tests/traits/root.rs
+++ b/src/tests/traits/root.rs
@@ -36,12 +36,13 @@ pub(in crate::tests) trait RootImpl: AsFd + std::fmt::Debug + Sized {
     type Handle: HandleImpl<Error = Self::Error> + Into<OwnedFd>;
     type Error: ErrorImpl;
 
+    // NOTE:: Not part of the actual API, only used for tests!
+    fn resolver(&self) -> Resolver;
+
     // NOTE: We return Self::Cloned so that we can share types with RootRef.
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned;
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
-
-    fn resolver(&self) -> Resolver;
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error>;
 
@@ -83,18 +84,21 @@ impl RootImpl for Root {
     type Handle = Handle;
     type Error = Error;
 
+    fn resolver(&self) -> Resolver {
+        Resolver {
+            backend: self.resolver_backend(),
+            flags: self.resolver_flags(),
+        }
+    }
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        let mut root = Self::Cloned::from_fd_unchecked(fd);
-        root.resolver = resolver;
-        root
+        Self::Cloned::from_fd_unchecked(fd)
+            .with_resolver_backend(resolver.backend)
+            .with_resolver_flags(resolver.flags)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
         self.try_clone().map_err(From::from)
-    }
-
-    fn resolver(&self) -> Resolver {
-        self.resolver
     }
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
@@ -157,18 +161,21 @@ impl RootImpl for &Root {
     type Handle = Handle;
     type Error = Error;
 
+    fn resolver(&self) -> Resolver {
+        Resolver {
+            backend: self.resolver_backend(),
+            flags: self.resolver_flags(),
+        }
+    }
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        let mut root = Self::Cloned::from_fd_unchecked(fd);
-        root.resolver = resolver;
-        root
+        Self::Cloned::from_fd_unchecked(fd)
+            .with_resolver_backend(resolver.backend)
+            .with_resolver_flags(resolver.flags)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
         Root::try_clone(self).map_err(From::from)
-    }
-
-    fn resolver(&self) -> Resolver {
-        self.resolver
     }
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
@@ -231,18 +238,21 @@ impl RootImpl for RootRef<'_> {
     type Handle = Handle;
     type Error = Error;
 
+    fn resolver(&self) -> Resolver {
+        Resolver {
+            backend: self.resolver_backend(),
+            flags: self.resolver_flags(),
+        }
+    }
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        let mut root = Self::Cloned::from_fd_unchecked(fd);
-        root.resolver = resolver;
-        root
+        Self::Cloned::from_fd_unchecked(fd)
+            .with_resolver_backend(resolver.backend)
+            .with_resolver_flags(resolver.flags)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
         self.try_clone().map_err(From::from)
-    }
-
-    fn resolver(&self) -> Resolver {
-        self.resolver
     }
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
@@ -305,18 +315,21 @@ impl RootImpl for &RootRef<'_> {
     type Handle = Handle;
     type Error = Error;
 
+    fn resolver(&self) -> Resolver {
+        Resolver {
+            backend: self.resolver_backend(),
+            flags: self.resolver_flags(),
+        }
+    }
+
     fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        let mut root = Self::Cloned::from_fd_unchecked(fd);
-        root.resolver = resolver;
-        root
+        Self::Cloned::from_fd_unchecked(fd)
+            .with_resolver_backend(resolver.backend)
+            .with_resolver_flags(resolver.flags)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
         RootRef::try_clone(self).map_err(From::from)
-    }
-
-    fn resolver(&self) -> Resolver {
-        self.resolver
     }
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {


### PR DESCRIPTION
This is modelled after a builder pattern, and it allows some for more
erngomic usage of flags in one-liners and temporarily for a few
commands.

```rust
let root = Root::open(rootdir)?;

// Apply ResolverFlags::NO_SYMLINKS for a single operation.
root.as_ref()
    .with_resolver_flags(ResolverFlags::NO_SYMLINKS)
    .mkdir_all("foo/bar/baz", &perm)?;

// Create a temporary RootRef to do multiple operations.
let root2 = root
    .as_ref()
    .with_resolver_flags(ResolverFlags::NO_SYMLINKS);
root2.create("one", &InodeType::Directory(perm))?;
root2.remove_all("foo")?;
```

Fixes #24
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>