### PR TITLE
root: support O_TMPFILE for create_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - go bindings: fix the internal `os.FileMode` to `S_IF*` conversion to not
   auto-include `S_IFREG` for non-`Mknod` operations (previously this would
   cause `MkdirAll` to error out).
+- `Root::create_file` now supports `O_TMPFILE`.
 
 ### Changed ###
 - The `openat2` resolver will now return `-EAGAIN` if the number of `openat2`

--- a/e2e-tests/tests/root-create.bats
+++ b/e2e-tests/tests/root-create.bats
@@ -111,23 +111,23 @@ function teardown() {
 }
 
 @test "root mkfile --oflags O_TMPFILE" {
-	# FIXME FIXME FIXME
-	skip "known bug <https://github.com/cyphar/libpathrs/issues/278>"
-
 	ROOT="$(setup_tmpdir)"
 	mkdir -p "$ROOT/var/tmp"
 
-	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE --mode 0700 .
+	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE,O_RDWR --mode 0700 .
 	[ "$status" -eq 0 ]
-	# TODO: FILE-PATH?
+	grep -Ex "FILE-PATH $ROOT/#[0-9]+ \(deleted\)" <<<"$output"
 
-	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE --mode 0700 /
+	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE,O_WRONLY --mode 0700 /
 	[ "$status" -eq 0 ]
-	# TODO: FILE-PATH?
+	grep -Ex "FILE-PATH $ROOT/#[0-9]+ \(deleted\)" <<<"$output"
 
-	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE --mode 0700 /var/tmp
+	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE,O_WRONLY --mode 0700 /var/tmp
 	[ "$status" -eq 0 ]
-	# TODO: FILE-PATH?
+	grep -Ex "FILE-PATH $ROOT/var/tmp/#[0-9]+ \(deleted\)" <<<"$output"
+
+	pathrs-cmd root --root "$ROOT" mkfile --oflags O_TMPFILE,O_RDONLY --mode 0700 .
+	check-errno EINVAL
 }
 
 @test "root mkfile [non-existent parent component]" {

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -494,6 +494,12 @@ root_op_tests! {
     trailing_slash: create_file("foobar/", O_RDONLY, 0o755) => Err(ErrorKind::InvalidArgument);
     trailing_dot: create_file("foobar/.", O_RDONLY, 0o755) => Err(ErrorKind::InvalidArgument);
     trailing_dotdot: create_file("foobar/..", O_RDONLY, 0o755) => Err(ErrorKind::InvalidArgument);
+    // TODO: Figure out how to match the success case...
+    //otmpfile: create_file("b/c", O_TMPFILE|O_RDWR, 0o755) => Ok(_); // has a random name
+    otmpfile_enoent: create_file("b/c/newfile", O_TMPFILE|O_RDWR, 0o755) => Err(ErrorKind::OsError(Some(libc::ENOENT)));
+    otmpfile_exist_file: create_file("b/c/file", O_TMPFILE|O_RDWR, 0o755) => Err(ErrorKind::OsError(Some(libc::ENOTDIR)));
+    //otmpfile_symlink: create_file("root-link", O_TMPFILE|O_RDWR, 0o755) => Ok(_); // has a random name
+    //otmpfile_symlink_parentdir: create_file("e/f", O_TMPFILE|O_RDWR, 0o755) => Ok(_); // has a random name
 
     ocreat: open_subpath("abc", O_CREAT|O_RDONLY) => Err(ErrorKind::InvalidArgument);
     oexcl: open_subpath("abc", O_EXCL|O_RDONLY) => Err(ErrorKind::InvalidArgument);


### PR DESCRIPTION
This case basically needs to be handled like Root::open_subpath()
because O_TMPFILE works by taking a directory that you want to create
the unnamed temporary file in.

Unfortunately the one-shot resolver open doesn't take permission bits so
we need to resolve then open-relative-to but this isn't that big of a
deal...

Fixes: #278
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>