### PR TITLE
Root: do not error out with EEXIST for racing Root::mkdir_all()s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   it would return `-ELOOP` in most cases and in other cases it would return
   unexpected results because the `O_NOFOLLOW` would have an effect on the
   magic-link used internally by `Handle::reopen`.
+- `Root::mkdir_all` will no longer return `-EEXIST` if another process tried to
+  do `Root::mkdir_all` at the same time, instead the race winner's directory
+  will be used by both processes. See [opencontainers/runc#4543][] for more
+  details.
 
 ### Changed ###
 - syscalls: switch to rustix for most of our syscall wrappers to simplify how
@@ -68,6 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [rustix#1186]: https://github.com/bytecodealliance/rustix/issues/1186
 [rustix#1187]: https://github.com/bytecodealliance/rustix/issues/1187
+[opencontainers/runc#4543]: https://github.com/opencontainers/runc/issues/4543
 
 ## [0.1.3] - 2024-10-10 ##
 

--- a/src/capi/error.rs
+++ b/src/capi/error.rs
@@ -256,21 +256,40 @@ mod tests {
     }
 
     #[test]
-    fn cerror_no_errno() {
+    fn cerror_exdev_errno() {
         let err = Error::from(ErrorImpl::SafetyViolation {
             description: "fake safety violation".into(),
         });
 
         assert_eq!(
             err.kind().errno(),
+            Some(libc::EXDEV),
+            "SafetyViolation kind().errno() should return the right error"
+        );
+
+        let cerr = CError::from(&err);
+        assert_eq!(
+            cerr.saved_errno,
+            libc::EXDEV as u64,
+            "cerror should contain EXDEV errno for SafetyViolation"
+        );
+    }
+
+    #[test]
+    fn cerror_no_errno() {
+        let parse_err = "a123".parse::<i32>().unwrap_err();
+        let err = Error::from(parse_err);
+
+        assert_eq!(
+            err.kind().errno(),
             None,
-            "SafetyViolation kind().errno() should return the no errno"
+            "ParseIntError kind().errno() should return no errno"
         );
 
         let cerr = CError::from(&err);
         assert_eq!(
             cerr.saved_errno, 0,
-            "cerror should contain zero errno for SafetyViolation"
+            "cerror should contain zero errno for ParseIntError"
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -163,8 +163,8 @@ impl ErrorKind {
         match self {
             ErrorKind::NotImplemented => Some(libc::ENOSYS),
             ErrorKind::InvalidArgument => Some(libc::EINVAL),
+            ErrorKind::SafetyViolation => Some(libc::EXDEV),
             ErrorKind::OsError(errno) => *errno,
-            // TODO: Should we remap SafetyViolation?
             _ => None,
         }
     }
@@ -231,6 +231,11 @@ mod tests {
             ErrorKind::NotImplemented.errno(),
             Some(libc::ENOSYS),
             "ErrorKind::NotImplemented is equivalent to ENOSYS"
+        );
+        assert_eq!(
+            ErrorKind::SafetyViolation.errno(),
+            Some(libc::EXDEV),
+            "ErrorKind::SafetyViolation is equivalent to EXDEV"
         );
         assert_eq!(
             ErrorKind::OsError(Some(libc::ENOANO)).errno(),

--- a/src/root.rs
+++ b/src/root.rs
@@ -995,6 +995,12 @@ impl RootRef<'_> {
 
         // For the remaining components, create a each component one-by-one.
         for part in remaining_parts {
+            if part.as_bytes().contains(&b'/') {
+                Err(ErrorImpl::SafetyViolation {
+                    description: "remaining component for mkdir contains '/'".into(),
+                })?;
+            }
+
             // NOTE: mkdirat(2) does not follow trailing symlinks (even if it is
             // a dangling symlink with only a trailing component missing), so we
             // can safely create the final component without worrying about
@@ -1009,11 +1015,16 @@ impl RootRef<'_> {
             // Get a handle to the directory we just created. Unfortunately we
             // can't do an atomic create+open (a-la O_CREAT) with mkdirat(), so
             // a separate O_NOFOLLOW is the best we can do.
-            let next = self
-                .resolver
-                .resolve(&current, &part, true)
-                .and_then(|handle| handle.reopen(OpenFlags::O_DIRECTORY))
-                .wrap("failed to open newly-created directory with O_DIRECTORY")?;
+            let next = syscalls::openat(
+                &current,
+                &part,
+                OpenFlags::O_NOFOLLOW | OpenFlags::O_DIRECTORY,
+                0,
+            )
+            .map_err(|err| ErrorImpl::RawOsError {
+                operation: "open newly created directory".into(),
+                source: err,
+            })?;
 
             // Unfortunately, we cannot create a directory and open it
             // atomically (a-la O_CREAT). This means an attacker could swap our
@@ -1035,7 +1046,7 @@ impl RootRef<'_> {
             // doesn't seem to provide any practical benefit.
 
             // Keep walking.
-            current = next;
+            current = next.into();
         }
 
         Ok(Handle::from_fd(current))

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -254,9 +254,9 @@ pub(crate) enum Error {
 }
 
 impl Error {
-    fn errno(&self) -> &Errno {
+    pub(crate) fn errno(&self) -> Errno {
         // XXX: This should probably be a macro...
-        match self {
+        *match self {
             Error::InvalidFd { source, .. } => source,
             Error::Openat { source, .. } => source,
             Error::Openat2 { source, .. } => source,

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -401,14 +401,14 @@ root_op_tests! {
     nondir_symlink_dotdot: mkdir_all("b-file/../d", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     nondir_symlink_subdir: mkdir_all("b-file/subdir", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     // Dangling symlinks are not followed.
-    dangling1_trailing: mkdir_all("a-fake1", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
-    dangling1_basic: mkdir_all("a-fake1/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
+    dangling1_trailing: mkdir_all("a-fake1", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling1_basic: mkdir_all("a-fake1/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     dangling1_dotdot: mkdir_all("a-fake1/../bar/baz", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-    dangling2_trailing: mkdir_all("a-fake2", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
-    dangling2_basic: mkdir_all("a-fake2/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
+    dangling2_trailing: mkdir_all("a-fake2", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling2_basic: mkdir_all("a-fake2/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     dangling2_dotdot: mkdir_all("a-fake2/../bar/baz", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-    dangling3_trailing: mkdir_all("a-fake3", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
-    dangling3_basic: mkdir_all("a-fake3/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
+    dangling3_trailing: mkdir_all("a-fake3", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling3_basic: mkdir_all("a-fake3/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     dangling3_dotdot: mkdir_all("a-fake3/../bar/baz", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
     // Non-lexical symlinks should work.
     nonlexical_basic: mkdir_all("target/foo", 0o711) => Ok(());
@@ -423,11 +423,11 @@ root_op_tests! {
     nonlexical_level3_abs: mkdir_all("link3/target_abs/foo", 0o711) => Ok(());
     nonlexical_level3_rel: mkdir_all("link3/target_rel/foo", 0o711) => Ok(());
     // But really tricky dangling symlinks should fail.
-    dangling_tricky1_trailing: mkdir_all("link3/deep_dangling1", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
-    dangling_tricky1_basic: mkdir_all("link3/deep_dangling1/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
+    dangling_tricky1_trailing: mkdir_all("link3/deep_dangling1", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling_tricky1_basic: mkdir_all("link3/deep_dangling1/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     dangling_tricky1_dotdot: mkdir_all("link3/deep_dangling1/../bar", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
-    dangling_tricky2_trailing: mkdir_all("link3/deep_dangling2", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
-    dangling_tricky2_basic: mkdir_all("link3/deep_dangling2/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::EEXIST)));
+    dangling_tricky2_trailing: mkdir_all("link3/deep_dangling2", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    dangling_tricky2_basic: mkdir_all("link3/deep_dangling2/foo", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
     dangling_tricky2_dotdot: mkdir_all("link3/deep_dangling2/../bar", 0o711) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
     // And trying to mkdir inside a loop should fail.
     loop_trailing: mkdir_all("loop/link", 0o711) => Err(ErrorKind::OsError(Some(libc::ELOOP)));


### PR DESCRIPTION
If two programs are doing Root::mkdir_all, the previous logic would
return an error if a directory already existed once we got into the
"mkdir" portion of the creation.

Since we already have to accept that an attacker can swap the inode with
a different directory, returning -EEXIST from mkdirat(2) just causes
spurious errors. All we care about is that we open a directory.

Fixes #128 
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>