### PR TITLE
capi: use rustversion for symver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "rustix",
+ "rustversion",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -342,6 +343,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ once_cell = "~1.20"
 open-enum = { version = "=0.3.0", optional = true }
 rand = { version = "^0.9", optional = true }
 rustix = { version = "^1", features = ["fs", "process", "thread", "mount"] }
+rustversion = "^1"
 thiserror = "^2"
 static_assertions = "^1.1"
 

--- a/src/capi/utils.rs
+++ b/src/capi/utils.rs
@@ -82,18 +82,15 @@ macro_rules! symver {
             target_arch = "x86_64",
             target_arch = "riscv32",
             target_arch = "riscv64",
-            // TODO: We should have a "rust_$ver" cfg to let us add attributes
-            // based on the Rust version being used for building, so we can
-            // maximise the usage of .symver without needing to bump the MSRV.
-            //target_arch = "arm64ec", // MSRV(1.84)
             //target_arch = "loongarch32", // MSRV(1.91?)
-            //target_arch = "loongarch64", // MSRV(1.72)
-            //target_arch = "s390x", // MSRV(1.84)
             // TODO: Once stabilised, add these arches:
             //target_arch = "powerpc",
             //target_arch = "powerpc64",
             //target_arch = "sparc64",
         ))]
+        #[::rustversion::attr(since(1.72), cfg(target_arch = "loongarch64"))]
+        #[::rustversion::attr(since(1.84), cfg(target_arch = "arm64ec"))]
+        #[::rustversion::attr(since(1.84), cfg(target_arch = "s390x"))]
         // .symver $implsym, $symname@$version
         $(#[$meta])*
         ::std::arch::global_asm! {concat!(
@@ -117,18 +114,15 @@ macro_rules! symver {
             target_arch = "x86_64",
             target_arch = "riscv32",
             target_arch = "riscv64",
-            // TODO: We should have a "rust_$ver" cfg to let us add attributes
-            // based on the Rust version being used for building, so we can
-            // maximise the usage of .symver without needing to bump the MSRV.
-            //target_arch = "arm64ec", // MSRV(1.84)
-            //target_arch = "loongarch32", // MSRV(1.91?)
-            //target_arch = "loongarch64", // MSRV(1.72)
-            //target_arch = "s390x", // MSRV(1.84)
             // TODO: Once stabilised, add these arches:
+            //target_arch = "loongarch32", // MSRV(1.91?)
             //target_arch = "powerpc",
             //target_arch = "powerpc64",
             //target_arch = "sparc64",
         ))]
+        #[::rustversion::attr(since(1.72), cfg(target_arch = "loongarch64"))]
+        #[::rustversion::attr(since(1.84), cfg(target_arch = "arm64ec"))]
+        #[::rustversion::attr(since(1.84), cfg(target_arch = "s390x"))]
         // .symver $implsym, $symname@@$version
         $(#[$meta])*
         ::std::arch::global_asm! {concat!(


### PR DESCRIPTION
It is quite important that we output .symver as much as we possibly can,
so use rustversion to conditionally output it based on the Rust versions
where global_asm! was stabilised.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>