### PR TITLE
capi: always apply O_CLOEXEC to returned file descriptors

### DIFF
--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -114,7 +114,8 @@ impl From<ProcfsBase> for CProcfsBase {
 ///
 /// # Return Value
 ///
-/// On success, this function returns a file descriptor.
+/// On success, this function returns a file descriptor. The file descriptor
+/// will have the `O_CLOEXEC` flag automatically applied.
 ///
 /// If an error occurs, this function will return a negative error code. To
 /// retrieve information about the error (such as a string describing the error,

--- a/src/tests/capi/handle.rs
+++ b/src/tests/capi/handle.rs
@@ -70,9 +70,6 @@ impl HandleImpl for CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
 
-    // C implementation *DOES NOT* set O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = false;
-
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
@@ -89,9 +86,6 @@ impl HandleImpl for CapiHandle {
 impl HandleImpl for &CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
-
-    // C implementation *DOES NOT* set O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = false;
 
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -218,6 +218,12 @@ procfs_tests! {
     // No overmounts.
     nomount: open(self, "attr/current", O_RDONLY) => (error: Ok);
     nomount: open_follow(self, "attr/current", O_RDONLY) => (error: Ok);
+    nomount_dir: open(self, "attr", O_RDONLY) => (error: Ok);
+    nomount_dir: open_follow(self, "attr", O_RDONLY) => (error: Ok);
+    nomount_dir_odir: open(self, "attr", O_DIRECTORY|O_RDONLY) => (error: Ok);
+    nomount_dir_odir: open_follow(self, "attr", O_DIRECTORY|O_RDONLY) => (error: Ok);
+    nomount_dir_trailing_slash: open(self, "attr/", O_RDONLY) => (error: Ok);
+    nomount_dir_trailing_slash: open_follow(self, "attr/", O_RDONLY) => (error: Ok);
     global_nomount: open(ProcfsBase::ProcRoot, "filesystems", O_RDONLY) => (error: Ok);
     global_nomount: readlink(ProcfsBase::ProcRoot, "mounts") => (error: Ok);
     // Procfs regular file overmount.
@@ -242,7 +248,11 @@ procfs_tests! {
     magiclink_fd0: open_follow(self, "fd/0", O_RDONLY) => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV))));
     magiclink_fd0: readlink(self, "fd/0") => (error: ErrOvermount(ErrorKind::OsError(Some(libc::EXDEV))));
     // Behaviour-related testing.
+    nondir_odir: open_follow(self, "environ", O_DIRECTORY|O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR))));
+    nondir_trailing_slash: open_follow(self, "environ/", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR))));
+    proc_cwd_odir: open_follow(self, "cwd", O_DIRECTORY|O_RDONLY) => (error: Ok);
     proc_cwd_trailing_slash: open_follow(self, "cwd/", O_RDONLY) => (error: Ok);
+    proc_fdlink_odir: open_follow(self, "fd//1", O_DIRECTORY|O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR))));
     proc_fdlink_trailing_slash: open_follow(self, "fd//1/", O_RDONLY) => (error: Err(ErrorKind::OsError(Some(libc::ENOTDIR))));
     // TODO: root can always open procfs files with O_RDWR even if writes fail.
     // proc_nowrite: open(self, "status", O_RDWR) => (error: Err(ErrorKind::OsError(Some(libc::EACCES))));

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -447,7 +447,7 @@ mod utils {
         syscalls,
         tests::{
             common as tests_common,
-            traits::{ErrorImpl, HandleImpl, RootImpl},
+            traits::{ErrorImpl, RootImpl},
         },
         utils::{FdExt, PathIterExt},
         Handle, InodeType,
@@ -612,11 +612,7 @@ mod utils {
                 // Note that create_file is always implemented as a two-step
                 // process (open the parent, create the file) with O_NOFOLLOW
                 // always being applied to the created handle (to avoid races).
-                tests_common::check_oflags(
-                    &file,
-                    oflags | OpenFlags::O_NOFOLLOW,
-                    R::Handle::FORCED_CLOEXEC,
-                )?;
+                tests_common::check_oflags(&file, oflags | OpenFlags::O_NOFOLLOW)?;
             }
         }
         Ok(())
@@ -658,7 +654,7 @@ mod utils {
                     "expected real path of {path:?} handles to be the same",
                 );
 
-                tests_common::check_oflags(&file, oflags, R::Handle::FORCED_CLOEXEC)?;
+                tests_common::check_oflags(&file, oflags)?;
             }
         }
         Ok(())

--- a/src/tests/traits/handle.rs
+++ b/src/tests/traits/handle.rs
@@ -28,10 +28,6 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
     type Cloned: HandleImpl<Error = Self::Error> + Into<OwnedFd>;
     type Error: ErrorImpl;
 
-    // Does the implementation force O_CLOEXEC for reopen() even if the user
-    // didn't ask for it?
-    const FORCED_CLOEXEC: bool;
-
     // NOTE: We return Self::Cloned so that we can share types with HandleRef.
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
 
@@ -43,9 +39,6 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
 impl HandleImpl for Handle {
     type Cloned = Handle;
     type Error = Error;
-
-    // Rust impl forces O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = true;
 
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
@@ -64,9 +57,6 @@ impl HandleImpl for &Handle {
     type Cloned = Handle;
     type Error = Error;
 
-    // Rust impl forces O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = true;
-
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
@@ -84,9 +74,6 @@ impl HandleImpl for HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
 
-    // Rust impl forces O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = true;
-
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
@@ -103,9 +90,6 @@ impl HandleImpl for HandleRef<'_> {
 impl HandleImpl for &HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
-
-    // Rust impl forces O_CLOEXEC by default.
-    const FORCED_CLOEXEC: bool = true;
 
     fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
         Self::Cloned::from_fd(fd)


### PR DESCRIPTION
It is incredibly easy to unset O_CLOEXEC using fcntl, and most users
should want O_CLOEXEC. This also matches how newer kernel APIs are
designed (where O_CLOEXEC is the default).

Fixes #120
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>