### PR TITLE
go: do not set S_IFMT bits except for mknod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed ###
 - python bindings: fix `pathrs.procfs` examples in README.
+- go bindings: fix the internal `os.FileMode` to `S_IF*` conversion to not
+  auto-include `S_IFREG` for non-`Mknod` operations (previously this would
+  cause `MkdirAll` to error out).
 
 ## [0.2.0] - 2025-10-17 ##
 

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -147,7 +147,7 @@ func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
 //
 // [os.Create]: https://pkg.go.dev/os#Create
 func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error) {
-	unixMode, err := toUnixMode(mode)
+	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (r *Root) RemoveAll(path string) error {
 //
 // [os.Mkdir]: https://pkg.go.dev/os#Mkdir
 func (r *Root) Mkdir(path string, mode os.FileMode) error {
-	unixMode, err := toUnixMode(mode)
+	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (r *Root) Mkdir(path string, mode os.FileMode) error {
 //
 // [os.MkdirAll]: https://pkg.go.dev/os#MkdirAll
 func (r *Root) MkdirAll(path string, mode os.FileMode) (*Handle, error) {
-	unixMode, err := toUnixMode(mode)
+	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (r *Root) MkdirAll(path string, mode os.FileMode) (*Handle, error) {
 //
 // [unix.Mknod]: https://pkg.go.dev/golang.org/x/sys/unix#Mknod
 func (r *Root) Mknod(path string, mode os.FileMode, dev uint64) error {
-	unixMode, err := toUnixMode(mode)
+	unixMode, err := toUnixMode(mode, true)
 	if err != nil {
 		return err
 	}

--- a/go-pathrs/utils_linux.go
+++ b/go-pathrs/utils_linux.go
@@ -32,11 +32,13 @@ func dupFd(fd uintptr, name string) (*os.File, error) {
 }
 
 //nolint:cyclop // this function needs to handle a lot of cases
-func toUnixMode(mode os.FileMode) (uint32, error) {
+func toUnixMode(mode os.FileMode, needsType bool) (uint32, error) {
 	sysMode := uint32(mode.Perm())
 	switch mode & os.ModeType { //nolint:exhaustive // we only care about ModeType bits
 	case 0:
-		sysMode |= unix.S_IFREG
+		if needsType {
+			sysMode |= unix.S_IFREG
+		}
 	case os.ModeDir:
 		sysMode |= unix.S_IFDIR
 	case os.ModeSymlink:


### PR DESCRIPTION
MkdirAll will scream bloody murder when we do this, and in most cases we
do not actually want to set the S_IFREG bit by default. For FileModes
that explcitly set a file, we keep it though.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>