### PR TITLE
syscalls: openat2: mirror openat / openat_follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
       directory (otherwise you get `ENOTDIR`).
 - opath resolver: we now return `ELOOP` when we run into a symlink that came
   from mount with the `MS_NOSYMFOLLOW` set, to match the behaviour of `openat2`.
+- openat2: we now set `O_NOCTTY` and `O_NOFOLLOW` more aggressively when doing
+  `openat2` operations, to avoid theoretical DoS attacks (these were set for
+  `openat` but we missed including them for `openat2`).
 
 ### Changed ###
 - syscalls: switch to rustix for most of our syscall wrappers to simplify how

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -54,7 +54,7 @@ pub(crate) fn open<Fd: AsFd, P: AsRef<Path>>(
         ..Default::default()
     };
 
-    syscalls::openat2(&root, path.as_ref(), &how)
+    syscalls::openat2_follow(&root, path.as_ref(), how)
         .map(File::from)
         .map_err(|err| {
             ErrorImpl::RawOsError {
@@ -96,7 +96,7 @@ pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
     // do is attempt the openat2(2) a couple of times. If it still fails, just
     // error out.
     for _ in 0..16 {
-        match syscalls::openat2(&root, path.as_ref(), &how) {
+        match syscalls::openat2_follow(&root, path.as_ref(), how) {
             Ok(file) => return Ok(Handle::from_fd(file)),
             Err(err) => match err.root_cause().raw_os_error() {
                 Some(libc::ENOSYS) => {

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -116,10 +116,10 @@ fn openat2_resolve<Fd: AsFd, P: AsRef<Path>>(
     let rflags =
         libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_XDEV | rflags.bits();
 
-    syscalls::openat2(
+    syscalls::openat2_follow(
         root,
         path,
-        &OpenHow {
+        OpenHow {
             flags: oflags,
             resolve: rflags,
             ..Default::default()


### PR DESCRIPTION
We should have always set O_NOCTTY, as with openat(2) because resolution
scoping flags don't affect the safety risks of opening PTYs.

As for auto-setting O_NOFOLLOW (and having openat2_follow), while
O_NOFOLLOW is safe when doing scoped lookups (RESOLVE_BENEATH and
RESOLVE_IN_ROOT), not every openat2 invocation is going to be using
scoped lookups. For safety, we should have the same scheme -- especially
since it's clear that we will always have these wrappers.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>