### PR TITLE
openat2: more flexible fallback logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - libpathrs will now apply the same `openat2` retry logic for any usage of
   `openat2` (for scoped lookups), to further improve resiliency on busy
   systems.
+- Our logic for deciding whether to use `openat2(2)` or fallback to an `O_PATH`
+  resolver would cache the result to avoid doing needless test runs of
+  `openat2(2)`. However, this causes issues when libpathrs is being used by a
+  program that applies new seccomp-bpf filters onto itself -- if the filter
+  denies `openat2(2)` then we would return that error rather than falling back
+  to the `O_PATH` resolver. To resolve this issue, we have introduced more
+  flexible fallback mechanisms and no longer cache the result if `openat2(2)`
+  was successful (only if there was an error).
 
 ## [0.2.1] - 2025-11-03 ##
 

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -54,12 +54,6 @@ pub(crate) fn open(
     rflags: ResolverFlags,
     oflags: OpenFlags,
 ) -> Result<File, Error> {
-    if !*syscalls::OPENAT2_IS_SUPPORTED {
-        Err(ErrorImpl::NotSupported {
-            feature: "openat2".into(),
-        })?
-    }
-
     let rflags = libc::RESOLVE_IN_ROOT | libc::RESOLVE_NO_MAGICLINKS | rflags.bits();
     let how = OpenHow {
         flags: oflags.bits() as u64,
@@ -85,12 +79,6 @@ pub(crate) fn resolve(
     rflags: ResolverFlags,
     no_follow_trailing: bool,
 ) -> Result<Handle, Error> {
-    if !*syscalls::OPENAT2_IS_SUPPORTED {
-        Err(ErrorImpl::NotSupported {
-            feature: "openat2".into(),
-        })?
-    }
-
     // Copy the O_NOFOLLOW and RESOLVE_NO_SYMLINKS bits from flags.
     let mut oflags = OpenFlags::O_PATH;
     if no_follow_trailing {
@@ -155,5 +143,5 @@ pub(crate) fn resolve_partial(
         }
     }
 
-    unreachable!("partial_ancestors should include root path which must be resolvable");
+    Err(last_error)
 }

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -62,10 +62,6 @@ macro_rules! procfs_tests {
             #[test]
             $(#[$meta])*
             fn [<procfs_overmounts_ $func_prefix openat2_ $test_name>]() -> Result<(), Error> {
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
-                    // skip this test
-                    return Ok(());
-                }
                 utils::[<check_proc_ $procfs_op>](
                     || {
                         let mut proc = $procfs_inst ?;
@@ -85,7 +81,8 @@ macro_rules! procfs_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }

--- a/src/tests/test_race_resolve_partial.rs
+++ b/src/tests/test_race_resolve_partial.rs
@@ -100,7 +100,8 @@ macro_rules! resolve_race_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }
@@ -157,10 +158,10 @@ macro_rules! resolve_race_tests {
                         // TODO: Maybe we should do more runs locally than in
                         // CI, since GHA boxes are quite slow compared to my
                         // laptop?
-                        let test_retries = if *syscalls::OPENAT2_IS_SUPPORTED {
-                            20000
-                        } else {
+                        let test_retries = if syscalls::openat2::openat2_is_not_supported() {
                             1000
+                        } else {
+                            20000
                         };
 
                         let expected = vec![ $($expected)* ];

--- a/src/tests/test_resolve.rs
+++ b/src/tests/test_resolve.rs
@@ -138,7 +138,8 @@ macro_rules! resolve_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }
@@ -169,7 +170,8 @@ macro_rules! resolve_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }

--- a/src/tests/test_resolve_partial.rs
+++ b/src/tests/test_resolve_partial.rs
@@ -94,7 +94,8 @@ macro_rules! resolve_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -103,7 +103,8 @@ macro_rules! root_op_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }
@@ -126,7 +127,8 @@ macro_rules! root_op_tests {
                 // This test only makes sense if openat2 is supported (i.e., the
                 // default resolver is openat2 -- otherwise the default test
                 // already tested this case).
-                if !*syscalls::OPENAT2_IS_SUPPORTED {
+                // TODO: Drop this?
+                if syscalls::openat2::openat2_is_not_supported() {
                     // skip this test
                     return Ok(());
                 }


### PR DESCRIPTION
Programs can configure seccomp-bpf filters during their execution,
potentially causing openat2(2) to start failing after libpathrs has
detected that it works.

The solution is two-fold:

 1. Only cache openat2(2) *failures* for the purposes of detecting if
    openat2(2) is supported.

    If a trivial openat2(2) fails then either the kernel does not
    support it or a seccomp-bpf filter was activated. In either case,
    the program cannot revert to a state where openat2(2) is supported
    again, so it's safe to cache this.

    On the other hand, openat2(2) working in the past does not guarantee
    it will continue to work, so we cannot cache this result.

 2. Because the resolver type is picked at the creation time of the
    top-level object being used for resolutions (ProcfsHandle and Root),
    the above solution is not enough, as objects created before the
    seccomp-bpf profile are created could have the wrong resolver.

    The solution here is a little more annoying -- the only option is to
    do a fallback if openat2(2) is not supported at the time we try to
    use the resolver. There are a few options here (with different
    downsides), but the goal should be to be as efficient as possible
    for the openat2(2)-is-supported case.

    To wit, for the openat2(2) resolvers we always try the actual
    openat2(2) operation first. If this works, then we just return the
    value and everything worked out. If it fails, then we check if any
    openat2(2) call will fail (by trying a basic open-"." call) -- if
    this is the case then we do the fallback, otherwise we return the
    error from openat2(2) directly. This secondary check is necessary to
    make sure that we don't fall victim to a downgrade attack if an
    attacker finds a bug in the O_PATH resolver that triggers an error
    in the openat2(2) resolver.

All of the above was already done in pathrs-lite (though only for the
Root resolver -- the procfs resolver doesn't do this, but in this patch
to libpathrs we do it for all resolvers).

However, one unfortunate aspect of libpathrs is that the resolvers are
all enums with an "impl Default" that selects the most appropriate
resolver automatically. As per (1), this would naively require every
Default call to do a dummy openat2(2) call, which is needlessly
expensive (especially with RootRef through C FFI -- every pathrs_*
function call will do an extra openat2(2) call first).

The solution is for this case to only check if there is a cached failure
without attempting openat2(2) if there isn't. If there is a cached
failure we can just select O_PATH by default, otherwise we select
openat2(2) so that if it is supported then we have no extra overhead.
Otherwise, the check for support is deferred to the error path, as
intended by (2).

Fixes #303
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>