### PR TITLE
VERSION: release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+## [0.1.1] - 2024-10-01 ##
+
+> 頒布と聞いたら蛇に睨まれた蛙になるよ
+
 ### Added ###
 - procfs: add support for operating on files in the `/proc` root (or other
   processes) with `ProcfsBase::ProcRoot`.
@@ -226,7 +230,8 @@ Initial release.
   - C FFI.
   - Python bindings.
 
-[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/openSUSE/libpathrs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openSUSE/libpathrs/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/openSUSE/libpathrs/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/openSUSE/libpathrs/compare/v0.0.0...v0.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.0+dev"
+version = "0.1.1"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.1"
+version = "0.1.1+dev"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.1"
+version = "0.1.1+dev"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 keywords = ["libpathrs", "pathrs"]
 license = { file = "COPYING.APACHE-2.0" }

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.0+dev"
+version = "0.1.1"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 keywords = ["libpathrs", "pathrs"]
 license = { file = "COPYING.APACHE-2.0" }


### PR DESCRIPTION
```md
## [0.1.1] - 2024-10-01 ##

> 頒布と聞いたら蛇に睨まれた蛙になるよ

### Added ###
- procfs: add support for operating on files in the `/proc` root (or other
  processes) with `ProcfsBase::ProcRoot`.

  While the cached file descriptor shouldn't leak into containers (container
  runtimes know to set `PR_SET_DUMPABLE`, and our cached file descriptor is
  `O_CLOEXEC`), I felt a little uncomfortable about having a global unmasked
  procfs handle sitting around in `libpathrs`. So, in order to avoid making a
  file descriptor leak by a `libpathrs` user catastrophic, `libpathrs` will
  always try to use a "limited" procfs handle as the global cached handle
  (which is much safer to leak into a container) and for operations on
  `ProcfsBase::ProcRoot`, a temporary new "unrestricted" procfs handle is
  created just for that operartion. This is more expensive, but it avoids a
  potential leak turning into a breakout or other nightmare scenario.

- python bindings: The `cffi` build script is now a little easier to use for
  distributions that want to build the python bindings at the same time as the
  main library. After compiling the library, set the `PATHRS_SRC_ROOT`
  environment variable to the root of the `libpathrs` source directory. This
  will instruct the `cffi` build script (when called from `setup.py` or
  `python3 -m build`) to link against the library built in the source directory
  rather than using system libraries. As long as you install the same library
  later, this should cause no issues.

  Standard wheel builds still work the same way, so users that want to link
  against the system libraries don't need to make any changes.

### Fixed ###
- `Root::mkdir_all` no longer does strict verification that directories craeted
  by `mkdir_all` "look right" after opening each component. These checks didn't
  protect against any practical attack (since an attacker could just get us to
  use a directory by creating it before `Root::mkdir_all` and we would happily
  use it) and just resulted in spurious errors when dealing with complicated
  filesystem configurations (POSIX ACLs, weird filesystem-specific mount
  options). (#71)

- capi: Passing invalid `pathrs_proc_base_t` values to `pathrs_proc_*` will now
  return an error rather than resulting in Undefined Behaviour™.
```

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>