### PR TITLE
syscalls: switch to rustix for most of our syscalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - python bindings: add `Root.creat_raw` to create a new file and wrap it in a
   raw `WrappedFd` (os opposed to `Root.creat` which returns an `os.fdopen`).
 
+### Changed ###
+- syscalls: switch to rustix for most of our syscall wrappers to simplify how
+  much code we have for wrapper raw syscalls. This also lets us build on
+  musl-based targets because musl doesn't support some of the syscalls we need.
+
+  There are some outstanding issues with rustix that make this switch a little
+  uglier than necessary ([rustix#1186][], [rustix#1187][]), but this is a net
+  improvement overall.
+
+[rustix#1186]: https://github.com/bytecodealliance/rustix/issues/1186
+[rustix#1187]: https://github.com/bytecodealliance/rustix/issues/1187
+
 ## [0.1.3] - 2024-10-10 ##
 
 > 自動化って物は試しとすればいい物だ

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ once_cell = "^1"
 # MSRV(1.65): Update to >=0.4.1 which uses let_else. 0.4.0 was broken.
 open-enum = { version = "=0.3.0", optional = true }
 rand = { version = "^0.8", optional = true }
-rustix = { version = "^0.38", features = ["fs"] }
+rustix = { version = "^0.38", features = ["fs", "process", "thread", "mount"] }
 thiserror = "^1"
 
 [dev-dependencies]
@@ -65,8 +65,6 @@ errno = "^0.3"
 tempfile = "^3"
 paste = "^1"
 pretty_assertions = "^1"
-# Enable the "process" feature for getcwd() in our tests.
-rustix = { version = "^0.38", features = ["process"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -123,6 +123,12 @@ bitflags! {
     }
 }
 
+impl From<OpenFlags> for rustix::fs::OFlags {
+    fn from(flags: OpenFlags) -> Self {
+        Self::from_bits_retain(flags.bits() as u32)
+    }
+}
+
 impl OpenFlags {
     /// Grab the access mode bits from the flags.
     ///
@@ -189,6 +195,12 @@ bitflags! {
 
         // Don't clobber unknown RENAME_* bits.
         const _ = !0;
+    }
+}
+
+impl From<RenameFlags> for rustix::fs::RenameFlags {
+    fn from(flags: RenameFlags) -> Self {
+        Self::from_bits_retain(flags.bits())
     }
 }
 

--- a/src/resolvers/opath/impl.rs
+++ b/src/resolvers/opath/impl.rs
@@ -38,7 +38,7 @@
 
 use crate::{
     error::{Error, ErrorExt, ErrorImpl},
-    flags::ResolverFlags,
+    flags::{OpenFlags, ResolverFlags},
     procfs::GLOBAL_PROCFS_HANDLE,
     resolvers::{opath::SymlinkStack, PartialLookup, MAX_SYMLINK_TRAVERSALS},
     syscalls,
@@ -262,15 +262,19 @@ fn do_resolve<Fd: AsFd, P: AsRef<Path>>(
 
         // Get our next element.
         // MSRV(1.69): Remove &*.
-        match syscalls::openat(&*current, &part, libc::O_PATH | libc::O_NOFOLLOW, 0).map_err(
-            |err| {
-                ErrorImpl::RawOsError {
-                    operation: "open next component of resolution".into(),
-                    source: err,
-                }
-                .into()
-            },
-        ) {
+        match syscalls::openat(
+            &*current,
+            &part,
+            OpenFlags::O_PATH | OpenFlags::O_NOFOLLOW,
+            0,
+        )
+        .map_err(|err| {
+            ErrorImpl::RawOsError {
+                operation: "open next component of resolution".into(),
+                source: err,
+            }
+            .into()
+        }) {
             Err(err) => {
                 return Ok(PartialLookup::Partial {
                     handle: current,

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -24,11 +24,12 @@ use crate::{
     flags::OpenFlags,
     procfs::{ProcfsBase, ProcfsHandle},
     resolvers::procfs::ProcfsResolver,
-    syscalls::{self, OpenTreeFlags},
+    syscalls,
 };
 use utils::ExpectedResult;
 
 use anyhow::Error;
+use rustix::mount::OpenTreeFlags;
 
 macro_rules! procfs_tests {
     // Create the actual test functions.


### PR DESCRIPTION
Using libc leads to several issues when dealing with multiarch that make things quite frustrating, and rustix does provide nicer APIs (for the most part -- some are a little wonky). One major annoyance is that building for musl leads to annoying build failures because musl uses differently-sized or differently-signed types, which we don't want to care about because we just want to use the actual kernel APIs. Also, musl is missing wrappers for things like statx(2) which we need to use.

We still need syscall wrappers to provide nice error information, but we can remove most of the internal-only bitflags and unsafe blocks. The only syscall wrapper we don't switch to rustix is openat2 because rustix's API is not designed to be extensible and so we can stick with libc for now.

In the future we might want to consider migrating away from libc entirely (to linux_raw_sys) to reduce the code bloat of having two different syscall wrappers.

Fixes #1
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<hr>

I hit two issues while working on this, but have applied workarounds so we can merge this without fixing those issues:

 * https://github.com/bytecodealliance/rustix/issues/1186
 * https://github.com/bytecodealliance/rustix/issues/1187