### PR TITLE
errors: improve error APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   efficient in some scenarios (especially with the openat2-based resolver or
   for C FFI users where function calls are expensive) as it saves one file
   descriptor allocation and extra function calls.
+- Error: `ErrorKind` is now exported, allowing you to programmatically handle
+  errors returned by libpathrs. This interface may change in the future (in
+  particular, `ErrorKind::OsError` might change its representation of `errno`
+  values).
 - capi: errors that are returned by libpathrs itself (such as invalid arguments
   being passed by users) will now contain a `saved_errno` value that makes
   sense for the error type (so `ErrorKind::InvalidArgument` will result in an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   efficient in some scenarios (especially with the openat2-based resolver or
   for C FFI users where function calls are expensive) as it saves one file
   descriptor allocation and extra function calls.
+- capi: errors that are returned by libpathrs itself (such as invalid arguments
+  being passed by users) will now contain a `saved_errno` value that makes
+  sense for the error type (so `ErrorKind::InvalidArgument` will result in an
+  `EINVAL` value for `saved_errno`). This will allow C users to have a nicer
+  time handling errors programmatically.
 
 ### Fixes ###
 - multiarch: we now build correctly on 32-bit architectures as well as

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,6 +26,9 @@ pub(crate) mod common {
 
     mod handle;
     pub(in crate::tests) use handle::*;
+
+    mod error;
+    pub(in crate::tests) use error::*;
 }
 
 #[cfg(feature = "capi")]

--- a/src/tests/capi/utils.rs
+++ b/src/tests/capi/utils.rs
@@ -69,9 +69,10 @@ impl ErrorImpl for CapiError {
         if let Some(errno) = self.errno {
             ErrorKind::OsError(Some(errno.0))
         } else {
-            // TODO TODO: We should probably expose the libpathrs internal
-            // ErrorKind types in the C API somehow?
-            ErrorKind::InvalidArgument
+            // TODO: We should probably have an actual "no-op" error here that
+            //       is unused except for these tests so we can properly detect
+            //       a bad ErrorKind.
+            ErrorKind::ParseError
         }
     }
 }

--- a/src/tests/capi/utils.rs
+++ b/src/tests/capi/utils.rs
@@ -72,7 +72,7 @@ impl ErrorImpl for CapiError {
             // TODO: We should probably have an actual "no-op" error here that
             //       is unused except for these tests so we can properly detect
             //       a bad ErrorKind.
-            ErrorKind::ParseError
+            ErrorKind::InternalError
         }
     }
 }

--- a/src/tests/common/error.rs
+++ b/src/tests/common/error.rs
@@ -1,0 +1,51 @@
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2024 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2024 SUSE LLC
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{error::ErrorKind, tests::traits::ErrorImpl};
+
+use std::fmt::Debug;
+
+use anyhow::Error;
+
+pub(in crate::tests) fn check_err<T1, Err1, T2>(
+    result: &Result<T1, Err1>,
+    expected: &Result<T2, ErrorKind>,
+) -> Result<(), Error>
+where
+    T1: Debug,
+    Err1: ErrorImpl,
+    T2: Debug,
+{
+    let result = result.as_ref();
+    let expected = expected.as_ref();
+
+    match (result, expected) {
+        (Err(error), Err(expected_kind)) => {
+            let kind = error.kind();
+            if kind != *expected_kind {
+                anyhow::bail!(
+                    "expected error {expected_kind:?} but got {error:?} (kind: {kind:?})"
+                );
+            }
+        }
+        (Ok(_), Ok(_)) => (),
+        (result, expected) => anyhow::bail!("expected {expected:?} but got {result:?}"),
+    }
+    Ok(())
+}

--- a/src/tests/common/error.rs
+++ b/src/tests/common/error.rs
@@ -38,9 +38,11 @@ where
     match (result, expected) {
         (Err(error), Err(expected_kind)) => {
             let kind = error.kind();
-            if kind != *expected_kind {
+            let (result_errno, expected_errno) = (kind.errno(), expected_kind.errno());
+
+            if kind != *expected_kind && result_errno != expected_errno {
                 anyhow::bail!(
-                    "expected error {expected_kind:?} but got {error:?} (kind: {kind:?})"
+                    "expected error {expected_kind:?} (errno: {expected_errno:?}) but got {error:?} (kind: {kind:?}, errno: {result_errno:?})"
                 );
             }
         }

--- a/src/utils/sysctl.rs
+++ b/src/utils/sysctl.rs
@@ -114,7 +114,7 @@ mod tests {
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.printk")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::ParseError),
+            Err(ErrorKind::InternalError),
             "parsing line from multi-number sysctl",
         );
     }
@@ -126,7 +126,7 @@ mod tests {
             super::sysctl_read_parse::<u32>(&GLOBAL_PROCFS_HANDLE, "kernel.random.uuid")
                 .as_ref()
                 .map_err(Error::kind),
-            Err(ErrorKind::ParseError),
+            Err(ErrorKind::InternalError),
             "parsing line from non-number sysctl",
         );
     }


### PR DESCRIPTION
This primarily contains two useful fixes related to our error APIs:

 * `capi: error: map pure-Rust errors into equivalent errno values` (#60)
 * `errors: document and export ErrorKind` (#61)

From the changelog:

- Error: `ErrorKind` is now exported, allowing you to programmatically handle
  errors returned by libpathrs. This interface may change in the future (in
  particular, `ErrorKind::OsError` might change its representation of `errno`
  values).
- capi: errors that are returned by libpathrs itself (such as invalid arguments
  being passed by users) will now contain a `saved_errno` value that makes
  sense for the error type (so `ErrorKind::InvalidArgument` will result in an
  `EINVAL` value for `saved_errno`). This will allow C users to have a nicer
  time handling errors programmatically.

Fixes #60 
Fixes #61
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>