### PR TITLE
procfs: remove GLOBAL_PROCFS_HANDLE

### DIFF
--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     error::{Error, ErrorImpl},
     flags::{OpenFlags, RenameFlags},
-    procfs::GLOBAL_PROCFS_HANDLE,
+    procfs::ProcfsHandle,
     utils::FdExt,
     InodeType, Root, RootRef,
 };
@@ -91,7 +91,7 @@ pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: c_int) -> RawFd {
 
     || -> Result<_, Error> {
         fd.try_as_borrowed_fd()?
-            .reopen(&GLOBAL_PROCFS_HANDLE, flags)
+            .reopen(&ProcfsHandle::new()?, flags)
     }()
     .into_c_return()
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -22,7 +22,7 @@
 use crate::{
     error::{Error, ErrorImpl},
     flags::OpenFlags,
-    procfs::GLOBAL_PROCFS_HANDLE,
+    procfs::ProcfsHandle,
     utils::FdExt,
 };
 
@@ -197,7 +197,7 @@ impl HandleRef<'_> {
     #[doc(alias = "pathrs_reopen")]
     pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
         self.inner
-            .reopen(&GLOBAL_PROCFS_HANDLE, flags.into())
+            .reopen(&ProcfsHandle::new()?, flags.into())
             .map(File::from)
     }
 

--- a/src/tests/capi/procfs.rs
+++ b/src/tests/capi/procfs.rs
@@ -32,8 +32,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// NOTE: The C API only lets us access the global GLOBAL_PROCFS_HANDLE
-// reference.
+// NOTE: The C API creates its own copy of the procfs handle internally
+// ProcfsHandle::new(), and does not provide any way of having your own procfs
+// handle.
 #[derive(Debug)]
 pub struct CapiProcfsHandle;
 

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -146,9 +146,9 @@ macro_rules! procfs_tests {
                 { ProcfsHandle::new_unsafe_open() }.$procfs_op($($args)*) => (over_mounts: true, $($tt)*);
         }
 
-        // Assume that GLOBAL_PROCFS_HANDLE is fsopen(2)-based.
+        // Assume that ProcfsHandle::new() is fsopen(2)-based.
         //
-        // TODO: Figure out the fd type of GLOBAL_PROCFS_HANDLE. In principle we
+        // TODO: Figure out the fd type of ProcfsHandle::new(). In principle we
         // would expect to be able to do fsopen(2) (otherwise the fsopen(2)
         // tests will fail) but it would be nice to avoid possible spurious
         // errors.

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -310,7 +310,7 @@ pub(crate) fn fetch_mnt_id<Fd: AsFd, P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{flags::OpenFlags, procfs::GLOBAL_PROCFS_HANDLE, syscalls, utils::FdExt};
+    use crate::{flags::OpenFlags, procfs::ProcfsHandle, syscalls, utils::FdExt};
 
     use std::{
         fs::File,
@@ -332,7 +332,7 @@ mod tests {
             "expected as_unsafe_path_unchecked to give the correct path"
         );
         // ProcfsHandle-based lookup.
-        let got_path = fd.as_unsafe_path(&GLOBAL_PROCFS_HANDLE)?;
+        let got_path = fd.as_unsafe_path(&ProcfsHandle::new()?)?;
         assert_eq!(
             got_path, want_path,
             "expected as_unsafe_path to give the correct path"
@@ -354,27 +354,29 @@ mod tests {
     }
 
     #[test]
-    fn as_unsafe_path_badfd() {
+    fn as_unsafe_path_badfd() -> Result<(), Error> {
         assert!(
             syscalls::BADFD.as_unsafe_path_unchecked().is_err(),
             "as_unsafe_path_unchecked should fail for bad file descriptor"
         );
         assert!(
             syscalls::BADFD
-                .as_unsafe_path(&GLOBAL_PROCFS_HANDLE)
+                .as_unsafe_path(&ProcfsHandle::new()?)
                 .is_err(),
             "as_unsafe_path should fail for bad file descriptor"
         );
+        Ok(())
     }
 
     #[test]
-    fn reopen_badfd() {
+    fn reopen_badfd() -> Result<(), Error> {
         assert!(
             syscalls::BADFD
-                .reopen(&GLOBAL_PROCFS_HANDLE, OpenFlags::O_PATH)
+                .reopen(&ProcfsHandle::new()?, OpenFlags::O_PATH)
                 .is_err(),
             "reopen should fail for bad file descriptor"
         );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
CVE-2024-21626 showed that long-lived file descriptors (even with
O_CLOEXEC set) can be used to attack container runtimes, and so it seems
less than prudent for libpathrs to silently create a long-lived file
descriptor to eek out (what I expect to be) a fairly small performance
benefit.

Rust users can create their own level of caching when interacting with
ProcfsHandle directly (where you expect ProcfsHandle::new() to be the
hottest after this patch) if they wish.

Implements #203
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>