### PR TITLE
*: migrate from lazy_static! to once_cell::sync::Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,12 @@ lto = true
 [dependencies]
 bitflags = "^2"
 itertools = "^0.13"
-# MSRV(1.70): Use OnceLock.
-# MSRV(1.80): Use LazyLock.
-lazy_static = "^1"
 libc = "^0.2"
 memchr = "^2"
+# MSRV(1.80): Use LazyLock.
+once_cell = "^1"
 # MSRV(1.65): Update to >=0.4.1 which uses let_else. 0.4.0 was broken.
-open-enum = {version = "=0.3.0", optional = true }
+open-enum = { version = "=0.3.0", optional = true }
 rand = { version = "^0.8", optional = true }
 rustix = { version = "^0.38", features = ["fs"] }
 thiserror = "^1"

--- a/src/capi/error.rs
+++ b/src/capi/error.rs
@@ -31,15 +31,12 @@ use std::{
 };
 
 use libc::{c_char, c_int};
+use once_cell::sync::Lazy;
 use rand::{self, Rng};
 
-// TODO: Switch this to using a slab or similar structure, possibly using a less
-// heavy-weight lock? Maybe sharded-slab?
-// MSRV(1.70): Use OnceLock.
+// TODO: Switch this to using a slab or similar structure, possibly using a less heavy-weight lock?
 // MSRV(1.80): Use LazyLock.
-lazy_static! {
-    static ref ERROR_MAP: Mutex<HashMap<CReturn, Error>> = Mutex::new(HashMap::new());
-}
+static ERROR_MAP: Lazy<Mutex<HashMap<CReturn, Error>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 pub(crate) fn store_error(err: Error) -> CReturn {
     let mut err_map = ERROR_MAP.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 extern crate libc;
 
 // `Handle` implementation.

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -36,17 +36,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// MSRV(1.70): Use OnceLock.
+use once_cell::sync::Lazy;
+
+/// A `procfs` handle to which is used globally by libpathrs.
 // MSRV(1.80): Use LazyLock.
-lazy_static! {
-    /// A lazy-allocated `procfs` handle which is used globally by libpathrs.
-    ///
-    /// As creating `procfs` handles can be somewhat expensive, library users
-    /// are recommended to make use of this handle for `procfs` operations if
-    /// possible.
-    pub static ref GLOBAL_PROCFS_HANDLE: ProcfsHandle =
-        ProcfsHandle::new().expect("should be able to get some /proc handle");
-}
+pub(crate) static GLOBAL_PROCFS_HANDLE: Lazy<ProcfsHandle> =
+    Lazy::new(|| ProcfsHandle::new().expect("should be able to get some /proc handle"));
 
 /// Indicate what base directory should be used when doing `/proc/...`
 /// operations with a [`ProcfsHandle`].

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -33,6 +33,8 @@ use std::{
     rc::Rc,
 };
 
+use once_cell::sync::Lazy;
+
 /// `O_PATH`-based userspace resolver.
 pub(crate) mod opath;
 /// `openat2(2)`-based in-kernel resolver.
@@ -63,15 +65,14 @@ pub(crate) enum ResolverBackend {
     //       hyper-concerned users.
 }
 
-// MSRV(1.70): Use OnceLock.
 // MSRV(1.80): Use LazyLock.
-lazy_static! {
-    static ref DEFAULT_RESOLVER_TYPE: ResolverBackend = if *syscalls::OPENAT2_IS_SUPPORTED {
+static DEFAULT_RESOLVER_TYPE: Lazy<ResolverBackend> = Lazy::new(|| {
+    if *syscalls::OPENAT2_IS_SUPPORTED {
         ResolverBackend::KernelOpenat2
     } else {
         ResolverBackend::EmulatedOpath
-    };
-}
+    }
+});
 
 impl Default for ResolverBackend {
     fn default() -> Self {


### PR DESCRIPTION
Ideally we would switch to std::sync::LazyLock but that was only stabilised in Rust 1.80.0, so we have to make do with once_cell. At least once_cell has basically the same API as the merged-into-std API, so we can switch over very easily.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>