### PR TITLE
docs: improve "Kernel Support" table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,9 +123,9 @@
 //!
 //! | Feature               | Minimum Kernel Version  | Description | Fallback |
 //! | --------------------- | ----------------------- | ----------- | -------- |
-//! | [`openat2(2)`]        | Linux 5.6 (2020-03-29)  | In-kernel restrictions of path lookup. This is used extensively by `libpathrs` to safely do path lookups. | Userspace emulated path lookups. |
 //! | `/proc/thread-self`   | Linux 3.17 (2014-10-05) | Used when operating on the current thread's `/proc` directory for use with `PATHRS_PROC_THREAD_SELF`. | `/proc/self/task/$tid` is used, but this might not be available in some edge cases so `/proc/self` is used as a final fallback. |
 //! | New Mount API         | Linux 5.2 (2019-07-07)  | Used to create a private procfs handle when operating on `/proc` (with `fsopen(2)` or `open_tree(2)`). | Open a regular handle to `/proc`. This can lead to certain race attacks if the attacker can dynamically create mounts. |
+//! | [`openat2(2)`]        | Linux 5.6 (2020-03-29)  | In-kernel restrictions of path lookup. This is used extensively by `libpathrs` to safely do path lookups. | Userspace emulated path lookups. |
 //! | `STATX_MNT_ID`        | Linux 5.8 (2020-08-02)  | Used to verify whether there are bind-mounts on top of `/proc` that could result in insecure operations. | There is **no fallback**. Not using this protection can lead to fairly trivial attacks if an attacker can configure your mount table. |
 //! | `STATX_MNT_ID_UNIQUE` | Linux 6.8 (2024-03-10)  | Used for the same reason as `STATX_MNT_ID`, but allows us to protect against mount ID recycling. This is effectively a safer version of `STATX_MNT_ID`. | `STATX_MNT_ID` is used (see the `STATX_MNT_ID` fallback if it's not available either). |
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@
 //! | Feature               | Minimum Kernel Version  | Description | Fallback |
 //! | --------------------- | ----------------------- | ----------- | -------- |
 //! | `/proc/thread-self`   | Linux 3.17 (2014-10-05) | Used when operating on the current thread's `/proc` directory for use with `PATHRS_PROC_THREAD_SELF`. | `/proc/self/task/$tid` is used, but this might not be available in some edge cases so `/proc/self` is used as a final fallback. |
-//! | New Mount API         | Linux 5.2 (2019-07-07)  | Used to create a private procfs handle when operating on `/proc` (with `fsopen(2)` or `open_tree(2)`). | Open a regular handle to `/proc`. This can lead to certain race attacks if the attacker can dynamically create mounts. |
+//! | [`open_tree(2)`]      | Linux 4.18 (2018-08-12) | Used to create a private procfs handle when operating on `/proc` (this is a copy of the host `/proc` -- in most cases this will also strip any overmounts). Requires `CAP_SYS_ADMIN` privileges. | Open a regular handle to `/proc`. This can lead to certain race attacks if the attacker can dynamically create mounts. |
+//! | [`fsopen(2)`]         | Linux 5.1 (2019-05-05)  | Used to create a private procfs handle when operating on `/proc` (with a completely fresh copy of `/proc` -- in some cases this operation will fail if there are locked overmounts on top of `/proc`). Requires `CAP_SYS_ADMIN` privileges. | Try to use [`open_tree(2)`] instead -- in the case of errors due to locked overmounts, [`open_tree(2)`] will be used to create a recursive copy that preserves the overmounts. This means that an attacker would not be able to actively change the mounts on top of `/proc` but there might be some overmounts that libpathrs will detect (and reject). |
 //! | [`openat2(2)`]        | Linux 5.6 (2020-03-29)  | In-kernel restrictions of path lookup. This is used extensively by `libpathrs` to safely do path lookups. | Userspace emulated path lookups. |
 //! | `STATX_MNT_ID`        | Linux 5.8 (2020-08-02)  | Used to verify whether there are bind-mounts on top of `/proc` that could result in insecure operations. | There is **no fallback**. Not using this protection can lead to fairly trivial attacks if an attacker can configure your mount table. |
 //! | `STATX_MNT_ID_UNIQUE` | Linux 6.8 (2024-03-10)  | Used for the same reason as `STATX_MNT_ID`, but allows us to protect against mount ID recycling. This is effectively a safer version of `STATX_MNT_ID`. | `STATX_MNT_ID` is used (see the `STATX_MNT_ID` fallback if it's not available either). |
@@ -141,6 +142,8 @@
 //! [lwn-openat2]: https://lwn.net/Articles/796868/
 //! [`File`]: std::fs::File
 //! [`chroot(2)`]: http://man7.org/linux/man-pages/man2/chroot.2.html
+//! [`open_tree(2)`]: https://github.com/brauner/man-pages-md/blob/main/open_tree.md
+//! [`fsopen(2)`]: https://github.com/brauner/man-pages-md/blob/main/fsopen.md
 
 // libpathrs only supports Linux at the moment.
 #![cfg(target_os = "linux")]


### PR DESCRIPTION
open_tree(2) was added before fsopen(2), and so really we need two rows
to better describe the behaviour. Also it seems germane to actually
explain what kinds of threats there are with overmounts with each type
ProcfsHandle, for those that care.

To users I also suspect that ordering by minimum kernel version is far
easier to follow and provides more useful information ("given a kernel
version, above this line is supported, below this line is not").

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>