### PR TITLE
python bindings: switch to ruff linter

### DIFF
--- a/.github/workflows/bindings-python.yml
+++ b/.github/workflows/bindings-python.yml
@@ -32,24 +32,15 @@ env:
 name: bindings-python
 
 jobs:
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: black --check contrib/bindings/python
-        uses: psf/black@stable
+      - uses: astral-sh/ruff-action@v3
         with:
-          options: "--check --verbose"
-          src: "./contrib/bindings/python"
-          version: "~= 24.0"
-      - name: black --check examples/python
-        uses: psf/black@stable
-        with:
-          options: "--check --verbose"
-          src: "./examples/python"
-          version: "~= 24.0"
-
-  # TODO: Do some kind of lints?
+          args: "--version"
+      - run: ruff check
+      - run: ruff format --check --diff
 
   mypy:
     permissions:
@@ -178,7 +169,7 @@ jobs:
   complete:
     if: ${{ ! failure() && ! cancelled() }}
     needs:
-      - black
+      - ruff
       - mypy
       - build-pyproject
       - smoke-test

--- a/contrib/bindings/python/Makefile
+++ b/contrib/bindings/python/Makefile
@@ -28,7 +28,8 @@ clean:
 
 .PHONY: lint
 lint:
-	black --check .
+	ruff format --check --diff .
+	ruff check .
 	mypy .
 
 .PHONY: install

--- a/contrib/bindings/python/pathrs/__init__.py
+++ b/contrib/bindings/python/pathrs/__init__.py
@@ -19,7 +19,7 @@ import importlib
 import importlib.metadata
 
 from . import _pathrs
-from ._pathrs import *
+from ._pathrs import *  # noqa: F403 # We just re-export everything.
 
 # In order get pydoc to include the documentation for the re-exported code from
 # _pathrs, we need to include all of the members in __all__. Rather than

--- a/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
+++ b/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cffi
-
-from typing import Optional, overload, type_check_only, Union
+from typing import type_check_only, Union
 
 # TODO: Remove this once we only support Python >= 3.10.
 from typing_extensions import TypeAlias, Literal

--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -17,7 +17,6 @@
 
 import io
 import os
-import re
 import sys
 import copy
 import errno

--- a/contrib/bindings/python/pathrs/pathrs_build.py
+++ b/contrib/bindings/python/pathrs/pathrs_build.py
@@ -83,7 +83,7 @@ def find_rootdir() -> str:
             if re.findall(r'^name = "pathrs"$', content, re.MULTILINE):
                 root_dir = candidate
                 break
-        except:
+        except FileNotFoundError:
             pass
         candidate = os.path.dirname(candidate)
 


### PR DESCRIPTION
ruff includes both black-like formatting as well as general linting
(which we were previously missing) and it is much faster than the
alternatives.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>