### PR TITLE
VERSION: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - syscalls: the pretty-printing of `openat2` errors now gives a string
   description of the flags passed rather that just a hex value (to match other
   syscalls).
+- python bindings: restrict how our methods and functions can be called using
+  `/` and `*` to reduce the possibility of future breakages if we rename or
+  re-order some of our arguments.
 
 ## [0.1.2] - 2024-10-09 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+## [0.1.3] - 2024-10-10 ##
+
+> 自動化って物は試しとすればいい物だ
+
 ### Changed ###
 - gha: our Rust crate and Python bindings are now uploaded automatically from a
   GitHub action when a tag is pushed.
@@ -252,7 +256,8 @@ Initial release.
   - C FFI.
   - Python bindings.
 
-[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/openSUSE/libpathrs/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/openSUSE/libpathrs/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/openSUSE/libpathrs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/openSUSE/libpathrs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openSUSE/libpathrs/compare/v0.0.2...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.3"
+version = "0.1.3+dev"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "pathrs"
-version = "0.1.2+dev"
+version = "0.1.3"
 license = "LGPL-3.0-or-later"
 authors = ["Aleksa Sarai <cyphar@cyphar.com>"]
 

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.2+dev"
+version = "0.1.3"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 readme = "README.md"
 keywords = ["libpathrs", "pathrs"]

--- a/contrib/bindings/python/pyproject.toml
+++ b/contrib/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pathrs"
 # TODO: Figure out a way to keep this version up-to-date with Cargo.toml.
-version = "0.1.3"
+version = "0.1.3+dev"
 description = "Python bindings for libpathrs, a safe path resolution library for Linux."
 readme = "README.md"
 keywords = ["libpathrs", "pathrs"]


### PR DESCRIPTION
```
## [0.1.3] - 2024-10-10 ##

> 自動化って物は試しとすればいい物だ

### Changed ###
- gha: our Rust crate and Python bindings are now uploaded automatically from a
  GitHub action when a tag is pushed.

### Fixes ###
- syscalls: the pretty-printing of `openat2` errors now gives a string
  description of the flags passed rather that just a hex value (to match other
  syscalls).
```

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>