### PR TITLE
go: move to 'cyphar.com/go-pathrs' vanity import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 > As of this release, the libpathrs repository has been moved to
 > https://github.com/cyphar/libpathrs. Please update any references you have
 > (though GitHub will redirect the old repository name to the new one).
+>
+> In addition, the `go-pathrs` package has been moved to a vanity URL of
+> `cyphar.com/go-pathrs`. Please update your Go import paths accordingly.
 
 > [!IMPORTANT]
 > The license of this project has changed. Now, the entire project (including
@@ -57,11 +60,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `ProcfsBase` is now an opaque `struct` type rather than a simple `int`
     wrapper -- this was necessary in order to add support for
     `ProcfsBase::ProcPid` in the form of the `ProcBasePid` helper function.
-- go bindings: due to the change in repository name, the Go module name for the
-  libpathrs Go bindings has also been renamed to `github.com/cyphar/libpathrs`.
-  This will cause build errors for existing users which used the old repository
-  path, but can easily be fixed by updating `go.mod` and `go.sum` to use the
-  new repository name.
+- go bindings: the Go module name for the libpathrs Go bindings has been
+  renamed to `cyphar.com/go-pathrs`. This will cause build errors for existing
+  users which used the old repository path, but can easily be fixed by updating
+  `go.mod` and `go.sum` to use the new name.
 - go bindings: the procfs APIs have been moved to a `procfs` subpackage, and
   several of the exported types and functions have changed names. We have not
   provided any compatibility aliases.

--- a/examples/go/cat.go
+++ b/examples/go/cat.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/cyphar/libpathrs/go-pathrs"
+	"cyphar.com/go-pathrs"
 )
 
 func Main(args ...string) error {

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -2,8 +2,8 @@ module pathrs-example
 
 go 1.18
 
-require github.com/cyphar/libpathrs/go-pathrs v0.0.0
+require cyphar.com/go-pathrs v0.0.0
 
 require golang.org/x/sys v0.26.0 // indirect
 
-replace github.com/cyphar/libpathrs/go-pathrs => ../../go-pathrs
+replace cyphar.com/go-pathrs => ../../go-pathrs

--- a/examples/go/sysctl.go
+++ b/examples/go/sysctl.go
@@ -20,7 +20,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/cyphar/libpathrs/go-pathrs/procfs"
+	"cyphar.com/go-pathrs/procfs"
 )
 
 func Main(names ...string) error {

--- a/go-pathrs/.golangci.yml
+++ b/go-pathrs/.golangci.yml
@@ -37,3 +37,7 @@ formatters:
   enable:
     - gofumpt
     - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - cyphar.com/go-pathrs

--- a/go-pathrs/go.mod
+++ b/go-pathrs/go.mod
@@ -1,4 +1,5 @@
-module github.com/cyphar/libpathrs/go-pathrs
+// Hosted at <https://github.com/cyphar/libpathrs>.
+module cyphar.com/go-pathrs
 
 go 1.18
 

--- a/go-pathrs/handle_linux.go
+++ b/go-pathrs/handle_linux.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cyphar/libpathrs/go-pathrs/internal/libpathrs"
+	"cyphar.com/go-pathrs/internal/libpathrs"
 )
 
 // Handle is a handle for a path within a given [Root]. This handle references

--- a/go-pathrs/procfs/procfs_linux.go
+++ b/go-pathrs/procfs/procfs_linux.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/cyphar/libpathrs/go-pathrs/internal/libpathrs"
+	"cyphar.com/go-pathrs/internal/libpathrs"
 )
 
 // ProcBase is used with [ProcReadlink] and related functions to indicate what

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/cyphar/libpathrs/go-pathrs/internal/libpathrs"
+	"cyphar.com/go-pathrs/internal/libpathrs"
 )
 
 // Root is a handle to the root of a directory tree to resolve within. The only

--- a/go-pathrs/utils_linux.go
+++ b/go-pathrs/utils_linux.go
@@ -19,7 +19,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/cyphar/libpathrs/go-pathrs/procfs"
+	"cyphar.com/go-pathrs/procfs"
 )
 
 // dupFd makes a duplicate of the given fd.


### PR DESCRIPTION
At the moment we have basically no Go users, so it's still safe for us
to make the switch now.

While I have used GitHub for more than a decade now, there is no
guarantee I will continue to use it forever and the way that Go (by
default) forces you to embed the hosting provider into your import
information in a way that cannot be migrated is quite frustrating.

Fixes #225
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>