### PR TITLE
VERSION: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
+
+## [0.1.2] - 2024-10-09 ##
+
+> 蛇のように賢く、鳩のように素直でありなさい
+
 ### Fixes ###
 - python bindings: add a minimal README for PyPI.
 - python bindings: actually export `PROC_ROOT`.
@@ -235,7 +240,8 @@ Initial release.
   - C FFI.
   - Python bindings.
 
-[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/openSUSE/libpathrs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/openSUSE/libpathrs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openSUSE/libpathrs/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/openSUSE/libpathrs/compare/v0.0.1...v0.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.1+dev"
+version = "0.1.2"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.2"
+version = "0.1.2+dev"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.2"
+version = "0.1.2+dev"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 readme = "README.md"
 keywords = ["libpathrs", "pathrs"]

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.1+dev"
+version = "0.1.2"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 readme = "README.md"
 keywords = ["libpathrs", "pathrs"]


### PR DESCRIPTION
```
## [0.1.2] - 2024-10-09 ##

> 蛇のように賢く、鳩のように素直でありなさい

### Fixes ###
- python bindings: add a minimal README for PyPI.
- python bindings: actually export `PROC_ROOT`.
- python bindings: add type annotations and `py.typed` to allow for downstream
  users to get proper type annotations for the API.
```

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>