### PR TITLE
*: switch to impl Trait for most APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   overwhelm the performance overhead of even `fsopen(2)`. It might make sense
   to revisit this in the future -- please open an issue if you can demonstrate
   that the lack of caching causes a measurable performance issue.
+- api: many of the generic type parameters have been replaced with `impl Trait`
+  arguments, in order to make using libpathrs a bit more ergonomic. Unless you
+  were specifically setting the generic types with `::<>` syntax, this change
+  should not affect you.
 
 ### Fixes ###
 - multiarch: we now build correctly on 32-bit architectures as well as

--- a/src/capi/utils.rs
+++ b/src/capi/utils.rs
@@ -99,8 +99,8 @@ pub(crate) unsafe fn parse_path<'a>(path: *const c_char) -> Result<&'a Path, Err
     Ok(OsStr::from_bytes(bytes).as_ref())
 }
 
-pub(crate) unsafe fn copy_path_into_buffer<P: AsRef<Path>>(
-    path: P,
+pub(crate) unsafe fn copy_path_into_buffer(
+    path: impl AsRef<Path>,
     buf: *mut c_char,
     bufsize: size_t,
 ) -> Result<c_int, Error> {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -54,7 +54,7 @@ pub struct Handle {
 impl Handle {
     /// Wrap an [`OwnedFd`] into a [`Handle`].
     #[inline]
-    pub fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    pub fn from_fd(fd: impl Into<OwnedFd>) -> Self {
         Self { inner: fd.into() }
     }
 
@@ -95,7 +95,7 @@ impl Handle {
     /// [`Root::create`]: crate::Root::create
     #[doc(alias = "pathrs_reopen")]
     #[inline]
-    pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
+    pub fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Error> {
         self.as_ref().reopen(flags)
     }
 }
@@ -195,7 +195,7 @@ impl HandleRef<'_> {
     ///
     /// [`Root::create`]: crate::Root::create
     #[doc(alias = "pathrs_reopen")]
-    pub fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Error> {
+    pub fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Error> {
         self.inner
             .reopen(&ProcfsHandle::new()?, flags.into())
             .map(File::from)

--- a/src/resolvers.rs
+++ b/src/resolvers.rs
@@ -206,11 +206,11 @@ impl From<PartialLookup<Rc<OwnedFd>>> for PartialLookup<Handle> {
 }
 
 impl Resolver {
-    pub(crate) fn open<Fd: AsFd, P: AsRef<Path>, F: Into<OpenFlags>>(
+    pub(crate) fn open(
         &self,
-        root: Fd,
-        path: P,
-        flags: F,
+        root: impl AsFd,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Error> {
         let flags = flags.into();
 
@@ -272,10 +272,10 @@ impl Resolver {
     }
 
     #[inline]
-    pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
+    pub(crate) fn resolve(
         &self,
-        root: Fd,
-        path: P,
+        root: impl AsFd,
+        path: impl AsRef<Path>,
         no_follow_trailing: bool,
     ) -> Result<Handle, Error> {
         match self.backend {
@@ -289,10 +289,10 @@ impl Resolver {
     }
 
     #[inline]
-    pub(crate) fn resolve_partial<Fd: AsFd, P: AsRef<Path>>(
+    pub(crate) fn resolve_partial(
         &self,
-        root: Fd,
-        path: P,
+        root: impl AsFd,
+        path: impl AsRef<Path>,
         no_follow_trailing: bool,
     ) -> Result<PartialLookup<Handle>, Error> {
         match self.backend {

--- a/src/resolvers/opath/imp.rs
+++ b/src/resolvers/opath/imp.rs
@@ -64,11 +64,11 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 
 /// Ensure that the expected path within the root matches the current fd.
-fn check_current<RootFd: AsFd, Fd: AsFd, P: AsRef<Path>>(
+fn check_current(
     procfs: &ProcfsHandle,
-    current: Fd,
-    root: RootFd,
-    expected: P,
+    current: impl AsFd,
+    root: impl AsFd,
+    expected: impl AsRef<Path>,
 ) -> Result<(), Error> {
     // SAFETY: as_unsafe_path is safe here since we're using it to build a path
     //         for a string-based check as part of a larger safety setup. This
@@ -147,7 +147,7 @@ static PROTECTED_SYMLINKS_SYSCTL: Lazy<u32> = Lazy::new(|| {
 ///
 /// Because we emulate symlink following in userspace, the kernel cannot apply
 /// `fs.protected_symlinks` restrictions so we need to emulate them ourselves.
-fn may_follow_link<DirFd: AsFd, Fd: AsFd>(dir: DirFd, link: Fd) -> Result<(), Error> {
+fn may_follow_link(dir: impl AsFd, link: impl AsFd) -> Result<(), Error> {
     let link = link.as_fd();
 
     // Not exposed by rustix. rustix::fs::StatVfs has a proper bitflags type but
@@ -204,9 +204,9 @@ fn may_follow_link<DirFd: AsFd, Fd: AsFd>(dir: DirFd, link: Fd) -> Result<(), Er
 /// difference is that if `symlink_stack` is `true`, the returned paths
 // TODO: Make (flags, no_follow_trailing, symlink_stack) a single struct to
 //       avoid possible issues with passing a bool to the wrong argument.
-fn do_resolve<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+fn do_resolve(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     flags: ResolverFlags,
     no_follow_trailing: bool,
     mut symlink_stack: Option<&mut SymlinkStack<OwnedFd>>,
@@ -493,9 +493,9 @@ fn do_resolve<Fd: AsFd, P: AsRef<Path>>(
 
 /// Resolve as many components as possible in `path` within `root` through
 /// user-space emulation.
-pub(crate) fn resolve_partial<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+pub(crate) fn resolve_partial(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     flags: ResolverFlags,
     no_follow_trailing: bool,
 ) -> Result<PartialLookup<Rc<OwnedFd>>, Error> {
@@ -539,9 +539,9 @@ pub(crate) fn resolve_partial<Fd: AsFd, P: AsRef<Path>>(
 }
 
 /// Resolve `path` within `root` through user-space emulation.
-pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+pub(crate) fn resolve(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     flags: ResolverFlags,
     no_follow_trailing: bool,
 ) -> Result<Handle, Error> {

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -35,9 +35,9 @@ use std::{
 /// Open `path` within `root` through `openat(2)`.
 ///
 /// This is an optimised version of `resolve(root, path, ...)?.reopen(flags)`.
-pub(crate) fn open<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+pub(crate) fn open(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     rflags: ResolverFlags,
     oflags: OpenFlags,
 ) -> Result<File, Error> {
@@ -66,9 +66,9 @@ pub(crate) fn open<Fd: AsFd, P: AsRef<Path>>(
 }
 
 /// Resolve `path` within `root` through `openat2(2)`.
-pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+pub(crate) fn resolve(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     rflags: ResolverFlags,
     no_follow_trailing: bool,
 ) -> Result<Handle, Error> {
@@ -123,13 +123,15 @@ pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
 
 /// Resolve as many components as possible in `path` within `root` using
 /// `openat2(2)`.
-pub(crate) fn resolve_partial<Fd: AsFd>(
-    root: Fd,
-    path: &Path,
+pub(crate) fn resolve_partial(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     rflags: ResolverFlags,
     no_follow_trailing: bool,
 ) -> Result<PartialLookup<Handle>, Error> {
     let root = root.as_fd();
+    let path = path.as_ref();
+
     let mut last_error = match resolve(root, path, rflags, no_follow_trailing) {
         Ok(handle) => return Ok(PartialLookup::Complete(handle)),
         Err(err) => err,

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -67,10 +67,10 @@ impl Default for ProcfsResolver {
 }
 
 impl ProcfsResolver {
-    pub(crate) fn resolve<Fd: AsFd, P: AsRef<Path>>(
+    pub(crate) fn resolve(
         &self,
-        root: Fd,
-        path: P,
+        root: impl AsFd,
+        path: impl AsRef<Path>,
         oflags: OpenFlags,
         rflags: ResolverFlags,
     ) -> Result<OwnedFd, Error> {
@@ -99,9 +99,9 @@ impl ProcfsResolver {
 /// [`openat2`][openat2.2]-based implementation of [`ProcfsResolver`].
 ///
 /// [openat2.2]: https://www.man7.org/linux/man-pages/man2/openat2.2.html
-fn openat2_resolve<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+fn openat2_resolve(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     oflags: OpenFlags,
     rflags: ResolverFlags,
 ) -> Result<OwnedFd, Error> {
@@ -135,9 +135,9 @@ fn openat2_resolve<Fd: AsFd, P: AsRef<Path>>(
 }
 
 /// `O_PATH`-based implementation of [`ProcfsResolver`].
-fn opath_resolve<Fd: AsFd, P: AsRef<Path>>(
-    root: Fd,
-    path: P,
+fn opath_resolve(
+    root: impl AsFd,
+    path: impl AsRef<Path>,
     oflags: OpenFlags,
     rflags: ResolverFlags,
 ) -> Result<OwnedFd, Error> {

--- a/src/root.rs
+++ b/src/root.rs
@@ -157,7 +157,7 @@ impl Root {
     /// fully-resolved pathname with no symlink components. This restriction
     /// might be relaxed in the future.
     #[doc(alias = "pathrs_open_root")]
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         let file = syscalls::openat(
             syscalls::AT_FDCWD,
             path,
@@ -179,7 +179,7 @@ impl Root {
     /// The configuration is set to the system default and should be configured
     /// prior to usage, if appropriate.
     #[inline]
-    pub fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    pub fn from_fd(fd: impl Into<OwnedFd>) -> Self {
         Self {
             inner: fd.into(),
             resolver: Default::default(),
@@ -273,7 +273,7 @@ impl Root {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_resolve")]
     #[inline]
-    pub fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
+    pub fn resolve(&self, path: impl AsRef<Path>) -> Result<Handle, Error> {
         self.as_ref().resolve(path)
     }
 
@@ -288,7 +288,7 @@ impl Root {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_resolve_nofollow")]
     #[inline]
-    pub fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
+    pub fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Handle, Error> {
         self.as_ref().resolve_nofollow(path)
     }
 
@@ -318,10 +318,10 @@ impl Root {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_open")]
     #[inline]
-    pub fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    pub fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Error> {
         self.as_ref().open_subpath(path, flags)
     }
@@ -339,7 +339,7 @@ impl Root {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_readlink")]
     #[inline]
-    pub fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Error> {
+    pub fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Error> {
         self.as_ref().readlink(path)
     }
 
@@ -355,7 +355,7 @@ impl Root {
     #[doc(alias = "pathrs_inroot_symlink")]
     #[doc(alias = "pathrs_inroot_hardlink")]
     #[inline]
-    pub fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Error> {
+    pub fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Error> {
         self.as_ref().create(path, inode_type)
     }
 
@@ -386,10 +386,10 @@ impl Root {
     #[doc(alias = "pathrs_inroot_creat")]
     #[doc(alias = "pathrs_inroot_create")]
     #[inline]
-    pub fn create_file<P: AsRef<Path>>(
+    pub fn create_file(
         &self,
-        path: P,
-        flags: OpenFlags,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
         perm: &Permissions,
     ) -> Result<File, Error> {
         self.as_ref().create_file(path, flags, perm)
@@ -423,7 +423,7 @@ impl Root {
     /// [`os.MkdirAll`]: https://pkg.go.dev/os#MkdirAll
     #[doc(alias = "pathrs_inroot_mkdir_all")]
     #[inline]
-    pub fn mkdir_all<P: AsRef<Path>>(&self, path: P, perm: &Permissions) -> Result<Handle, Error> {
+    pub fn mkdir_all(&self, path: impl AsRef<Path>, perm: &Permissions) -> Result<Handle, Error> {
         self.as_ref().mkdir_all(path, perm)
     }
 
@@ -442,7 +442,7 @@ impl Root {
     /// [`remove_all`]: Self::remove_all
     #[doc(alias = "pathrs_inroot_rmdir")]
     #[inline]
-    pub fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         self.as_ref().remove_dir(path)
     }
 
@@ -462,7 +462,7 @@ impl Root {
     /// [`remove_all`]: Self::remove_all
     #[doc(alias = "pathrs_inroot_unlink")]
     #[inline]
-    pub fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         self.as_ref().remove_file(path)
     }
 
@@ -483,7 +483,7 @@ impl Root {
     /// [`os.RemoveAll`]: https://pkg.go.dev/os#RemoveAll
     #[doc(alias = "pathrs_inroot_remove_all")]
     #[inline]
-    pub fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         self.as_ref().remove_all(path)
     }
 
@@ -497,10 +497,10 @@ impl Root {
     ///
     /// [`renameat2(2)`]: http://man7.org/linux/man-pages/man2/renameat2.2.html
     #[doc(alias = "pathrs_inroot_rename")]
-    pub fn rename<P: AsRef<Path>>(
+    pub fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Error> {
         self.as_ref().rename(source, destination, rflags)
@@ -697,7 +697,7 @@ impl RootRef<'_> {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_resolve")]
     #[inline]
-    pub fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
+    pub fn resolve(&self, path: impl AsRef<Path>) -> Result<Handle, Error> {
         self.resolver.resolve(self, path, false)
     }
 
@@ -712,7 +712,7 @@ impl RootRef<'_> {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_resolve_nofollow")]
     #[inline]
-    pub fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Handle, Error> {
+    pub fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Handle, Error> {
         self.resolver.resolve(self, path, true)
     }
 
@@ -742,10 +742,10 @@ impl RootRef<'_> {
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_open")]
     #[inline]
-    pub fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    pub fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Error> {
         self.resolver.open(self, path, flags)
     }
@@ -836,7 +836,7 @@ impl RootRef<'_> {
     /// [`resolve`]: Self::resolve
     /// [`resolve_nofollow`]: Self::resolve_nofollow
     #[doc(alias = "pathrs_inroot_readlink")]
-    pub fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Error> {
+    pub fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Error> {
         let link = self
             .resolve_nofollow(path)
             .wrap("resolve symlink O_NOFOLLOW for readlink")?;
@@ -860,7 +860,7 @@ impl RootRef<'_> {
     #[doc(alias = "pathrs_inroot_mknod")]
     #[doc(alias = "pathrs_inroot_symlink")]
     #[doc(alias = "pathrs_inroot_hardlink")]
-    pub fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Error> {
+    pub fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Error> {
         // The path doesn't exist yet, so we need to get a safe reference to the
         // parent and just operate on the final (slashless) component.
         let (dir, name, trailing_slash) = self
@@ -952,12 +952,14 @@ impl RootRef<'_> {
     /// [`O_CREAT`]: http://man7.org/linux/man-pages/man2/open.2.html
     #[doc(alias = "pathrs_inroot_creat")]
     #[doc(alias = "pathrs_inroot_create")]
-    pub fn create_file<P: AsRef<Path>>(
+    pub fn create_file(
         &self,
-        path: P,
-        mut flags: OpenFlags,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
         perm: &Permissions,
     ) -> Result<File, Error> {
+        let mut flags = flags.into();
+
         // The path doesn't exist yet, so we need to get a safe reference to the
         // parent and just operate on the final (slashless) component.
         let (dir, name, trailing_slash) = self
@@ -1015,7 +1017,7 @@ impl RootRef<'_> {
     ///
     /// [`os.MkdirAll`]: https://pkg.go.dev/os#MkdirAll
     #[doc(alias = "pathrs_inroot_mkdir_all")]
-    pub fn mkdir_all<P: AsRef<Path>>(&self, path: P, perm: &Permissions) -> Result<Handle, Error> {
+    pub fn mkdir_all(&self, path: impl AsRef<Path>, perm: &Permissions) -> Result<Handle, Error> {
         if perm.mode() & !0o7777 != 0 {
             Err(ErrorImpl::InvalidArgument {
                 name: "perm".into(),
@@ -1204,7 +1206,7 @@ impl RootRef<'_> {
     /// [`remove_all`]: Self::remove_all
     #[doc(alias = "pathrs_inroot_rmdir")]
     #[inline]
-    pub fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         self.remove_inode(path.as_ref(), RemoveInodeType::Directory)
     }
 
@@ -1224,7 +1226,7 @@ impl RootRef<'_> {
     /// [`remove_all`]: Self::remove_all
     #[doc(alias = "pathrs_inroot_unlink")]
     #[inline]
-    pub fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         self.remove_inode(path.as_ref(), RemoveInodeType::Regular)
     }
 
@@ -1244,7 +1246,7 @@ impl RootRef<'_> {
     ///
     /// [`os.RemoveAll`]: https://pkg.go.dev/os#RemoveAll
     #[doc(alias = "pathrs_inroot_remove_all")]
-    pub fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         // Ignore trailing slashes -- we want to support handling trailing
         // slashes for directories, but adding resolve_exists_parent-like
         // verification logic to remove_all() is a bit much. So we just ignore
@@ -1268,10 +1270,10 @@ impl RootRef<'_> {
     ///
     /// [`renameat2(2)`]: http://man7.org/linux/man-pages/man2/renameat2.2.html
     #[doc(alias = "pathrs_inroot_rename")]
-    pub fn rename<P: AsRef<Path>>(
+    pub fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Error> {
         // renameat2(2) doesn't let us rename paths using AT_EMPTY_PATH handles.

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -307,9 +307,9 @@ impl<Fd: AsFd + Sized> HotfixRustixFd for Fd {
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `openat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn openat_follow<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn openat_follow(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mut flags: OpenFlags,
     mode: RawMode, // TODO: Should we take rustix::fs::Mode directly?
 ) -> Result<OwnedFd, Error> {
@@ -335,9 +335,9 @@ pub(crate) fn openat_follow<Fd: AsFd, P: AsRef<Path>>(
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `openat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn openat<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn openat(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mut flags: OpenFlags,
     mode: RawMode, // TODO: Should we take rustix::fs::Mode directly?
 ) -> Result<OwnedFd, Error> {
@@ -350,7 +350,7 @@ pub(crate) fn openat<Fd: AsFd, P: AsRef<Path>>(
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `readlinkat(2)`. We need the dirfd argument, so we need a
 /// wrapper.
-pub(crate) fn readlinkat<Fd: AsFd, P: AsRef<Path>>(dirfd: Fd, path: P) -> Result<PathBuf, Error> {
+pub(crate) fn readlinkat(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<PathBuf, Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
     let path = path.as_ref();
 
@@ -386,9 +386,9 @@ pub(crate) fn readlinkat<Fd: AsFd, P: AsRef<Path>>(dirfd: Fd, path: P) -> Result
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `mkdirat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn mkdirat<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn mkdirat(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mode: RawMode, // TODO: Should we take rustix::fs::Mode directly?
 ) -> Result<(), Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
@@ -410,9 +410,9 @@ pub(crate) fn devmajorminor(dev: Dev) -> (u32, u32) {
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `mknodat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn mknodat<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn mknodat(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     raw_mode: RawMode, // TODO: Should we take rustix::fs::{Mode,FileType} directly?
     dev: Dev,
 ) -> Result<(), Error> {
@@ -440,9 +440,9 @@ pub(crate) fn mknodat<Fd: AsFd, P: AsRef<Path>>(
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `unlinkat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn unlinkat<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn unlinkat(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     flags: AtFlags,
 ) -> Result<(), Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
@@ -460,11 +460,11 @@ pub(crate) fn unlinkat<Fd: AsFd, P: AsRef<Path>>(
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `linkat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn linkat<Fd1: AsFd, P1: AsRef<Path>, Fd2: AsFd, P2: AsRef<Path>>(
-    old_dirfd: Fd1,
-    old_path: P1,
-    new_dirfd: Fd2,
-    new_path: P2,
+pub(crate) fn linkat(
+    old_dirfd: impl AsFd,
+    old_path: impl AsRef<Path>,
+    new_dirfd: impl AsFd,
+    new_path: impl AsRef<Path>,
     flags: AtFlags,
 ) -> Result<(), Error> {
     let (old_dirfd, old_path) = (old_dirfd.as_fd().hotfix_rustix_fd()?, old_path.as_ref());
@@ -487,10 +487,10 @@ pub(crate) fn linkat<Fd1: AsFd, P1: AsRef<Path>, Fd2: AsFd, P2: AsRef<Path>>(
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `symlinkat(2)`. We need the dirfd argument, so we need a
 /// wrapper.
-pub(crate) fn symlinkat<P1: AsRef<Path>, Fd: AsFd, P2: AsRef<Path>>(
-    target: P1,
-    dirfd: Fd,
-    path: P2,
+pub(crate) fn symlinkat(
+    target: impl AsRef<Path>,
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
 ) -> Result<(), Error> {
     let (dirfd, path) = (dirfd.as_fd().hotfix_rustix_fd()?, path.as_ref());
     let target = target.as_ref();
@@ -507,11 +507,11 @@ pub(crate) fn symlinkat<P1: AsRef<Path>, Fd: AsFd, P2: AsRef<Path>>(
 ///
 /// This is needed because Rust doesn't provide a way to access the dirfd
 /// argument of `renameat(2)`. We need the dirfd argument, so we need a wrapper.
-pub(crate) fn renameat<Fd1: AsFd, P1: AsRef<Path>, Fd2: AsFd, P2: AsRef<Path>>(
-    old_dirfd: Fd1,
-    old_path: P1,
-    new_dirfd: Fd2,
-    new_path: P2,
+pub(crate) fn renameat(
+    old_dirfd: impl AsFd,
+    old_path: impl AsRef<Path>,
+    new_dirfd: impl AsFd,
+    new_path: impl AsRef<Path>,
 ) -> Result<(), Error> {
     let (old_dirfd, old_path) = (old_dirfd.as_fd().hotfix_rustix_fd()?, old_path.as_ref());
     let (new_dirfd, new_path) = (new_dirfd.as_fd().hotfix_rustix_fd()?, new_path.as_ref());
@@ -538,11 +538,11 @@ pub(crate) static RENAME_FLAGS_SUPPORTED: Lazy<bool> = Lazy::new(|| {
 ///
 /// This is needed because Rust doesn't provide any interface for `renameat2(2)`
 /// (especially not an interface for the dirfd).
-pub(crate) fn renameat2<Fd1: AsFd, P1: AsRef<Path>, Fd2: AsFd, P2: AsRef<Path>>(
-    old_dirfd: Fd1,
-    old_path: P1,
-    new_dirfd: Fd2,
-    new_path: P2,
+pub(crate) fn renameat2(
+    old_dirfd: impl AsFd,
+    old_path: impl AsRef<Path>,
+    new_dirfd: impl AsFd,
+    new_path: impl AsRef<Path>,
     flags: RenameFlags,
 ) -> Result<(), Error> {
     // Use renameat(2) if no flags are specified.
@@ -568,7 +568,7 @@ pub(crate) fn renameat2<Fd1: AsFd, P1: AsRef<Path>, Fd2: AsFd, P2: AsRef<Path>>(
 /// Wrapper for `fstatfs(2)`.
 ///
 /// This is needed because Rust doesn't provide any interface for `fstatfs(2)`.
-pub(crate) fn fstatfs<Fd: AsFd>(fd: Fd) -> Result<StatFs, Error> {
+pub(crate) fn fstatfs(fd: impl AsFd) -> Result<StatFs, Error> {
     let fd = fd.as_fd().hotfix_rustix_fd()?;
 
     rustix_fs::fstatfs(fd).map_err(|errno| Error::Fstatfs {
@@ -581,7 +581,7 @@ pub(crate) fn fstatfs<Fd: AsFd>(fd: Fd) -> Result<StatFs, Error> {
 /// AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH`.
 ///
 /// This is needed because Rust doesn't provide any interface for `fstatat(2)`.
-pub(crate) fn fstatat<Fd: AsFd, P: AsRef<Path>>(dirfd: Fd, path: P) -> Result<Stat, Error> {
+pub(crate) fn fstatat(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<Stat, Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
     let path = path.as_ref();
     let flags = AtFlags::NO_AUTOMOUNT | AtFlags::SYMLINK_NOFOLLOW | AtFlags::EMPTY_PATH;
@@ -594,9 +594,9 @@ pub(crate) fn fstatat<Fd: AsFd, P: AsRef<Path>>(dirfd: Fd, path: P) -> Result<St
     })
 }
 
-pub(crate) fn statx<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn statx(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mask: StatxFlags,
 ) -> Result<Statx, Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
@@ -675,9 +675,9 @@ impl fmt::Display for OpenHow {
 /// Wrapper for `openat2(2)` which auto-sets `O_CLOEXEC | O_NOCTTY`.
 // NOTE: rustix's openat2 wrapper is not extensible-friendly so we use our own
 // for now. See <https://github.com/bytecodealliance/rustix/issues/1186>.
-pub(crate) fn openat2_follow<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn openat2_follow(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mut how: OpenHow,
 ) -> Result<OwnedFd, Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;
@@ -722,9 +722,9 @@ pub(crate) fn openat2_follow<Fd: AsFd, P: AsRef<Path>>(
 
 /// Wrapper for `openat2(2)` which auto-sets `O_CLOEXEC | O_NOCTTY |
 /// O_NOFOLLOW`.
-pub(crate) fn openat2<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn openat2(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     mut how: OpenHow,
 ) -> Result<OwnedFd, Error> {
     how.flags |= libc::O_NOFOLLOW as u64;
@@ -756,9 +756,7 @@ pub(crate) fn getcwd() -> Result<PathBuf, anyhow::Error> {
     Ok(OsStr::from_bytes(rustix_process::getcwd(buffer)?.to_bytes()).into())
 }
 
-pub(crate) fn fsopen<S: AsRef<str>>(fstype: S, flags: FsOpenFlags) -> Result<OwnedFd, Error> {
-    let fstype = fstype.as_ref();
-
+pub(crate) fn fsopen(fstype: &str, flags: FsOpenFlags) -> Result<OwnedFd, Error> {
     rustix_mount::fsopen(fstype, flags).map_err(|errno| Error::Fsopen {
         fstype: fstype.into(),
         flags,
@@ -766,14 +764,8 @@ pub(crate) fn fsopen<S: AsRef<str>>(fstype: S, flags: FsOpenFlags) -> Result<Own
     })
 }
 
-pub(crate) fn fsconfig_set_string<Fd: AsFd, K: AsRef<str>, V: AsRef<str>>(
-    sfd: Fd,
-    key: K,
-    value: V,
-) -> Result<(), Error> {
+pub(crate) fn fsconfig_set_string(sfd: impl AsFd, key: &str, value: &str) -> Result<(), Error> {
     let sfd = sfd.as_fd().hotfix_rustix_fd()?;
-    let key = key.as_ref();
-    let value = value.as_ref();
 
     rustix_mount::fsconfig_set_string(sfd, key, value).map_err(|errno| Error::FsconfigSetString {
         sfd: sfd.into(),
@@ -783,7 +775,7 @@ pub(crate) fn fsconfig_set_string<Fd: AsFd, K: AsRef<str>, V: AsRef<str>>(
     })
 }
 
-pub(crate) fn fsconfig_create<Fd: AsFd>(sfd: Fd) -> Result<(), Error> {
+pub(crate) fn fsconfig_create(sfd: impl AsFd) -> Result<(), Error> {
     let sfd = sfd.as_fd().hotfix_rustix_fd()?;
 
     rustix_mount::fsconfig_create(sfd).map_err(|errno| Error::FsconfigCreate {
@@ -792,8 +784,8 @@ pub(crate) fn fsconfig_create<Fd: AsFd>(sfd: Fd) -> Result<(), Error> {
     })
 }
 
-pub(crate) fn fsmount<Fd: AsFd>(
-    sfd: Fd,
+pub(crate) fn fsmount(
+    sfd: impl AsFd,
     flags: FsMountFlags,
     mount_attrs: MountAttrFlags,
 ) -> Result<OwnedFd, Error> {
@@ -807,9 +799,9 @@ pub(crate) fn fsmount<Fd: AsFd>(
     })
 }
 
-pub(crate) fn open_tree<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
+pub(crate) fn open_tree(
+    dirfd: impl AsFd,
+    path: impl AsRef<Path>,
     flags: OpenTreeFlags,
 ) -> Result<OwnedFd, Error> {
     let dirfd = dirfd.as_fd().hotfix_rustix_fd()?;

--- a/src/tests/capi/handle.rs
+++ b/src/tests/capi/handle.rs
@@ -37,7 +37,7 @@ pub struct CapiHandle {
 }
 
 impl CapiHandle {
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self {
         Self { inner: fd.into() }
     }
 
@@ -45,7 +45,7 @@ impl CapiHandle {
         Ok(Self::from_fd(self.inner.try_clone()?))
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, CapiError> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, CapiError> {
         let fd = self.inner.as_fd();
         let flags = flags.into();
 
@@ -70,7 +70,7 @@ impl HandleImpl for CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -78,7 +78,7 @@ impl HandleImpl for CapiHandle {
         self.try_clone()
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         self.reopen(flags)
     }
 }
@@ -87,7 +87,7 @@ impl HandleImpl for &CapiHandle {
     type Cloned = CapiHandle;
     type Error = CapiError;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -95,7 +95,7 @@ impl HandleImpl for &CapiHandle {
         CapiHandle::try_clone(self)
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         CapiHandle::reopen(self, flags)
     }
 }

--- a/src/tests/capi/procfs.rs
+++ b/src/tests/capi/procfs.rs
@@ -39,11 +39,11 @@ use std::{
 pub struct CapiProcfsHandle;
 
 impl CapiProcfsHandle {
-    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_follow(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        oflags: F,
+        subpath: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
     ) -> Result<File, CapiError> {
         let base: CProcfsBase = base.into();
         let subpath = capi_utils::path_to_cstring(subpath);
@@ -55,17 +55,17 @@ impl CapiProcfsHandle {
         .map(File::from)
     }
 
-    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        oflags: F,
+        subpath: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
     ) -> Result<File, CapiError> {
         // The C API exposes ProcfsHandle::open using O_NOFOLLOW.
         self.open_follow(base, subpath, oflags.into() | OpenFlags::O_NOFOLLOW)
     }
 
-    fn readlink<P: AsRef<Path>>(&self, base: ProcfsBase, subpath: P) -> Result<PathBuf, CapiError> {
+    fn readlink(&self, base: ProcfsBase, subpath: impl AsRef<Path>) -> Result<PathBuf, CapiError> {
         let base: CProcfsBase = base.into();
         let subpath = capi_utils::path_to_cstring(subpath);
 
@@ -78,28 +78,28 @@ impl CapiProcfsHandle {
 impl ProcfsHandleImpl for CapiProcfsHandle {
     type Error = CapiError;
 
-    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_follow(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
-        self.open_follow(base, subpath, flags)
+        self.open_follow(base, subpath, oflags)
     }
 
-    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
-        self.open(base, subpath, flags)
+        self.open(base, subpath, oflags)
     }
 
-    fn readlink<P: AsRef<Path>>(
+    fn readlink(
         &self,
         base: ProcfsBase,
-        subpath: P,
+        subpath: impl AsRef<Path>,
     ) -> Result<PathBuf, Self::Error> {
         self.readlink(base, subpath)
     }

--- a/src/tests/capi/utils.rs
+++ b/src/tests/capi/utils.rs
@@ -108,7 +108,7 @@ fn fetch_error(res: libc::c_int) -> Result<libc::c_int, CapiError> {
     }
 }
 
-pub(in crate::tests) fn path_to_cstring<P: AsRef<Path>>(path: P) -> CString {
+pub(in crate::tests) fn path_to_cstring(path: impl AsRef<Path>) -> CString {
     CString::new(path.as_ref().as_os_str().as_bytes())
         .expect("normal path conversion shouldn't result in spurious nul bytes")
 }

--- a/src/tests/common/handle.rs
+++ b/src/tests/common/handle.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-pub(in crate::tests) fn check_oflags<Fd: AsFd>(fd: Fd, flags: OpenFlags) -> Result<(), Error> {
+pub(in crate::tests) fn check_oflags(fd: impl AsFd, flags: OpenFlags) -> Result<(), Error> {
     let fd = fd.as_fd();
 
     // Convert to OFlags so we can compare them.

--- a/src/tests/common/mntns.rs
+++ b/src/tests/common/mntns.rs
@@ -58,7 +58,7 @@ fn are_vfs_flags(flags: MountFlags) -> bool {
         .is_empty()
 }
 
-pub(in crate::tests) fn mount<P: AsRef<Path>>(dst: P, ty: MountType) -> Result<(), Error> {
+pub(in crate::tests) fn mount(dst: impl AsRef<Path>, ty: MountType) -> Result<(), Error> {
     let dst = dst.as_ref();
     let dst_file = syscalls::openat(
         syscalls::AT_FDCWD,

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -376,9 +376,9 @@ mod utils {
         "/proc/thread-self/fdinfo/",
     ];
 
-    fn try_mount<P: AsRef<Path>>(
+    fn try_mount(
         over_mounts: &mut HashSet<PathBuf>,
-        dst: P,
+        dst: impl AsRef<Path>,
         ty: MountType,
     ) -> Result<(), Error> {
         let dst = dst.as_ref();
@@ -511,11 +511,11 @@ mod utils {
         }
     }
 
-    pub(super) fn check_proc_open<Proc, ProcFn, P: AsRef<Path>, F: Into<OpenFlags>>(
+    pub(super) fn check_proc_open<Proc, ProcFn>(
         proc_fn: ProcFn,
         base: ProcfsBase,
-        path: P,
-        oflags: F,
+        path: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
         are_over_mounts_visible: bool,
         expected: ExpectedResult,
     ) -> Result<(), Error>
@@ -544,11 +544,11 @@ mod utils {
         )
     }
 
-    pub(super) fn check_proc_open_follow<Proc, ProcFn, P: AsRef<Path>, F: Into<OpenFlags>>(
+    pub(super) fn check_proc_open_follow<Proc, ProcFn>(
         proc_fn: ProcFn,
         base: ProcfsBase,
-        path: P,
-        oflags: F,
+        path: impl AsRef<Path>,
+        oflags: impl Into<OpenFlags>,
         are_over_mounts_visible: bool,
         expected: ExpectedResult,
     ) -> Result<(), Error>
@@ -587,10 +587,10 @@ mod utils {
         )
     }
 
-    pub(super) fn check_proc_readlink<Proc, ProcFn, P: AsRef<Path>>(
+    pub(super) fn check_proc_readlink<Proc, ProcFn>(
         proc_fn: ProcFn,
         base: ProcfsBase,
-        path: P,
+        path: impl AsRef<Path>,
         are_over_mounts_visible: bool,
         expected: ExpectedResult,
     ) -> Result<(), Error>

--- a/src/tests/test_race_resolve_partial.rs
+++ b/src/tests/test_race_resolve_partial.rs
@@ -793,11 +793,11 @@ mod utils {
         Quit,
     }
 
-    pub(super) fn rename_exchange<Fd: AsFd, P1: AsRef<Path>, P2: AsRef<Path>>(
+    pub(super) fn rename_exchange(
         ctl_rx: Receiver<RenameStateMsg>,
-        root: Fd,
-        path1: P1,
-        path2: P2,
+        root: impl AsFd,
+        path1: impl AsRef<Path>,
+        path2: impl AsRef<Path>,
     ) {
         let root = root.as_fd();
         let (path1, path2) = (path1.as_ref(), path2.as_ref());
@@ -837,10 +837,10 @@ mod utils {
         }
     }
 
-    pub(super) fn check_root_race_resolve_partial<P: AsRef<Path>>(
+    pub(super) fn check_root_race_resolve_partial(
         root: &Root,
         ctl_tx: &SyncSender<RenameStateMsg>,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         no_follow_trailing: bool,
         allowed_results: &[Result<PartialLookup<LookupResult, ErrorKind>, ErrorKind>],
     ) -> Result<(), Error> {

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -548,9 +548,9 @@ mod utils {
         })
     }
 
-    pub(super) fn check_root_resolve<R, H, P: AsRef<Path>>(
+    pub(super) fn check_root_resolve<R, H>(
         root: R,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         no_follow_trailing: bool,
         expected: Result<LookupResult, ErrorKind>,
     ) -> Result<(), Error>

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -744,9 +744,9 @@ mod utils {
         })
     }
 
-    pub(super) fn check_root_resolve_partial<P: AsRef<Path>>(
+    pub(super) fn check_root_resolve_partial(
         root: &Root,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         no_follow_trailing: bool,
         expected: Result<PartialLookup<LookupResult, ErrorKind>, ErrorKind>,
     ) -> Result<(), Error> {

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -715,9 +715,9 @@ mod utils {
         Ok(R::from_fd(root_fd, root.resolver()))
     }
 
-    pub(super) fn check_root_create<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_create<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         inode_type: InodeType,
         expected_result: Result<(&str, RawMode), ErrorKind>,
     ) -> Result<(), Error> {
@@ -785,9 +785,9 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_create_file<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_create_file<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         oflags: OpenFlags,
         perm: &Permissions,
         expected_result: Result<&str, ErrorKind>,
@@ -858,9 +858,9 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_open_subpath<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_open_subpath<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         oflags: OpenFlags,
         expected_result: Result<&str, ErrorKind>,
     ) -> Result<(), Error> {
@@ -939,9 +939,9 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_remove_dir<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_remove_dir<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
         check_root_remove(
@@ -952,9 +952,9 @@ mod utils {
         )
     }
 
-    pub(super) fn check_root_remove_file<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_remove_file<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
         check_root_remove(
@@ -965,9 +965,9 @@ mod utils {
         )
     }
 
-    pub(super) fn check_root_remove_all<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_remove_all<R: RootImpl>(
         root: R,
-        path: P,
+        path: impl AsRef<Path>,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
         check_root_remove(
@@ -978,10 +978,10 @@ mod utils {
         )
     }
 
-    pub(super) fn check_root_rename<R: RootImpl, P1: AsRef<Path>, P2: AsRef<Path>>(
+    pub(super) fn check_root_rename<R: RootImpl>(
         root: R,
-        src_path: P1,
-        dst_path: P2,
+        src_path: impl AsRef<Path>,
+        dst_path: impl AsRef<Path>,
         rflags: RenameFlags,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
@@ -1084,9 +1084,9 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_mkdir_all<R: RootImpl, P: AsRef<Path>>(
+    pub(super) fn check_root_mkdir_all<R: RootImpl>(
         root: R,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         perm: Permissions,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
@@ -1175,10 +1175,10 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_mkdir_all_racing<R: RootImpl + Sync, P: AsRef<Path>>(
+    pub(super) fn check_root_mkdir_all_racing<R: RootImpl + Sync>(
         num_threads: usize,
         root: R,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         perm: Permissions,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
@@ -1206,10 +1206,10 @@ mod utils {
         Ok(())
     }
 
-    pub(super) fn check_root_remove_all_racing<R: RootImpl + Sync, P: AsRef<Path>>(
+    pub(super) fn check_root_remove_all_racing<R: RootImpl + Sync>(
         num_threads: usize,
         root: R,
-        unsafe_path: P,
+        unsafe_path: impl AsRef<Path>,
         expected_result: Result<(), ErrorKind>,
     ) -> Result<(), Error> {
         let root = &root;

--- a/src/tests/traits/handle.rs
+++ b/src/tests/traits/handle.rs
@@ -29,18 +29,18 @@ pub(in crate::tests) trait HandleImpl: AsFd + std::fmt::Debug + Sized {
     type Error: ErrorImpl;
 
     // NOTE: We return Self::Cloned so that we can share types with HandleRef.
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned;
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned;
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
 
-    fn reopen<Fd: Into<OpenFlags>>(&self, flags: Fd) -> Result<File, Self::Error>;
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error>;
 }
 
 impl HandleImpl for Handle {
     type Cloned = Handle;
     type Error = Error;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -48,7 +48,7 @@ impl HandleImpl for Handle {
         self.as_ref().try_clone().map_err(From::from)
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         self.as_ref().reopen(flags)
     }
 }
@@ -57,7 +57,7 @@ impl HandleImpl for &Handle {
     type Cloned = Handle;
     type Error = Error;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -65,7 +65,7 @@ impl HandleImpl for &Handle {
         Handle::try_clone(self).map_err(From::from)
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         Handle::reopen(self, flags)
     }
 }
@@ -74,7 +74,7 @@ impl HandleImpl for HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -82,7 +82,7 @@ impl HandleImpl for HandleRef<'_> {
         self.try_clone().map_err(From::from)
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         self.reopen(flags)
     }
 }
@@ -91,7 +91,7 @@ impl HandleImpl for &HandleRef<'_> {
     type Cloned = Handle;
     type Error = Error;
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
     }
 
@@ -99,7 +99,7 @@ impl HandleImpl for &HandleRef<'_> {
         HandleRef::try_clone(self).map_err(From::from)
     }
 
-    fn reopen<F: Into<OpenFlags>>(&self, flags: F) -> Result<File, Self::Error> {
+    fn reopen(&self, flags: impl Into<OpenFlags>) -> Result<File, Self::Error> {
         HandleRef::reopen(self, flags)
     }
 }

--- a/src/tests/traits/procfs.rs
+++ b/src/tests/traits/procfs.rs
@@ -32,52 +32,49 @@ use std::{
 pub(in crate::tests) trait ProcfsHandleImpl: std::fmt::Debug {
     type Error: ErrorImpl;
 
-    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_follow(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error>;
 
-    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error>;
 
-    fn readlink<P: AsRef<Path>>(
-        &self,
-        base: ProcfsBase,
-        subpath: P,
-    ) -> Result<PathBuf, Self::Error>;
+    fn readlink(&self, base: ProcfsBase, subpath: impl AsRef<Path>)
+        -> Result<PathBuf, Self::Error>;
 }
 
 impl ProcfsHandleImpl for ProcfsHandle {
     type Error = Error;
 
-    fn open_follow<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_follow(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         self.open_follow(base, subpath, flags)
     }
 
-    fn open<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open(
         &self,
         base: ProcfsBase,
-        subpath: P,
-        flags: F,
+        subpath: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         self.open(base, subpath, flags)
     }
 
-    fn readlink<P: AsRef<Path>>(
+    fn readlink(
         &self,
         base: ProcfsBase,
-        subpath: P,
+        subpath: impl AsRef<Path>,
     ) -> Result<PathBuf, Self::Error> {
         self.readlink(base, subpath)
     }

--- a/src/tests/traits/root.rs
+++ b/src/tests/traits/root.rs
@@ -40,47 +40,47 @@ pub(in crate::tests) trait RootImpl: AsFd + std::fmt::Debug + Sized {
     fn resolver(&self) -> Resolver;
 
     // NOTE: We return Self::Cloned so that we can share types with RootRef.
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned;
+    fn from_fd(fd: impl Into<OwnedFd>, resolver: Resolver) -> Self::Cloned;
 
     fn try_clone(&self) -> Result<Self::Cloned, anyhow::Error>;
 
-    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error>;
+    fn resolve(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error>;
 
-    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error>;
+    fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error>;
 
-    fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error>;
 
-    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error>;
+    fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Self::Error>;
 
-    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error>;
+    fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Self::Error>;
 
-    fn create_file<P: AsRef<Path>>(
+    fn create_file(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         flags: OpenFlags,
         perm: &Permissions,
     ) -> Result<File, Self::Error>;
 
-    fn mkdir_all<P: AsRef<Path>>(
+    fn mkdir_all(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         perm: &Permissions,
     ) -> Result<Self::Handle, Self::Error>;
 
-    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+    fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Self::Error>;
 
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Self::Error>;
 
-    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+    fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Self::Error>;
 
-    fn rename<P: AsRef<Path>>(
+    fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Self::Error>;
 }
@@ -97,7 +97,7 @@ impl RootImpl for Root {
         }
     }
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>, resolver: Resolver) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
@@ -107,63 +107,63 @@ impl RootImpl for Root {
         self.try_clone().map_err(From::from)
     }
 
-    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         self.resolve(path)
     }
 
-    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         self.resolve_nofollow(path)
     }
 
-    fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         self.open_subpath(path, flags)
     }
 
-    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+    fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Self::Error> {
         self.readlink(path)
     }
 
-    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+    fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Self::Error> {
         self.create(path, inode_type)
     }
 
-    fn create_file<P: AsRef<Path>>(
+    fn create_file(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         flags: OpenFlags,
         perm: &Permissions,
     ) -> Result<File, Self::Error> {
         self.create_file(path, flags, perm)
     }
 
-    fn mkdir_all<P: AsRef<Path>>(
+    fn mkdir_all(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         perm: &Permissions,
     ) -> Result<Self::Handle, Self::Error> {
         self.mkdir_all(path, perm)
     }
 
-    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_dir(path)
     }
 
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_file(path)
     }
 
-    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_all(path)
     }
 
-    fn rename<P: AsRef<Path>>(
+    fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Self::Error> {
         self.rename(source, destination, rflags)
@@ -182,7 +182,7 @@ impl RootImpl for &Root {
         }
     }
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>, resolver: Resolver) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
@@ -192,63 +192,63 @@ impl RootImpl for &Root {
         Root::try_clone(self).map_err(From::from)
     }
 
-    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         Root::resolve(self, path)
     }
 
-    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         Root::resolve_nofollow(self, path)
     }
 
-    fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         Root::open_subpath(self, path, flags)
     }
 
-    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+    fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Self::Error> {
         Root::readlink(self, path)
     }
 
-    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+    fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Self::Error> {
         Root::create(self, path, inode_type)
     }
 
-    fn create_file<P: AsRef<Path>>(
+    fn create_file(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         flags: OpenFlags,
         perm: &Permissions,
     ) -> Result<File, Self::Error> {
         Root::create_file(self, path, flags, perm)
     }
 
-    fn mkdir_all<P: AsRef<Path>>(
+    fn mkdir_all(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         perm: &Permissions,
     ) -> Result<Self::Handle, Self::Error> {
         Root::mkdir_all(self, path, perm)
     }
 
-    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         Root::remove_dir(self, path)
     }
 
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         Root::remove_file(self, path)
     }
 
-    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         Root::remove_all(self, path)
     }
 
-    fn rename<P: AsRef<Path>>(
+    fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Self::Error> {
         Root::rename(self, source, destination, rflags)
@@ -267,7 +267,7 @@ impl RootImpl for RootRef<'_> {
         }
     }
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>, resolver: Resolver) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
@@ -277,63 +277,63 @@ impl RootImpl for RootRef<'_> {
         self.try_clone().map_err(From::from)
     }
 
-    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         self.resolve(path)
     }
 
-    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         self.resolve_nofollow(path)
     }
 
-    fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         self.open_subpath(path, flags)
     }
 
-    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+    fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Self::Error> {
         self.readlink(path)
     }
 
-    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+    fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Self::Error> {
         self.create(path, inode_type)
     }
 
-    fn create_file<P: AsRef<Path>>(
+    fn create_file(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         flags: OpenFlags,
         perm: &Permissions,
     ) -> Result<File, Self::Error> {
         self.create_file(path, flags, perm)
     }
 
-    fn mkdir_all<P: AsRef<Path>>(
+    fn mkdir_all(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         perm: &Permissions,
     ) -> Result<Self::Handle, Self::Error> {
         self.mkdir_all(path, perm)
     }
 
-    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_dir(path)
     }
 
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_file(path)
     }
 
-    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         self.remove_all(path)
     }
 
-    fn rename<P: AsRef<Path>>(
+    fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Self::Error> {
         self.rename(source, destination, rflags)
@@ -352,7 +352,7 @@ impl RootImpl for &RootRef<'_> {
         }
     }
 
-    fn from_fd<Fd: Into<OwnedFd>>(fd: Fd, resolver: Resolver) -> Self::Cloned {
+    fn from_fd(fd: impl Into<OwnedFd>, resolver: Resolver) -> Self::Cloned {
         Self::Cloned::from_fd(fd)
             .with_resolver_backend(resolver.backend)
             .with_resolver_flags(resolver.flags)
@@ -362,63 +362,63 @@ impl RootImpl for &RootRef<'_> {
         RootRef::try_clone(self).map_err(From::from)
     }
 
-    fn resolve<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         RootRef::resolve(self, path)
     }
 
-    fn resolve_nofollow<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle, Self::Error> {
+    fn resolve_nofollow(&self, path: impl AsRef<Path>) -> Result<Self::Handle, Self::Error> {
         RootRef::resolve_nofollow(self, path)
     }
 
-    fn open_subpath<P: AsRef<Path>, F: Into<OpenFlags>>(
+    fn open_subpath(
         &self,
-        path: P,
-        flags: F,
+        path: impl AsRef<Path>,
+        flags: impl Into<OpenFlags>,
     ) -> Result<File, Self::Error> {
         RootRef::open_subpath(self, path, flags)
     }
 
-    fn readlink<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, Self::Error> {
+    fn readlink(&self, path: impl AsRef<Path>) -> Result<PathBuf, Self::Error> {
         RootRef::readlink(self, path)
     }
 
-    fn create<P: AsRef<Path>>(&self, path: P, inode_type: &InodeType) -> Result<(), Self::Error> {
+    fn create(&self, path: impl AsRef<Path>, inode_type: &InodeType) -> Result<(), Self::Error> {
         RootRef::create(self, path, inode_type)
     }
 
-    fn create_file<P: AsRef<Path>>(
+    fn create_file(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         flags: OpenFlags,
         perm: &Permissions,
     ) -> Result<File, Self::Error> {
         RootRef::create_file(self, path, flags, perm)
     }
 
-    fn mkdir_all<P: AsRef<Path>>(
+    fn mkdir_all(
         &self,
-        path: P,
+        path: impl AsRef<Path>,
         perm: &Permissions,
     ) -> Result<Self::Handle, Self::Error> {
         RootRef::mkdir_all(self, path, perm)
     }
 
-    fn remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_dir(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         RootRef::remove_dir(self, path)
     }
 
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         RootRef::remove_file(self, path)
     }
 
-    fn remove_all<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    fn remove_all(&self, path: impl AsRef<Path>) -> Result<(), Self::Error> {
         RootRef::remove_all(self, path)
     }
 
-    fn rename<P: AsRef<Path>>(
+    fn rename(
         &self,
-        source: P,
-        destination: P,
+        source: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
         rflags: RenameFlags,
     ) -> Result<(), Self::Error> {
         RootRef::rename(self, source, destination, rflags)

--- a/src/utils/dir.rs
+++ b/src/utils/dir.rs
@@ -45,8 +45,9 @@ impl RmdirResultExt for Result<(), Error> {
     }
 }
 
-fn remove_inode<Fd: AsFd>(dirfd: Fd, name: &Path) -> Result<(), Error> {
+fn remove_inode(dirfd: impl AsFd, name: impl AsRef<Path>) -> Result<(), Error> {
     let dirfd = dirfd.as_fd();
+    let name = name.as_ref();
 
     // To ensure we return a useful error, we try both unlink and rmdir and
     // try to avoid returning EISDIR/ENOTDIR if both failed.
@@ -69,8 +70,9 @@ fn remove_inode<Fd: AsFd>(dirfd: Fd, name: &Path) -> Result<(), Error> {
         })
 }
 
-pub(crate) fn remove_all<Fd: AsFd>(dirfd: Fd, name: &Path) -> Result<(), Error> {
+pub(crate) fn remove_all(dirfd: impl AsFd, name: impl AsRef<Path>) -> Result<(), Error> {
     let dirfd = dirfd.as_fd();
+    let name = name.as_ref();
 
     if name.as_os_str().as_bytes().contains(&b'/') {
         Err(ErrorImpl::SafetyViolation {

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -254,10 +254,7 @@ impl<Fd: AsFd> FdExt for Fd {
     }
 }
 
-pub(crate) fn fetch_mnt_id<Fd: AsFd, P: AsRef<Path>>(
-    dirfd: Fd,
-    path: P,
-) -> Result<Option<u64>, Error> {
+pub(crate) fn fetch_mnt_id(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<Option<u64>, Error> {
     // NOTE: stx.stx_mnt_id is fairly new (added in Linux 5.8[1]) so this check
     // might not work on quite a few kernels and so we have to fallback to not
     // checking the mount ID (removing some protections).
@@ -322,7 +319,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
-    fn check_as_unsafe_path<Fd: AsFd, P: AsRef<Path>>(fd: Fd, want_path: P) -> Result<(), Error> {
+    fn check_as_unsafe_path(fd: impl AsFd, want_path: impl AsRef<Path>) -> Result<(), Error> {
         let want_path = want_path.as_ref();
 
         // Plain /proc/... lookup.


### PR DESCRIPTION
It turns out that taking `impl Trait` arguments is actually more ergonomic
in a lot of cases:

 * It makes it easier to write APIs where the caller specifying a
   generic type with `::<>` (like `str::parse::<T>`) much easier. If every
   type parameter is named then you need to do `::<_, _, Foo, _>()` which
   is awful.

 * It avoids the need to define a generic type for each argument even if
   they implement the same trait (`<P1: AsRef<Path>, P2: AsRef<Path>`).
   This is needed to avoid annoying reference issues (and it turns out
   that we missed fixing this in a few places).

 * The rustdoc documentation generated looks much nicer -- it is far
   clearer to users what types we accept (previously, the use of generic
   type parameter names would require users to look at the where clause
   to see what Trait impl is needed).

Note that these types are still monomorphised during compilation (unlike
the very-similar-looking "&dyn Trait" arguments). It's a shame that this
appears to be fairly underutilised in Rust libraries (so much so that I
didn't realise this was a feature -- I thought "impl Trait" always
referred to a single concrete type without needing to spell out its
name).

I also removed a few ill-advised AsRef<str> arguments.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>