### PR TITLE
Manual parser for umask values.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,6 @@ lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
 rand = { version = "^0.8", optional = true }
-# MSRV(1.65): Use regex >= 1.10.
-regex = "1.9.*"
 rustix = { version = "^0.38", features = ["fs"] }
 thiserror = "^1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
-extern crate regex;
 
 // `Handle` implementation.
 mod handle;

--- a/src/utils/umask.rs
+++ b/src/utils/umask.rs
@@ -30,7 +30,6 @@ use std::{
 };
 
 use libc::mode_t;
-use regex::Regex;
 
 /// Get the current process's umask from `/proc/thread-self/status`.
 // There has been a Umask: field in /proc/self/status since Linux 4.7.
@@ -39,14 +38,6 @@ use regex::Regex;
 //NOTE: While the umask is shared between threads, it unshared with `CLONE_FS`
 //      so a single thread could have a different umask to other threads.
 fn get_umask_procfs(procfs: &ProcfsHandle) -> Result<Option<mode_t>, Error> {
-    // MSRV(1.70): Use OnceLock.
-    // MSRV(1.80): Use LazyLock.
-    // TODO: Figure out if we even need to use a regex for this. Surely there's
-    //       something like sscanf which works properly in Rust...
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r"^Umask:\s*(0[0-7]+)$").unwrap();
-    }
-
     let status_file = procfs.open(ProcfsBase::ProcThreadSelf, "status", OpenFlags::O_RDONLY)?;
     let reader = BufReader::new(status_file);
     for line in reader.lines() {
@@ -54,11 +45,9 @@ fn get_umask_procfs(procfs: &ProcfsHandle) -> Result<Option<mode_t>, Error> {
             operation: "read lines from /proc/self/status".into(),
             source: err,
         })?;
-        // MSRV(1.65): Use let-else here.
-        if let Some((_, [umask])) = RE.captures(&line).map(|caps| caps.extract()) {
-            return Ok(Some(
-                mode_t::from_str_radix(umask, 8).expect("parsing 0[0-7]+ octal should work"),
-            ));
+
+        if let Some(umask) = line.strip_prefix("Umask:") {
+            return Ok(mode_t::from_str_radix(umask.trim(), 8).ok());
         }
     }
     Ok(None)


### PR DESCRIPTION
This patch changes the implementation of `get_umask_procfs` to avoid the dependency on the `regex` crate.

The original expression `^Umask:\s*(0[0-7]+)$` is implemented as:

```rust
if let Some(umask) = line.strip_prefix("Umask:") {
    return Ok(mode_t::from_str_radix(umask.trim(), 8).ok());
}
```

The previous code was using `expect` to get the result from `from_str_radix`. Now it just converts the `Result` from `from_str_radix` to an `Option`. The logic is different, but the behaviour is the same:

* If the value is correct (like `Umask: 0022`), both `Ok(Some(from_str_radix().expect()))` and  `Ok(from_str_radix().ok())` returns the same value.
* If the value is unexpected (like `Umask: 0999`),
    * The previous code will ignore the line (it does not match the regular expression), and will return `Ok(None)` after reading the `/proc/self/status` file.
    * The new code will try to parse `0999` as an octal. It will return an error, which is then converted to `None` by `ok()`.

## Build Improvements

After removing the `regex` crate, the size of the library and the compilation time improve significantly. 

|                     |  Before |     Now |
|---------------------|--------:|--------:|
| `libpathrs.so` size | `2.2 M` | `608 K` |
| Build time          |  `36 s` |  `16 s` |

* Before the patch:

    ```console
    $ hyperfine -w 1 -r 4 -p 'cargo clean || :' 'make release'
    Benchmark 1: make release
      Time (mean ± σ):     36.602 s ±  0.050 s    [User: 61.361 s, System: 4.345 s]
      Range (min … max):   36.552 s … 36.669 s    4 runs

    $ ls -sh target/release/libpathrs.so
    2.2M target/release/libpathrs.so
    ```

* After the patch:

    ```console
    $ hyperfine -w 1 -r 4 -p 'cargo clean || :' 'make release'
    Benchmark 1: make release
      Time (mean ± σ):     16.919 s ±  0.129 s    [User: 26.672 s, System: 2.974 s]
      Range (min … max):   16.744 s … 17.035 s    4 runs

    $ ls -sh target/release/libpathrs.so
    608K target/release/libpathrs.so
    ```
