### PR TITLE
resolvers: add opt-out openat2 feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --workspace --all-features --all-targets
+      - uses: taiki-e/install-action@cargo-hack
+      - name: cargo check
+        run: >-
+          cargo hack --workspace --feature-powerset --keep-going \
+            check --all-targets
 
   check-msrv:
     name: cargo check (msrv)
@@ -55,7 +59,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_MSRV }}
-      - run: cargo check --workspace --all-features --all-targets
+      - uses: taiki-e/install-action@cargo-hack
+      - name: cargo check
+        run: >-
+          cargo hack --workspace --feature-powerset --keep-going \
+            check --all-targets
 
   check-cross:
     strategy:
@@ -84,12 +92,28 @@ jobs:
         with:
           # TODO: Should we use MSRV for this?
           targets: ${{ matrix.target }}
+      - uses: taiki-e/install-action@cargo-hack
       - name: cargo check --target=${{ matrix.target }}
         run: >-
-          cargo check --target=${{ matrix.target }} --workspace --all-features --all-targets
+          cargo hack --workspace --feature-powerset --keep-going \
+            check --target=${{ matrix.target }} --all-targets
       - name: cargo build --target=${{ matrix.target }}
         run: >-
-          cargo build --target=${{ matrix.target }} --release --all-features
+          cargo hack --workspace --feature-powerset --keep-going \
+            build --target=${{ matrix.target }} --release
+
+  check-lint-nohack:
+    name: make lint (no cargo-hack)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt,clippy
+      - name: install cbindgen
+        run: cargo install --force cbindgen
+      - name: make lint
+        run: make CARGO_NIGHTLY=cargo lint
 
   validate-cbindgen:
     runs-on: ubuntu-latest
@@ -124,6 +148,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-hack
 
       # Rust tests.
       - name: rust doc tests
@@ -172,7 +197,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88
         with:
           components: clippy
-      - run: cargo clippy --all-features --all-targets
+      - uses: taiki-e/install-action@cargo-hack
+      - name: cargo clippy
+        run: >-
+          cargo hack --workspace --feature-powerset --keep-going \
+            clippy --all-targets
 
   release-crate:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -205,6 +234,7 @@ jobs:
       - check
       - check-msrv
       - check-cross
+      - check-lint-nohack
       - validate-cbindgen
       - rustdoc
       - test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,20 @@ maintenance = { status = "experimental" }
 crate-type = ["rlib"]
 
 [features]
+default = []
 capi = ["dep:rand", "dep:open-enum"]
-# Only used for tests.
+# All of these _test_* features are only used for our own tests -- they must
+# not be used by actual users of libpathrs! The leading "_" should mean that
+# they are hidden from documentation (such as the features list on crates.io).
 _test_as_root = []
+# NOTE: These features _disable_ functionality! This is generally a no-no when
+# designing features, but since these features are internal-only and must be
+# enabled-by-default, the alternative would be to add undocumented features to
+# the default-features set and make --no-default-features disable core parts of
+# libpathrs. So instead, these features disable features but only in an
+# "additive way" (by forcing the syscall wrapper to return -ENOSYS). This
+# should avoid the possible issues with non-additive features.
+_test_enosys_openat2 = []
 
 [profile.release]
 # Enable link-time optimisations.

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -48,6 +48,7 @@ macro_rules! procfs_tests {
 
             #[test]
             $(#[$meta])*
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             fn [<procfs_overmounts_ $func_prefix openat2_ $test_name>]() -> Result<(), Error> {
                 if !*syscalls::OPENAT2_IS_SUPPORTED {
                     // skip this test
@@ -68,6 +69,7 @@ macro_rules! procfs_tests {
 
             #[test]
             $(#[$meta])*
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             fn [<procfs_overmounts_ $func_prefix opath_ $test_name>]() -> Result<(), Error> {
                 utils::[<check_proc_ $procfs_op>](
                     || {
@@ -117,21 +119,21 @@ macro_rules! procfs_tests {
 
         procfs_tests! {
             $(#[$meta])*
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             @rust-fn [<new_fsopen_ $test_name>]
                 { ProcfsHandle::new_fsopen(false) }.$procfs_op($($args)*) => (over_mounts: false, $($tt)*);
         }
 
         procfs_tests! {
             $(#[$meta])*
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             @rust-fn [<new_fsopen_subset_ $test_name>]
                 { ProcfsHandle::new_fsopen(true) }.$procfs_op($($args)*) => (over_mounts: false, $($tt)*);
         }
 
         procfs_tests! {
             $(#[$meta])*
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             @rust-fn [<new_open_tree_ $test_name>]
                 {
                     ProcfsHandle::new_open_tree(OpenTreeFlags::OPEN_TREE_CLONE)
@@ -140,7 +142,7 @@ macro_rules! procfs_tests {
 
         procfs_tests! {
             $(#[$meta])*
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             @rust-fn [<new_open_tree_recursive_ $test_name>]
                 {
                     ProcfsHandle::new_open_tree(OpenTreeFlags::OPEN_TREE_CLONE | OpenTreeFlags::AT_RECURSIVE)
@@ -170,7 +172,7 @@ macro_rules! procfs_tests {
     ($(#[cfg($ignore_meta:meta)])* $test_name:ident : readlink (ProcfsBase::$base:ident $(($pid:literal))?, $path:expr ) => ($($tt:tt)*)) => {
         paste::paste! {
             procfs_tests! {
-                $(#[cfg_attr(not($ignore_meta), ignore)])*
+                $(#[cfg_attr(not($ignore_meta), ignore, allow(unused_attributes))])*
                 @impl [<$base:lower $($pid)* _readlink_ $test_name>]
                     procfs.readlink(ProcfsBase::$base $(($pid))*, $path) => ($($tt)*);
             }
@@ -181,7 +183,7 @@ macro_rules! procfs_tests {
     ($(#[cfg($ignore_meta:meta)])* $test_name:ident : open (ProcfsBase::$base:ident $(($pid:literal))?, $path:expr, $($flag:ident)|* ) => ($($tt:tt)*)) => {
         paste::paste! {
             procfs_tests! {
-                $(#[cfg_attr(not($ignore_meta), ignore)])*
+                $(#[cfg_attr(not($ignore_meta), ignore, allow(unused_attributes))])*
                 @impl [<$base:lower $($pid)* _open_ $test_name>]
                     procfs.open(ProcfsBase::$base $(($pid))*, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
             }
@@ -192,7 +194,7 @@ macro_rules! procfs_tests {
     ($(#[cfg($ignore_meta:meta)])* $test_name:ident : open_follow (ProcfsBase::$base:ident $(($pid:literal))?, $path:expr, $($flag:ident)|* ) => ($($tt:tt)*)) => {
         paste::paste! {
             procfs_tests! {
-                $(#[cfg_attr(not($ignore_meta), ignore)])*
+                $(#[cfg_attr(not($ignore_meta), ignore, allow(unused_attributes))])*
                 @impl [<$base:lower $($pid)* _open_follow_ $test_name>]
                     procfs.open_follow(ProcfsBase::$base $(($pid))*, $path, $(OpenFlags::$flag)|*) => ($($tt)*);
             }

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -74,6 +74,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 utils::$with_root_fn(|root_dir: &Path| {
@@ -97,6 +98,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<rootref_ $test_name _openat2>]() -> Result<(), Error> {
                 utils::$with_root_fn(|root_dir: &Path| {
@@ -120,6 +122,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 utils::$with_root_fn(|root_dir: &Path| {
@@ -143,6 +146,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<rootref_ $test_name _opath>]() -> Result<(), Error> {
                 utils::$with_root_fn(|root_dir: &Path| {
@@ -173,8 +177,8 @@ macro_rules! resolve_tests {
 
     ([$with_root_fn:ident] $(#[cfg($ignore_meta:meta)])* capi-fn $test_name:ident ($root_var:ident : CapiRoot) $body:block => $expected:expr) => {
         paste::paste! {
-            #[cfg(feature = "capi")]
             #[test]
+            #[cfg(feature = "capi")]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<capi_root_ $test_name>]() -> Result<(), Error> {
                 utils::$with_root_fn(|root_dir: &Path| {

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -54,6 +54,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 utils::$with_root_fn(|mut $root_var: Root| {
@@ -76,6 +77,7 @@ macro_rules! resolve_tests {
             }
 
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 utils::$with_root_fn(|mut $root_var: Root| {

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -34,8 +34,8 @@ use anyhow::Error;
 macro_rules! root_op_tests {
     ($(#[$meta:meta])* fn $test_name:ident ($root_var:ident) $body:block) => {
         paste::paste! {
-            $(#[$meta])*
             #[test]
+            $(#[$meta])*
             fn [<root_ $test_name>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let $root_var = Root::open(&root_dir)?;
@@ -43,8 +43,8 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
             #[test]
+            $(#[$meta])*
             fn [<rootref_ $test_name>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let root = Root::open(&root_dir)?;
@@ -53,8 +53,9 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
+            $(#[$meta])*
             fn [<root_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let $root_var = Root::open(&root_dir)?
@@ -67,8 +68,9 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
+            $(#[$meta])*
             fn [<rootref_ $test_name _openat2>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let root = Root::open(&root_dir)?;
@@ -83,8 +85,9 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
+            $(#[$meta])*
             fn [<root_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let $root_var = Root::open(&root_dir)?
@@ -98,8 +101,9 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
             #[test]
+            #[cfg_attr(feature = "_test_enosys_openat2", ignore, allow(unused_attributes))]
+            $(#[$meta])*
             fn [<rootref_ $test_name _opath>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let root = Root::open(&root_dir)?;
@@ -115,9 +119,9 @@ macro_rules! root_op_tests {
                 $body
             }
 
-            $(#[$meta])*
-            #[cfg(feature = "capi")]
             #[test]
+            #[cfg(feature = "capi")]
+            $(#[$meta])*
             fn [<capi_root_ $test_name>]() -> Result<(), Error> {
                 let root_dir = tests_common::create_basic_tree()?;
                 let $root_var = capi::CapiRoot::open(&root_dir)?;
@@ -179,7 +183,7 @@ macro_rules! root_op_tests {
     };
     ($(#[cfg($ignore_meta:meta)])* @impl mkblk $test_name:ident ($path:expr, $mode:literal, $major:literal, $minor:literal) => $expected_result:expr) => {
         root_op_tests!{
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             @mknod fn $test_name ($path) {
                 InodeType::BlockDevice(Permissions::from_mode($mode), libc::makedev($major, $minor))
@@ -188,7 +192,7 @@ macro_rules! root_op_tests {
     };
     ($(#[cfg($ignore_meta:meta)])* @impl mkchar $test_name:ident ($path:expr, $mode:literal, $major:literal, $minor:literal) => $expected_result:expr) => {
         root_op_tests!{
-            #[cfg_attr(not(feature = "_test_as_root"), ignore)]
+            #[cfg_attr(not(feature = "_test_as_root"), ignore, allow(unused_attributes))]
             $(#[cfg_attr(not($ignore_meta), ignore)])*
             @mknod fn $test_name ($path) {
                 InodeType::CharacterDevice(Permissions::from_mode($mode), libc::makedev($major, $minor))


### PR DESCRIPTION
This will allow us to test our code in a way that emulates kernels
without openat2 (or openat2 disabled with seccomp).

Rather than #[cfg(...)]-gating every bit of openat2 code, it is much
less messy to just make the underlying syscall wrapper return -ENOSYS
(which will then cause *OPENAT2_IS_SUPPORTED to be false). This will
also let us test -ENOSYS fallbacks. Though, we need to disallow the
KernelOpenat2 to stop things from explicitly requesting that resolver.

Also, now that we have default features we need to run checks and tests
with them disabled.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>