### PR TITLE
openat2: bump retry limit to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   retries is exceeded -- this allows higher-level users easily detect if an
   error is an indication they should retry (based on their own retry policy).
 
+  In addition, the number of retries done has been bumped from `32` to `128`
+  based on some benchmarking which showed that `32` could fail up to 3% of the
+  time but `128` would only fail ~0.1% of the time in the worst case scenario
+  of an attacker that can saturate all cores with `rename(2)` operations.
+
+  Users that need stronger resiliency guarantees can do their own additional
+  retry loop on top of `libpathrs` by checking the return value for `EAGAIN`.
+  Please note that we would strongly recommend having some restriction to avoid
+  denial-of-service attacks (such as a deadline -- for reference, our testing
+  showed that even with >50k trials containing >200k operations a deadline of
+  1ms was never exceeded even in the most pessimistic attack scenario).
+
 ## [0.2.0] - 2025-10-17 ##
 
 > You're gonna need a bigger boat.

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -106,9 +106,13 @@ pub(crate) fn resolve(
 
     // openat2(2) can fail with -EAGAIN if there was a racing rename or mount
     // *anywhere on the system*. This can happen pretty frequently, so what we
-    // do is attempt the openat2(2) a couple of times. If it still fails, just
-    // error out.
-    const MAX_RETRIES: u8 = 32;
+    // do is attempt the openat2(2) a couple of times.
+    //
+    // Based on some fairly extensive tests, with 128 retries you only have a
+    // ~0.1% chance of hitting the error path (even with an attacker pounding on
+    // rename on all cores). Users that need stricter retry requirements can do
+    // their own higher-level retry loop based on the errno.
+    const MAX_RETRIES: u8 = 128;
     let mut tries = 0u8;
     loop {
         tries += 1;


### PR DESCRIPTION
Based on some testing, the 32 limit can still fail in 3% of cases which
is a bit too high for some users. 128 only fails in ~0.1% of cases in
the worst-case "attacker is banging on the door" scenario, and higher
level runtimes that need stronger resiliency assurances can do extra
retry loops themselves by looking at ErrorKind.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>