### PR TITLE
procfs: add support for ProcfsBase::ProcRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   filesystem configurations (POSIX ACLs, weird filesystem-specific mount
   options). (#71)
 
+- capi: Passing invalid `pathrs_proc_base_t` values to `pathrs_proc_*` will now
+  return an error rather than resulting in Undefined Behaviour™.
+
 ## [0.1.0] - 2024-09-14 ##
 
 > 負けたくないことに理由って要る?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] ##
 
 ### Added ###
+- procfs: add support for operating on files in the `/proc` root (or other
+  processes) with `ProcfsBase::ProcRoot`.
+
+  While the cached file descriptor shouldn't leak into containers (container
+  runtimes know to set `PR_SET_DUMPABLE`, and our cached file descriptor is
+  `O_CLOEXEC`), I felt a little uncomfortable about having a global unmasked
+  procfs handle sitting around in `libpathrs`. So, in order to avoid making a
+  file descriptor leak by a `libpathrs` user catastrophic, `libpathrs` will
+  always try to use a "limited" procfs handle as the global cached handle
+  (which is much safer to leak into a container) and for operations on
+  `ProcfsBase::ProcRoot`, a temporary new "unrestricted" procfs handle is
+  created just for that operartion. This is more expensive, but it avoids a
+  potential leak turning into a breakout or other nightmare scenario.
+
 - python bindings: The `cffi` build script is now a little easier to use for
   distributions that want to build the python bindings at the same time as the
   main library. After compiling the library, set the `PATHRS_SRC_ROOT`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ maintenance = { status = "experimental" }
 crate-type = ["rlib"]
 
 [features]
-capi = ["dep:rand"]
+capi = ["dep:rand", "dep:open-enum"]
 # Only used for tests.
 _test_as_root = []
 
@@ -53,6 +53,8 @@ itertools = "^0.13"
 lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
+# MSRV(1.65): Update to >=0.4.1 which uses let_else. 0.4.0 was broken.
+open-enum = {version = "=0.3.0", optional = true }
 rand = { version = "^0.8", optional = true }
 rustix = { version = "^0.38", features = ["fs"] }
 thiserror = "^1"

--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -220,6 +220,7 @@ def _convert_mode(mode):
 	return flags
 
 
+PROC_ROOT = libpathrs_so.PATHRS_PROC_ROOT
 PROC_SELF = libpathrs_so.PATHRS_PROC_SELF
 PROC_THREAD_SELF = libpathrs_so.PATHRS_PROC_THREAD_SELF
 

--- a/go-pathrs/libpathrs_linux.go
+++ b/go-pathrs/libpathrs_linux.go
@@ -195,6 +195,7 @@ func pathrsHardlink(rootFd uintptr, path, target string) error {
 type pathrsProcBase C.pathrs_proc_base_t
 
 const (
+	pathrsProcRoot       pathrsProcBase = C.PATHRS_PROC_ROOT
 	pathrsProcSelf       pathrsProcBase = C.PATHRS_PROC_SELF
 	pathrsProcThreadSelf pathrsProcBase = C.PATHRS_PROC_THREAD_SELF
 )

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -44,7 +44,7 @@
  * pre-3.17 kernels and so it may be necessary to emulate /proc/thread-self
  * access on those older kernels.
  */
-typedef enum {
+enum pathrs_proc_base_t {
     /**
      * Use `/proc`. Note that this mode may be more expensive because we have
      * to take steps to try to avoid leaking unmasked procfs handles, so you
@@ -65,7 +65,8 @@ typedef enum {
      * be killed (such as Go -- where you want to use runtime.LockOSThread).
      */
     PATHRS_PROC_THREAD_SELF = 1051549215,
-} pathrs_proc_base_t;
+};
+typedef uint64_t pathrs_proc_base_t;
 
 /**
  * Attempts to represent a Rust Error type in C. This structure must be freed

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -43,10 +43,14 @@
  * pathrs_proc_*. This is necessary because /proc/thread-self is not present on
  * pre-3.17 kernels and so it may be necessary to emulate /proc/thread-self
  * access on those older kernels.
- *
- * NOTE: Currently, operating on /proc/... directly is not supported.
  */
 typedef enum {
+    /**
+     * Use `/proc`. Note that this mode may be more expensive because we have
+     * to take steps to try to avoid leaking unmasked procfs handles, so you
+     * should use `PATHRS_PROC_SELF` if you can.
+     */
+    PATHRS_PROC_ROOT = 1342308351,
     /**
      * Use /proc/self. For most programs, this is the standard choice.
      */

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -19,21 +19,25 @@
 
 use crate::{
     capi::{ret::IntoCReturn, utils},
-    error::Error,
+    error::{Error, ErrorImpl},
     flags::OpenFlags,
     procfs::{ProcfsBase, GLOBAL_PROCFS_HANDLE},
 };
 
-use std::os::unix::io::{OwnedFd, RawFd};
+use std::{
+    convert::TryFrom,
+    os::unix::io::{OwnedFd, RawFd},
+};
 
 use libc::{c_char, c_int, size_t};
+use open_enum::open_enum;
 
 /// Indicate what base directory should be used when doing operations with
 /// pathrs_proc_*. This is necessary because /proc/thread-self is not present on
 /// pre-3.17 kernels and so it may be necessary to emulate /proc/thread-self
 /// access on those older kernels.
-// TODO: Switch to open_enum so C code that passes garbage values can be caught.
-#[repr(C)]
+#[open_enum]
+#[repr(u64)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(non_camel_case_types, dead_code)]
 pub enum CProcfsBase {
@@ -55,12 +59,19 @@ pub enum CProcfsBase {
     PATHRS_PROC_THREAD_SELF = 0x3EAD_5E1F,
 }
 
-impl From<CProcfsBase> for ProcfsBase {
-    fn from(c_base: CProcfsBase) -> Self {
+impl TryFrom<CProcfsBase> for ProcfsBase {
+    type Error = Error;
+
+    fn try_from(c_base: CProcfsBase) -> Result<Self, Self::Error> {
         match c_base {
-            CProcfsBase::PATHRS_PROC_ROOT => ProcfsBase::ProcRoot,
-            CProcfsBase::PATHRS_PROC_SELF => ProcfsBase::ProcSelf,
-            CProcfsBase::PATHRS_PROC_THREAD_SELF => ProcfsBase::ProcThreadSelf,
+            CProcfsBase::PATHRS_PROC_ROOT => Ok(ProcfsBase::ProcRoot),
+            CProcfsBase::PATHRS_PROC_SELF => Ok(ProcfsBase::ProcSelf),
+            CProcfsBase::PATHRS_PROC_THREAD_SELF => Ok(ProcfsBase::ProcThreadSelf),
+            _ => Err(ErrorImpl::InvalidArgument {
+                name: "procfs base".into(),
+                description: "the procfs base must be one of the PATHRS_PROC_* values".into(),
+            }
+            .into()),
         }
     }
 }
@@ -119,12 +130,13 @@ pub unsafe extern "C" fn pathrs_proc_open(
     flags: c_int,
 ) -> RawFd {
     || -> Result<_, Error> {
+        let base = base.try_into()?;
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let oflags = OpenFlags::from_bits_retain(flags);
 
         match oflags.contains(OpenFlags::O_NOFOLLOW) {
-            true => GLOBAL_PROCFS_HANDLE.open(base.into(), path, oflags),
-            false => GLOBAL_PROCFS_HANDLE.open_follow(base.into(), path, oflags),
+            true => GLOBAL_PROCFS_HANDLE.open(base, path, oflags),
+            false => GLOBAL_PROCFS_HANDLE.open_follow(base, path, oflags),
         }
     }()
     .map(OwnedFd::from)
@@ -175,8 +187,9 @@ pub unsafe extern "C" fn pathrs_proc_readlink(
     linkbuf_size: size_t,
 ) -> c_int {
     || -> Result<_, Error> {
+        let base = base.try_into()?;
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
-        let link_target = GLOBAL_PROCFS_HANDLE.readlink(base.into(), path)?;
+        let link_target = GLOBAL_PROCFS_HANDLE.readlink(base, path)?;
         // SAFETY: C caller guarantees buffer is at least linkbuf_size and can
         // be written to.
         unsafe { utils::copy_path_into_buffer(link_target, linkbuf, linkbuf_size) }

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -291,7 +291,7 @@ impl ProcfsHandle {
     /// This is intended to only ever be used internally, as leaking this handle
     /// into containers could lead to serious security issues (while leaking
     /// `subset=pid` is a far less worrisome).
-    fn new_unmasked() -> Result<Self, Error> {
+    pub(crate) fn new_unmasked() -> Result<Self, Error> {
         Self::new_fsopen(false)
             .or_else(|_| Self::new_open_tree(OpenTreeFlags::empty()))
             .or_else(|_| Self::new_unsafe_open())

--- a/src/resolvers/opath/impl.rs
+++ b/src/resolvers/opath/impl.rs
@@ -137,8 +137,6 @@ lazy_static! {
     // TODO: In theory this value could change during the lifetime of the
     // program, but there's no nice way of detecting that, and the overhead of
     // checking this for every symlink lookup is more likely to be an issue.
-    // TODO: Maybe we should make a private ProcfsHandle just for this so that
-    // we can use subset=pid for GLOBAL_PROCFS_HANDLE?
     static ref PROTECTED_SYMLINKS_SYSCTL: u32 =
         utils::sysctl_read_parse(&GLOBAL_PROCFS_HANDLE, "fs.protected_symlinks")
             .expect("should be able to parse fs.protected_symlinks");

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -109,7 +109,12 @@ macro_rules! procfs_tests {
 
         procfs_tests! {
             @rust-fn [<new_fsopen_ $test_name>]
-                { ProcfsHandle::new_fsopen() }.$procfs_op($($args)*) => (over_mounts: false, $($tt)*);
+                { ProcfsHandle::new_fsopen(false) }.$procfs_op($($args)*) => (over_mounts: false, $($tt)*);
+        }
+
+        procfs_tests! {
+            @rust-fn [<new_fsopen_subset_ $test_name>]
+                { ProcfsHandle::new_fsopen(true) }.$procfs_op($($args)*) => (over_mounts: false, $($tt)*);
         }
 
         procfs_tests! {

--- a/src/utils/sysctl.rs
+++ b/src/utils/sysctl.rs
@@ -20,7 +20,7 @@
 use crate::{
     error::{Error, ErrorExt, ErrorImpl},
     flags::OpenFlags,
-    procfs::ProcfsHandle,
+    procfs::{ProcfsBase, ProcfsHandle},
 };
 
 use std::{
@@ -35,7 +35,7 @@ pub(crate) fn sysctl_read_line(procfs: &ProcfsHandle, sysctl: &str) -> Result<St
     // Convert "foo.bar.baz" to "foo/bar/baz".
     sysctl_path.push(sysctl.replace(".", "/"));
 
-    let sysctl_file = procfs.open_raw(sysctl_path, OpenFlags::O_RDONLY)?;
+    let sysctl_file = procfs.open(ProcfsBase::ProcRoot, sysctl_path, OpenFlags::O_RDONLY)?;
 
     // Just read the first line.
     let mut reader = BufReader::new(sysctl_file);

--- a/src/utils/sysctl.rs
+++ b/src/utils/sysctl.rs
@@ -69,59 +69,66 @@ mod tests {
         error::{Error, ErrorKind},
         procfs::GLOBAL_PROCFS_HANDLE,
     };
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn bad_sysctl_file_noexist() {
-        assert!(matches!(
+        assert_eq!(
             super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "nonexistent.dummy.sysctl.path")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::OsError(Some(libc::ENOENT)))
-        ));
-        assert!(matches!(
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            "reading line from non-existent sysctl",
+        );
+        assert_eq!(
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "nonexistent.sysctl.path")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::OsError(Some(libc::ENOENT)))
-        ));
+            Err(ErrorKind::OsError(Some(libc::ENOENT))),
+            "parsing line from non-existent sysctl",
+        );
     }
 
     #[test]
     fn bad_sysctl_file_noread() {
-        assert!(matches!(
+        assert_eq!(
             super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "vm.drop_caches")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::OsError(Some(libc::EACCES)))
-        ));
-        assert!(matches!(
+            Err(ErrorKind::OsError(Some(libc::EACCES))),
+            "reading line from non-readable sysctl",
+        );
+        assert_eq!(
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "vm.drop_caches")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::OsError(Some(libc::EACCES)))
-        ));
+            Err(ErrorKind::OsError(Some(libc::EACCES))),
+            "parse line from non-readable sysctl",
+        );
     }
 
     #[test]
     fn bad_sysctl_parse_invalid_multinumber() {
         assert!(super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "kernel.printk").is_ok());
-        assert!(matches!(
+        assert_eq!(
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.printk")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::ParseError)
-        ));
+            Err(ErrorKind::ParseError),
+            "parsing line from multi-number sysctl",
+        );
     }
 
     #[test]
     fn bad_sysctl_parse_invalid_nonnumber() {
         assert!(super::sysctl_read_line(&GLOBAL_PROCFS_HANDLE, "kernel.random.uuid").is_ok());
-        assert!(matches!(
+        assert_eq!(
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.random.uuid")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::ParseError)
-        ));
+            Err(ErrorKind::ParseError),
+            "parsing line from non-number sysctl",
+        );
     }
 
     #[test]


### PR DESCRIPTION
The semantics are the same as the other bases, except that in the
fsopen() case we will have to create a temporary instance for the
operation.

We want to set subset=pid,hidepid=ptraceable for the global procfs
handle (to restrict the scope if the handle was leaked into a
container). Unfortunately we also need to access stuff outside of
/proc/$pid such as sysctls (/proc/sys/*), and we plan to allow users to
access stuff in the root of /proc eventually.

So, in order to balance these two requirements, we can just create a
temporary procfs handle whenever we need to access stuff outside of the
root (which should be far more rare than accessing things inside
/proc/$pid) and use it as a fallback if the global procfs handle return
ENOENT. This will increase the overhead of accessing stuff outside
/proc/$pid, but the security benefits should be well worth it.

Fixes #69 (the temporary handle trick solves the main concerns with a global handle)
Fixes #62
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>