### PR TITLE
{Root,Handle}::from_fd_unchecked -> from_fd

### DIFF
--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -122,7 +122,7 @@ pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: c_int) -> RawFd {
 pub unsafe extern "C" fn pathrs_resolve(root_fd: CBorrowedFd<'_>, path: *const c_char) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         root.resolve(path)
     }()
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn pathrs_resolve_nofollow(
 ) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         root.resolve_nofollow(path)
     }()
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn pathrs_readlink(
 ) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let link_target = root.readlink(path)?;
         // SAFETY: C caller guarantees buffer is at least linkbuf_size and can
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn pathrs_rename(
 ) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let src = unsafe { utils::parse_path(src) }?; // SAFETY: C caller guarantees path is safe.
         let dst = unsafe { utils::parse_path(dst) }?; // SAFETY: C caller guarantees path is safe.
 
@@ -259,7 +259,7 @@ pub unsafe extern "C" fn pathrs_rename(
 pub unsafe extern "C" fn pathrs_rmdir(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         root.remove_dir(path)
     }()
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn pathrs_rmdir(root_fd: CBorrowedFd<'_>, path: *const c_c
 pub unsafe extern "C" fn pathrs_unlink(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         root.remove_file(path)
     }()
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn pathrs_unlink(root_fd: CBorrowedFd<'_>, path: *const c_
 pub unsafe extern "C" fn pathrs_remove_all(root_fd: CBorrowedFd<'_>, path: *const c_char) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         root.remove_all(path)
     }()
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn pathrs_creat(
 ) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let mode = mode & !libc::S_IFMT;
         let perm = Permissions::from_mode(mode);
@@ -406,7 +406,7 @@ pub unsafe extern "C" fn pathrs_mkdir_all(
 ) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path) }?; // SAFETY: C caller guarantees path is safe.
         let perm = Permissions::from_mode(mode);
         root.mkdir_all(path, &perm)
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn pathrs_mknod(
 ) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
 
         let fmt = mode & libc::S_IFMT;
@@ -477,7 +477,7 @@ pub unsafe extern "C" fn pathrs_symlink(
 ) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
         let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
         root.create(path, &InodeType::Symlink(target.into()))
@@ -504,7 +504,7 @@ pub unsafe extern "C" fn pathrs_hardlink(
 ) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd_unchecked(root_fd);
+        let root = RootRef::from_fd(root_fd);
         let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
         let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
         root.create(path, &InodeType::Hardlink(target.into()))

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -53,23 +53,8 @@ pub struct Handle {
 
 impl Handle {
     /// Wrap an [`OwnedFd`] into a [`Handle`].
-    ///
-    /// # Safety
-    ///
-    /// The caller guarantees that the provided file is an `O_PATH` file
-    /// descriptor with exactly the same semantics as one created through
-    /// [`Root::resolve`]. This means that this function should usually be used
-    /// to convert an [`OwnedFd`] returned from [`OwnedFd::from`] (possibly from
-    /// another process) into a [`Handle`].
-    ///
-    /// While this function is not marked as `unsafe` (because the safety
-    /// guarantee required is not related to memory-safety), users should still
-    /// take great care when using this method because it can cause other kinds
-    /// of unsafety.
-    ///
-    /// [`Root::resolve`]: crate::Root::resolve
     #[inline]
-    pub fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    pub fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
         Self { inner: fd.into() }
     }
 
@@ -159,24 +144,8 @@ pub struct HandleRef<'fd> {
 }
 
 impl HandleRef<'_> {
-    /// Wrap a [`BorrowedFd`] into a [`HandleRef`]. The lifetime is tied to the
-    /// [`BorrowedFd`].
-    ///
-    /// # Safety
-    ///
-    /// The caller guarantees that the provided file is an `O_PATH` file
-    /// descriptor with exactly the same semantics as one created through
-    /// [`Root::resolve`]. This means that this function should usually be used
-    /// to convert a [`BorrowedFd`] returned from [`AsFd::as_fd`] (possibly from
-    /// another process) into a [`HandleRef`].
-    ///
-    /// While this function is not marked as `unsafe` (because the safety
-    /// guarantee required is not related to memory-safety), users should still
-    /// take great care when using this method because it can cause other kinds
-    /// of unsafety.
-    ///
-    /// [`Root::resolve`]: crate::Root::resolve
-    pub fn from_fd_unchecked(inner: BorrowedFd<'_>) -> HandleRef<'_> {
+    /// Wrap a [`BorrowedFd`] into a [`HandleRef`].
+    pub fn from_fd(inner: BorrowedFd<'_>) -> HandleRef<'_> {
         HandleRef { inner }
     }
 
@@ -188,6 +157,9 @@ impl HandleRef<'_> {
     ///
     /// To create a shallow copy of a [`HandleRef`], you can use
     /// [`Clone::clone`] (or just [`Copy`]).
+    // TODO: We might need to call this something other than try_clone(), since
+    //       it's a little too easy to confuse with Clone::clone() but we also
+    //       really want to have Copy.
     pub fn try_clone(&self) -> Result<Handle, Error> {
         self.as_fd()
             .try_clone_to_owned()
@@ -198,7 +170,7 @@ impl HandleRef<'_> {
                 }
                 .into()
             })
-            .map(Handle::from_fd_unchecked)
+            .map(Handle::from_fd)
     }
 
     /// "Upgrade" the handle to a usable [`File`] handle.
@@ -252,10 +224,10 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_fd_unchecked() -> Result<(), Error> {
+    fn from_fd() -> Result<(), Error> {
         let handle = Root::open(".")?.resolve(".")?;
         let handle_ref1 = handle.as_ref();
-        let handle_ref2 = HandleRef::from_fd_unchecked(handle.as_fd());
+        let handle_ref2 = HandleRef::from_fd(handle.as_fd());
 
         assert_eq!(
             handle.as_fd().as_raw_fd(),
@@ -265,7 +237,7 @@ mod tests {
         assert_eq!(
             handle.as_fd().as_raw_fd(),
             handle_ref2.as_fd().as_raw_fd(),
-            "HandleRef::from_fd_unchecked should have the same underlying fd"
+            "HandleRef::from_fd should have the same underlying fd"
         );
 
         Ok(())

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -100,6 +100,13 @@ impl Handle {
     }
 }
 
+impl From<OwnedFd> for Handle {
+    /// Shorthand for [`Handle::from_fd`].
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_fd(fd)
+    }
+}
+
 impl From<Handle> for OwnedFd {
     /// Unwrap a [`Handle`] to reveal the underlying [`OwnedFd`].
     ///
@@ -199,6 +206,13 @@ impl HandleRef<'_> {
     // TODO: bind(). This might be safe to do (set the socket path to
     //       /proc/self/fd/...) but I'm a bit sad it'd be separate from
     //       Handle::reopen().
+}
+
+impl<'fd> From<BorrowedFd<'fd>> for HandleRef<'fd> {
+    /// Shorthand for [`HandleRef::from_fd`].
+    fn from(fd: BorrowedFd<'fd>) -> Self {
+        Self::from_fd(fd)
+    }
 }
 
 impl AsFd for HandleRef<'_> {

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -183,7 +183,7 @@ impl From<PartialLookup<Rc<OwnedFd>>> for PartialLookup<Handle> {
         // We are now sure that there is only a single reference to whatever
         // current points to. There is nowhere else we could've stashed a
         // reference, and we only do Rc::clone for root (which we've dropped).
-        let handle = Handle::from_fd_unchecked(
+        let handle = Handle::from_fd(
             // MSRV(1.70): Use Rc::into_inner().
             Rc::try_unwrap(rc)
                 .expect("current handle in lookup should only have a single Rc reference"),

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -63,7 +63,7 @@ pub(crate) fn resolve<F: AsFd, P: AsRef<Path>>(
     // error out.
     for _ in 0..16 {
         match syscalls::openat2(&root, path.as_ref(), &how) {
-            Ok(file) => return Ok(Handle::from_fd_unchecked(file)),
+            Ok(file) => return Ok(Handle::from_fd(file)),
             Err(err) => match err.root_cause().raw_os_error() {
                 Some(libc::ENOSYS) => {
                     // shouldn't happen
@@ -126,7 +126,7 @@ pub(crate) fn resolve_partial<F: AsFd>(
     Ok(PartialLookup::Partial {
         handle: root
             .try_clone_to_owned()
-            .map(Handle::from_fd_unchecked)
+            .map(Handle::from_fd)
             .map_err(|err| ErrorImpl::OsError {
                 operation: "clone root".into(),
                 source: err,

--- a/src/root.rs
+++ b/src/root.rs
@@ -165,31 +165,18 @@ impl Root {
             operation: "open root handle".into(),
             source: err,
         })?;
-        Ok(Self::from_fd_unchecked(file))
+        Ok(Self::from_fd(file))
     }
 
     /// Wrap an [`OwnedFd`] into a [`Root`].
     ///
+    /// The [`OwnedFd`] should be a file descriptor referencing a directory,
+    /// otherwise all [`Root`] operations will fail.
+    ///
     /// The configuration is set to the system default and should be configured
     /// prior to usage, if appropriate.
-    ///
-    /// # Safety
-    ///
-    /// The caller guarantees that the provided file is an `O_PATH` file
-    /// descriptor with exactly the same semantics as one created through
-    /// [`Root::open`]. This means that this function should usually be used to
-    /// convert an [`OwnedFd`] returned from [`OwnedFd::from`] (possibly from
-    /// another process) into a [`Root`].
-    ///
-    /// While this function is not marked as `unsafe` (because the safety
-    /// guarantee required is not related to memory-safety), users should still
-    /// take great care when using this method because it can cause other kinds
-    /// of unsafety.
-    // TODO: We should probably have a `Root::from_file` which attempts to
-    //       re-open the path with `O_PATH | O_DIRECTORY`, to allow for an
-    //       alternative to `Root::open`.
     #[inline]
-    pub fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    pub fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
         Self {
             inner: fd.into(),
             resolver: Default::default(),
@@ -528,28 +515,14 @@ pub struct RootRef<'fd> {
 }
 
 impl RootRef<'_> {
-    /// Wrap a [`BorrowedFd`] into a [`RootRef`]. The lifetime is tied to the
-    /// [`BorrowedFd`].
+    /// Wrap a [`BorrowedFd`] into a [`RootRef`].
+    ///
+    /// The [`BorrowedFd`] should be a file descriptor referencing a directory,
+    /// otherwise all [`Root`] operations will fail.
     ///
     /// The configuration is set to the system default and should be configured
     /// prior to usage, if appropriate.
-    ///
-    /// # Safety
-    ///
-    /// The caller guarantees that the provided file is an `O_PATH` file
-    /// descriptor with exactly the same semantics as one created through
-    /// [`Root::open`]. This means that this function should usually be used to
-    /// convert a [`BorrowedFd`] returned from [`AsFd::as_fd`] into a
-    /// [`RootRef`].
-    ///
-    /// While this function is not marked as `unsafe` (because the safety
-    /// guarantee required is not related to memory-safety), users should still
-    /// take great care when using this method because it can cause other kinds
-    /// of unsafety.
-    // TODO: We should probably have a `Root::from_file` which attempts to
-    //       re-open the path with `O_PATH | O_DIRECTORY`, to allow for an
-    //       alternative to `Root::open`.
-    pub fn from_fd_unchecked(inner: BorrowedFd<'_>) -> RootRef<'_> {
+    pub fn from_fd(inner: BorrowedFd<'_>) -> RootRef<'_> {
         RootRef {
             inner,
             resolver: Default::default(),
@@ -594,7 +567,7 @@ impl RootRef<'_> {
     /// # let tmpdir = tempfile::TempDir::new()?;
     /// # let rootdir = &tmpdir;
     /// let fd: OwnedFd = File::open(rootdir)?.into();
-    /// let root = RootRef::from_fd_unchecked(fd.as_fd())
+    /// let root = RootRef::from_fd(fd.as_fd())
     ///     .with_resolver_flags(ResolverFlags::NO_SYMLINKS);
     ///
     /// // Continue to use RootRef.
@@ -646,6 +619,9 @@ impl RootRef<'_> {
     ///
     /// To create a shallow copy of a [`RootRef`], you can use [`Clone::clone`]
     /// (or just [`Copy`]).
+    // TODO: We might need to call this something other than try_clone(), since
+    //       it's a little too easy to confuse with Clone::clone() but we also
+    //       really want to have Copy.
     pub fn try_clone(&self) -> Result<Root, Error> {
         Ok(Root {
             inner: self
@@ -987,7 +963,7 @@ impl RootRef<'_> {
             current = next;
         }
 
-        Ok(Handle::from_fd_unchecked(current))
+        Ok(Handle::from_fd(current))
     }
 
     /// Within the [`RootRef`]'s tree, remove the inode of type `inode_type` at
@@ -1212,10 +1188,10 @@ mod tests {
     }
 
     #[test]
-    fn from_fd_unchecked() -> Result<(), Error> {
+    fn from_fd() -> Result<(), Error> {
         let root = Root::open(".")?;
         let root_ref1 = root.as_ref();
-        let root_ref2 = RootRef::from_fd_unchecked(root.as_fd());
+        let root_ref2 = RootRef::from_fd(root.as_fd());
 
         assert_eq!(
             root.as_fd().as_raw_fd(),
@@ -1225,7 +1201,7 @@ mod tests {
         assert_eq!(
             root.as_fd().as_raw_fd(),
             root_ref2.as_fd().as_raw_fd(),
-            "RootRef::from_fd_unchecked should have the same underlying fd"
+            "RootRef::from_fd should have the same underlying fd"
         );
 
         Ok(())

--- a/src/root.rs
+++ b/src/root.rs
@@ -470,6 +470,13 @@ impl Root {
     }
 }
 
+impl From<OwnedFd> for Root {
+    /// Shorthand for [`Root::from_fd`].
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_fd(fd)
+    }
+}
+
 impl From<Root> for OwnedFd {
     /// Unwrap a [`Root`] to reveal the underlying [`OwnedFd`].
     ///
@@ -1118,6 +1125,13 @@ impl RootRef<'_> {
             }
             .into()
         })
+    }
+}
+
+impl<'fd> From<BorrowedFd<'fd>> for RootRef<'fd> {
+    /// Shorthand for [`RootRef::from_fd`].
+    fn from(fd: BorrowedFd<'fd>) -> Self {
+        Self::from_fd(fd)
     }
 }
 

--- a/src/tests/capi/handle.rs
+++ b/src/tests/capi/handle.rs
@@ -37,12 +37,12 @@ pub struct CapiHandle {
 }
 
 impl CapiHandle {
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
         Self { inner: fd.into() }
     }
 
     fn try_clone(&self) -> Result<Self, anyhow::Error> {
-        Ok(Self::from_fd_unchecked(self.inner.try_clone()?))
+        Ok(Self::from_fd(self.inner.try_clone()?))
     }
 
     fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, CapiError> {
@@ -73,8 +73,8 @@ impl HandleImpl for CapiHandle {
     // C implementation *DOES NOT* set O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = false;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
@@ -93,8 +93,8 @@ impl HandleImpl for &CapiHandle {
     // C implementation *DOES NOT* set O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = false;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -50,15 +50,15 @@ impl CapiRoot {
         let path = capi_utils::path_to_cstring(path);
 
         capi_utils::call_capi_fd(|| unsafe { capi::core::pathrs_root_open(path.as_ptr()) })
-            .map(Self::from_fd_unchecked)
+            .map(Self::from_fd)
     }
 
-    pub(in crate::tests) fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    pub(in crate::tests) fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
         Self { inner: fd.into() }
     }
 
     fn try_clone(&self) -> Result<Self, anyhow::Error> {
-        Ok(Self::from_fd_unchecked(self.inner.try_clone()?))
+        Ok(Self::from_fd(self.inner.try_clone()?))
     }
 
     fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<CapiHandle, CapiError> {
@@ -68,7 +68,7 @@ impl CapiRoot {
         capi_utils::call_capi_fd(|| unsafe {
             capi::core::pathrs_resolve(root_fd.into(), path.as_ptr())
         })
-        .map(CapiHandle::from_fd_unchecked)
+        .map(CapiHandle::from_fd)
     }
 
     fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<CapiHandle, CapiError> {
@@ -78,7 +78,7 @@ impl CapiRoot {
         capi_utils::call_capi_fd(|| unsafe {
             capi::core::pathrs_resolve_nofollow(root_fd.into(), path.as_ptr())
         })
-        .map(CapiHandle::from_fd_unchecked)
+        .map(CapiHandle::from_fd)
     }
 
     fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, CapiError> {
@@ -161,7 +161,7 @@ impl CapiRoot {
         capi_utils::call_capi_fd(|| unsafe {
             capi::core::pathrs_mkdir_all(root_fd.into(), path.as_ptr(), perm.mode())
         })
-        .map(CapiHandle::from_fd_unchecked)
+        .map(CapiHandle::from_fd)
     }
 
     fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), CapiError> {
@@ -231,13 +231,13 @@ impl RootImpl for CapiRoot {
     // <https://github.com/dtolnay/anyhow/issues/25>
     type Error = CapiError;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
         assert_eq!(
             resolver,
             Resolver::default(),
             "cannot use non-default Resolver with capi"
         );
-        Self::Cloned::from_fd_unchecked(fd)
+        Self::Cloned::from_fd(fd)
     }
 
     fn resolver(&self) -> Resolver {
@@ -310,13 +310,13 @@ impl RootImpl for &CapiRoot {
     // <https://github.com/dtolnay/anyhow/issues/25>
     type Error = CapiError;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
         assert_eq!(
             resolver,
             Resolver::default(),
             "cannot use non-default Resolver with capi"
         );
-        Self::Cloned::from_fd_unchecked(fd)
+        Self::Cloned::from_fd(fd)
     }
 
     fn resolver(&self) -> Resolver {

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -448,7 +448,7 @@ mod utils {
         );
         let root_fd: OwnedFd = root_clone.into();
 
-        Ok(R::from_fd_unchecked(root_fd, root.resolver()))
+        Ok(R::from_fd(root_fd, root.resolver()))
     }
 
     pub(super) fn check_root_create<R: RootImpl, P: AsRef<Path>>(

--- a/src/tests/traits/handle.rs
+++ b/src/tests/traits/handle.rs
@@ -33,7 +33,7 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
     const FORCED_CLOEXEC: bool;
 
     // NOTE: We return Self::Cloned so that we can share types with HandleRef.
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
 
@@ -47,8 +47,8 @@ impl HandleImpl for Handle {
     // Rust impl forces O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = true;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
@@ -67,8 +67,8 @@ impl HandleImpl for &Handle {
     // Rust impl forces O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = true;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
@@ -87,8 +87,8 @@ impl HandleImpl for HandleRef<'_> {
     // Rust impl forces O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = true;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {
@@ -107,8 +107,8 @@ impl HandleImpl for &HandleRef<'_> {
     // Rust impl forces O_CLOEXEC by default.
     const FORCED_CLOEXEC: bool = true;
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
     }
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error> {

--- a/src/tests/traits/root.rs
+++ b/src/tests/traits/root.rs
@@ -40,7 +40,7 @@ pub(in crate::tests) trait RootImpl: AsFd + std::fmt::Debug + Sized {
     fn resolver(&self) -> Resolver;
 
     // NOTE: We return Self::Cloned so that we can share types with RootRef.
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned;
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned;
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
 
@@ -91,8 +91,8 @@ impl RootImpl for Root {
         }
     }
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
     }
@@ -168,8 +168,8 @@ impl RootImpl for &Root {
         }
     }
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
     }
@@ -245,8 +245,8 @@ impl RootImpl for RootRef<'_> {
         }
     }
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
     }
@@ -322,8 +322,8 @@ impl RootImpl for &RootRef<'_> {
         }
     }
 
-    fn from_fd_unchecked<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
-        Self::Cloned::from_fd_unchecked(fd)
+    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+        Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
     }


### PR DESCRIPTION
It seems incredibly unlikely that we will ever add verification to
Handle::from_fd / Root::from_fd, so having the _unchecked suffix doesn't
really make sense.

Fixes #85 
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>