### PR TITLE
capi: change *link and rename arguments to match syscall API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `new_root_fd`. At the moment, callers must pass *the same value* to both
     arguments (this means the same numeric file descriptor value, not just a
     reference to the same underlying file).
+* `pathrs_inroot_rename` also now accepts both an `old_root_fd` and
+  `new_root_fd`, with the same caveats as `pathrs_inroot_hardlink` above.
 * `RenameFlags` is now backed by a `u64` (instead of `libc::c_uint`) so that we
   can accommodate future extension bits beyond the kernel's current 32-bit ABI.
   Rust callers using `RenameFlags::bits()` or storing the raw value will need
   to adjust their types.
+  - As part of this, `pathrs_inroot_rename` now also takes a `uint64_t`, and
+    thus the the Go `(*Root).Rename` wrapper takes a `uint64` as well.
 
 ### Added ###
 - capi: We now have a new `pathrs_version` API that provides runtime version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Breaking ###
+* `RenameFlags` is now backed by a `u64` (instead of `libc::c_uint`) so that we
+  can accommodate future extension bits beyond the kernel's current 32-bit ABI.
+  Rust callers using `RenameFlags::bits()` or storing the raw value will need
+  to adjust their types.
+
 ### Added ###
 - capi: We now have a new `pathrs_version` API that provides runtime version
   information, which loosely matches other libraries like `libseccomp`. The API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] ##
 
 ### Breaking ###
+* `pathrs_inroot_hardlink` and `pathrs_inroot_symlink` have been switched to
+  using the standard argument order from their respective system calls
+  (previously the order was swapped, which lead to possible confusion).
+  - Previously compiled programs will continue to work (thanks to symbol
+    versioning) but rebuilt programs will need to adjust their argument order.
+  - Rust users are not affected by this change.
+  - For the Go and Python bindings, the wrappers have also had their argument
+    orders swapped to match the C API and so will also need to be updated when
+    rebuilding.
+  - For the sake of future extensions (and to ease the migration),
+    `pathrs_inroot_hardlink` now accepts both an `old_root_fd` and
+    `new_root_fd`. At the moment, callers must pass *the same value* to both
+    arguments (this means the same numeric file descriptor value, not just a
+    reference to the same underlying file).
 * `RenameFlags` is now backed by a `u64` (instead of `libc::c_uint`) so that we
   can accommodate future extension bits beyond the kernel's current 32-bit ABI.
   Rust callers using `RenameFlags::bits()` or storing the raw value will need

--- a/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
+++ b/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
@@ -107,10 +107,16 @@ def pathrs_inroot_mknod(
     rootfd: RawFd, path: CString, mode: int, dev: int
 ) -> Union[Literal[0], ErrorId]: ...
 def pathrs_inroot_hardlink(
-    rootfd: RawFd, path: CString, target: CString
+    old_rootfd: RawFd,
+    old_path: CString,
+    new_rootfd: RawFd,
+    new_path: CString,
+    flags: int,
 ) -> Union[Literal[0], ErrorId]: ...
 def pathrs_inroot_symlink(
-    rootfd: RawFd, path: CString, target: CString
+    target: CString,
+    rootfd: RawFd,
+    linkpath: CString,
 ) -> Union[Literal[0], ErrorId]: ...
 def pathrs_inroot_readlink(
     rootfd: RawFd, path: CString, linkbuf: CBuffer, linkbuf_size: int

--- a/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
+++ b/contrib/bindings/python/pathrs/_libpathrs_cffi/lib.pyi
@@ -90,7 +90,11 @@ def pathrs_inroot_creat(
     rootfd: RawFd, path: CString, flags: int, filemode: int
 ) -> Union[RawFd, ErrorId]: ...
 def pathrs_inroot_rename(
-    rootfd: RawFd, src: CString, dst: CString, flags: int
+    old_rootfd: RawFd,
+    old_path: CString,
+    new_rootfd: RawFd,
+    new_path: CString,
+    flags: int,
 ) -> Union[Literal[0], ErrorId]: ...
 def pathrs_inroot_rmdir(rootfd: RawFd, path: CString) -> Union[Literal[0], ErrorId]: ...
 def pathrs_inroot_unlink(

--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -398,35 +398,35 @@ class Root(WrappedFd):
         if _is_pathrs_err(err):
             raise PathrsError._fetch(err) or INTERNAL_ERROR
 
-    def hardlink(self, path: str, target: str, /) -> None:
+    def hardlink(self, target: str, linkname: str, /) -> None:
         """
         Create a hardlink between two paths inside the Root.
 
-        path is the path to the *new* hardlink, and target is a path to the
-        *existing* file.
+        linkname is the path to the *new* hardlink, and target is a path to
+        the *existing* file.
 
         A pathrs.Error is raised if the path for the new hardlink already
         exists.
         """
         err = libpathrs_so.pathrs_inroot_hardlink(
-            self.fileno(), _cstr(path), _cstr(target)
+            self.fileno(), _cstr(target), self.fileno(), _cstr(linkname), 0
         )
         if _is_pathrs_err(err):
             raise PathrsError._fetch(err) or INTERNAL_ERROR
 
-    def symlink(self, path: str, target: str, /) -> None:
+    def symlink(self, target: str, linkname: str, /) -> None:
         """
         Create a symlink at the given path in the Root.
 
-        path is the path to the *new* symlink, and target is what the symink
-        will point to. Note that symlinks contents are not verified on Linux,
-        so there are no restrictions on what target you put.
+        linkname is the path to the *new* symlink, and target is what the
+        symlink will point to. Note that symlink contents are not verified on
+        Linux, so there are no restrictions on what target you put.
 
         A pathrs.Error is raised if the path for the new symlink already
         exists.
         """
         err = libpathrs_so.pathrs_inroot_symlink(
-            self.fileno(), _cstr(path), _cstr(target)
+            _cstr(target), self.fileno(), _cstr(linkname)
         )
         if _is_pathrs_err(err):
             raise PathrsError._fetch(err) or INTERNAL_ERROR

--- a/contrib/bindings/python/pathrs/_pathrs.py
+++ b/contrib/bindings/python/pathrs/_pathrs.py
@@ -305,7 +305,7 @@ class Root(WrappedFd):
         """
         # TODO: Should we have a separate Root.swap() operation?
         err = libpathrs_so.pathrs_inroot_rename(
-            self.fileno(), _cstr(src), _cstr(dst), flags
+            self.fileno(), _cstr(src), self.fileno(), _cstr(dst), flags
         )
         if _is_pathrs_err(err):
             raise PathrsError._fetch(err) or INTERNAL_ERROR

--- a/e2e-tests/cmd/go/root.go
+++ b/e2e-tests/cmd/go/root.go
@@ -314,8 +314,7 @@ var rootHardlinkCmd = &cli.Command{
 		target := cmd.StringArg("target")
 		linkname := cmd.StringArg("linkname")
 
-		// TODO: These arguments need to get swapped.
-		return root.Hardlink(linkname, target)
+		return root.Hardlink(target, linkname)
 	},
 }
 
@@ -336,8 +335,7 @@ var rootSymlinkCmd = &cli.Command{
 		target := cmd.StringArg("target")
 		linkname := cmd.StringArg("linkname")
 
-		// TODO: These arguments need to get swapped.
-		return root.Symlink(linkname, target)
+		return root.Symlink(target, linkname)
 	},
 }
 

--- a/e2e-tests/cmd/go/root.go
+++ b/e2e-tests/cmd/go/root.go
@@ -441,7 +441,7 @@ var rootRenameCmd = &cli.Command{
 		src := cmd.StringArg("source")
 		dst := cmd.StringArg("destination")
 
-		var renameArgs uint
+		var renameArgs uint64
 		if !cmd.Bool("clobber") {
 			renameArgs |= unix.RENAME_NOREPLACE
 		}

--- a/e2e-tests/cmd/python/pathrs-cmd.py
+++ b/e2e-tests/cmd/python/pathrs-cmd.py
@@ -104,8 +104,7 @@ def root_hardlink(args: argparse.Namespace):
     target: str = args.target
     linkname: str = args.linkname
 
-    # TODO: These arguments need to get swapped.
-    root.hardlink(linkname, target)
+    root.hardlink(target, linkname)
 
 
 def root_symlink(args: argparse.Namespace):
@@ -113,8 +112,7 @@ def root_symlink(args: argparse.Namespace):
     target: str = args.target
     linkname: str = args.linkname
 
-    # TODO: These arguments need to get swapped.
-    root.symlink(linkname, target)
+    root.symlink(target, linkname)
 
 
 def root_readlink(args: argparse.Namespace):

--- a/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -154,14 +154,14 @@ func InRootCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, 
 }
 
 // InRootRename wraps pathrs_inroot_rename.
-func InRootRename(rootFd uintptr, src, dst string, flags uint) error {
-	cSrc := C.CString(src)
-	defer C.free(unsafe.Pointer(cSrc))
+func InRootRename(oldRootFd uintptr, oldPath string, newRootFd uintptr, newPath string, flags uint64) error {
+	cOldPath := C.CString(oldPath)
+	defer C.free(unsafe.Pointer(cOldPath))
 
-	cDst := C.CString(dst)
-	defer C.free(unsafe.Pointer(cDst))
+	cNewPath := C.CString(newPath)
+	defer C.free(unsafe.Pointer(cNewPath))
 
-	err := C.pathrs_inroot_rename(C.int(rootFd), cSrc, cDst, C.uint(flags))
+	err := C.pathrs_inroot_rename(C.int(oldRootFd), cOldPath, C.int(newRootFd), cNewPath, C.uint64_t(flags))
 	return fetchError(err)
 }
 

--- a/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -193,26 +193,26 @@ func InRootMknod(rootFd uintptr, path string, mode uint32, dev uint64) error {
 }
 
 // InRootSymlink wraps pathrs_inroot_symlink.
-func InRootSymlink(rootFd uintptr, path, target string) error {
-	cPath := C.CString(path)
-	defer C.free(unsafe.Pointer(cPath))
+func InRootSymlink(target string, rootFd uintptr, linkpath string) error {
+	cLinkpath := C.CString(linkpath)
+	defer C.free(unsafe.Pointer(cLinkpath))
 
 	cTarget := C.CString(target)
 	defer C.free(unsafe.Pointer(cTarget))
 
-	err := C.pathrs_inroot_symlink(C.int(rootFd), cPath, cTarget)
+	err := C.pathrs_inroot_symlink(cTarget, C.int(rootFd), cLinkpath)
 	return fetchError(err)
 }
 
 // InRootHardlink wraps pathrs_inroot_hardlink.
-func InRootHardlink(rootFd uintptr, path, target string) error {
-	cPath := C.CString(path)
-	defer C.free(unsafe.Pointer(cPath))
+func InRootHardlink(oldRootFd uintptr, oldPath string, newRootFd uintptr, newPath string, flags uint64) error {
+	cNewPath := C.CString(newPath)
+	defer C.free(unsafe.Pointer(cNewPath))
 
-	cTarget := C.CString(target)
-	defer C.free(unsafe.Pointer(cTarget))
+	cOldPath := C.CString(oldPath)
+	defer C.free(unsafe.Pointer(cOldPath))
 
-	err := C.pathrs_inroot_hardlink(C.int(rootFd), cPath, cTarget)
+	err := C.pathrs_inroot_hardlink(C.int(oldRootFd), cOldPath, C.int(newRootFd), cNewPath, C.uint64_t(flags))
 	return fetchError(err)
 }
 

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -155,9 +155,9 @@ func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error
 
 // Rename two paths within a [Root]'s directory tree. The flags argument is
 // identical to the RENAME_* flags to the renameat2(2) system call.
-func (r *Root) Rename(src, dst string, flags uint) error {
+func (r *Root) Rename(src, dst string, flags uint64) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootRename(rootFd, src, dst, flags)
+		err := libpathrs.InRootRename(rootFd, src, rootFd, dst, flags)
 		return struct{}{}, err
 	})
 	return err

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -277,26 +277,26 @@ func (r *Root) Mknod(path string, mode os.FileMode, dev uint64) error {
 }
 
 // Symlink creates a symlink within a [Root]'s directory tree. The symlink is
-// created at path and is a link to target.
+// created at newname and is a link to oldname.
 //
 // This is effectively equivalent to [os.Symlink].
-func (r *Root) Symlink(path, target string) error {
+func (r *Root) Symlink(oldname, newname string) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootSymlink(rootFd, path, target)
+		err := libpathrs.InRootSymlink(oldname, rootFd, newname)
 		return struct{}{}, err
 	})
 	return err
 }
 
 // Hardlink creates a hardlink within a [Root]'s directory tree. The hardlink
-// is created at path and is a link to target. Both paths are within the
+// is created at newname and is a link to oldname. Both paths are within the
 // [Root]'s directory tree (you cannot hardlink to a different [Root] or the
 // host).
 //
 // This is effectively equivalent to [os.Link].
-func (r *Root) Hardlink(path, target string) error {
+func (r *Root) Hardlink(oldname, newname string) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootHardlink(rootFd, path, target)
+		err := libpathrs.InRootHardlink(rootFd, oldname, rootFd, newname, 0)
 		return struct{}{}, err
 	})
 	return err

--- a/hack/check-elf-symbols.sh
+++ b/hack/check-elf-symbols.sh
@@ -93,7 +93,13 @@ unversioned="$(awk '!($(NF-1) ~ /^LIBPATHRS_|^\(LIBPATHRS_.*\)/)' <<<"$SYMBOL_OB
 [ -z "$unversioned" ] || {
 	echo "UNVERSIONED SYMBOLS ($(wc -l <<<"$unversioned") total):"
 	echo "$unversioned"
-	bail "$ELF_FILE contains unversioned symbols"
+	# FIXME: lld incorrectly keeps the compatibility shim functions visible and
+	# there doesn't appear to be a way to fix this. For a longer discussion of
+	# these problems, see the upstream discussion -- in particular:
+	# <https://internals.rust-lang.org/t/support-symbol-versioning-with-export-name/23626/10>.
+	if grep -Evwq "__pathrs_.*_v[[:digit:]]+" <<<"$unversioned"; then
+		bail "$ELF_FILE contains non-compat unversioned symbols"
+	fi
 }
 
 echo "++ ALL SYMBOLS ARE VERSIONED! ++"

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -530,11 +530,22 @@ int pathrs_inroot_mknod(int root_fd,
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_inroot_symlink(int root_fd, const char *path, const char *target);
+int pathrs_inroot_symlink(const char *target,
+                          int root_fd,
+                          const char *linkpath);
 
 /**
  * Create a hardlink within the rootfs referenced by root_fd. Both the hardlink
  * path and target are resolved within the rootfs.
+ *
+ * # Future-proofing
+ *
+ * This function takes two `root_fd` arguments in order for future extensions
+ * to be able to use them, but callers must specify the same *value* for both
+ * arguments. (NOTE: This is not referring to the same underlying file, the
+ * actual file descriptor number must be identical.)
+ *
+ * The `flags` argument is included for future extensions and must be 0.
  *
  * # Return Value
  *
@@ -545,7 +556,11 @@ int pathrs_inroot_symlink(int root_fd, const char *path, const char *target);
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_inroot_hardlink(int root_fd, const char *path, const char *target);
+int pathrs_inroot_hardlink(int old_root_fd,
+                           const char *old_path,
+                           int new_root_fd,
+                           const char *new_path,
+                           uint64_t flags);
 
 /**
  * Create a new (custom) procfs root handle.

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -367,6 +367,13 @@ int pathrs_inroot_readlink(int root_fd,
  * Rename a path within the rootfs referenced by root_fd. The flags argument is
  * identical to the renameat2(2) flags that are supported on the system.
  *
+ * # Future-proofing
+ *
+ * This function takes two `root_fd` arguments in order for future extensions
+ * to be able to use them, but callers must specify the same *value* for both
+ * arguments. (NOTE: This is not referring to the same underlying file, the
+ * actual file descriptor number must be identical.)
+ *
  * # Return Value
  *
  * On success, this function returns 0.
@@ -376,10 +383,11 @@ int pathrs_inroot_readlink(int root_fd,
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_inroot_rename(int root_fd,
-                         const char *src,
-                         const char *dst,
-                         uint32_t flags);
+int pathrs_inroot_rename(int old_root_fd,
+                         const char *old_path,
+                         int new_root_fd,
+                         const char *new_path,
+                         uint64_t flags);
 
 /**
  * Remove the empty directory at path within the rootfs referenced by root_fd.

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -44,7 +44,10 @@ use crate::{
 
 use std::{
     fs::Permissions,
-    os::unix::{fs::PermissionsExt, io::RawFd},
+    os::unix::{
+        fs::PermissionsExt,
+        io::{AsRawFd, RawFd},
+    },
 };
 
 use libc::{c_char, c_int, c_uint, dev_t, size_t};
@@ -622,29 +625,56 @@ utils::symver! {
 /// pathrs_errorinfo().
 #[no_mangle]
 pub unsafe extern "C" fn pathrs_inroot_symlink(
-    root_fd: CBorrowedFd<'_>,
-    path: *const c_char,
     target: *const c_char,
+    root_fd: CBorrowedFd<'_>,
+    linkpath: *const c_char,
 ) -> c_int {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
         let root = RootRef::from_fd(root_fd);
-        let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
         let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
-        root.create(path, &InodeType::Symlink(target.into()))
+        let linkpath = unsafe { utils::parse_path(linkpath)? }; // SAFETY: C caller guarantees path is safe.
+        root.create(linkpath, &InodeType::Symlink(target.into()))
     }()
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_inroot_symlink <- (pathrs_inroot_symlink, version = "LIBPATHRS_0.2", default);
+    fn pathrs_inroot_symlink <- (pathrs_inroot_symlink, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_inroot_symlink`, which previously took its
+/// arguments in the wrong order.
+///
+/// cbindgen:ignore
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_inroot_symlink_v1(
+    root_fd: CBorrowedFd<'_>,
+    path: *const c_char,
+    target: *const c_char,
+) -> c_int {
+    pathrs_inroot_symlink(target, root_fd, path)
+}
+utils::symver! {
+    // The old version of pathrs_inroot_symlink had "target" and "linkpath"
+    // flipped and the dirfd was in the wrong position.
+    fn __pathrs_inroot_symlink_v1 <- (pathrs_inroot_symlink, version = "LIBPATHRS_0.2");
     // This symbol was renamed in libpathrs 0.2. For backward compatibility with
     // pre-symbol-versioned builds of libpathrs, it needs to be a default so
     // that loaders will pick it when searching for the unversioned name.
-    fn pathrs_inroot_symlink <- (pathrs_symlink, version = "LIBPATHRS_0.1", default);
+    fn __pathrs_inroot_symlink_v1 <- (pathrs_symlink, version = "LIBPATHRS_0.1", default);
 }
 
 /// Create a hardlink within the rootfs referenced by root_fd. Both the hardlink
 /// path and target are resolved within the rootfs.
+///
+/// # Future-proofing
+///
+/// This function takes two `root_fd` arguments in order for future extensions
+/// to be able to use them, but callers must specify the same *value* for both
+/// arguments. (NOTE: This is not referring to the same underlying file, the
+/// actual file descriptor number must be identical.)
+///
+/// The `flags` argument is included for future extensions and must be 0.
 ///
 /// # Return Value
 ///
@@ -656,23 +686,56 @@ utils::symver! {
 /// pathrs_errorinfo().
 #[no_mangle]
 pub unsafe extern "C" fn pathrs_inroot_hardlink(
-    root_fd: CBorrowedFd<'_>,
-    path: *const c_char,
-    target: *const c_char,
+    old_root_fd: CBorrowedFd<'_>,
+    old_path: *const c_char,
+    new_root_fd: CBorrowedFd<'_>,
+    new_path: *const c_char,
+    flags: u64,
 ) -> c_int {
     || -> Result<_, Error> {
-        let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd(root_fd);
-        let path = unsafe { utils::parse_path(path)? }; // SAFETY: C caller guarantees path is safe.
-        let target = unsafe { utils::parse_path(target)? }; // SAFETY: C caller guarantees path is safe.
-        root.create(path, &InodeType::Hardlink(target.into()))
+        if flags != 0 {
+            Err(ErrorImpl::InvalidArgument {
+                name: "flags".into(),
+                description: "flags are unsupported".into(),
+            })?;
+        }
+        let old_root_fd = old_root_fd.try_as_borrowed_fd()?;
+        let new_root_fd = new_root_fd.try_as_borrowed_fd()?;
+        if old_root_fd.as_raw_fd() != new_root_fd.as_raw_fd() {
+            Err(ErrorImpl::InvalidArgument {
+                name: "new_root_fd".into(),
+                description: "new_root_fd and old_root_fd must have the same fd value".into(),
+            })?;
+        }
+        let root = RootRef::from_fd(new_root_fd);
+        let old_path = unsafe { utils::parse_path(old_path) }?; // SAFETY: C caller guarantees path is safe.
+        let new_path = unsafe { utils::parse_path(new_path) }?; // SAFETY: C caller guarantees path is safe.
+        root.create(new_path, &InodeType::Hardlink(old_path.into()))
     }()
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_inroot_hardlink <- (pathrs_inroot_hardlink, version = "LIBPATHRS_0.2", default);
+    fn pathrs_inroot_hardlink <- (pathrs_inroot_hardlink, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_inroot_hardlink`, which previously took its
+/// arguments in the wrong order.
+///
+/// cbindgen:ignore
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_inroot_hardlink_v1(
+    root_fd: CBorrowedFd<'_>,
+    path: *const c_char,
+    target: *const c_char,
+) -> c_int {
+    pathrs_inroot_hardlink(root_fd, target, root_fd, path, 0)
+}
+utils::symver! {
+    // The old version of pathrs_inroot_hardlink had "target" and "linkpath"
+    // flipped, and only one dirfd argument was taken.
+    fn __pathrs_inroot_hardlink_v1 <- (pathrs_inroot_hardlink, version = "LIBPATHRS_0.2");
     // This symbol was renamed in libpathrs 0.2. For backward compatibility with
     // pre-symbol-versioned builds of libpathrs, it needs to be a default so
     // that loaders will pick it when searching for the unversioned name.
-    fn pathrs_inroot_hardlink <- (pathrs_hardlink, version = "LIBPATHRS_0.1", default);
+    fn __pathrs_inroot_hardlink_v1 <- (pathrs_hardlink, version = "LIBPATHRS_0.1", default);
 }

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -319,7 +319,7 @@ pub unsafe extern "C" fn pathrs_inroot_rename(
         let src = unsafe { utils::parse_path(src) }?; // SAFETY: C caller guarantees path is safe.
         let dst = unsafe { utils::parse_path(dst) }?; // SAFETY: C caller guarantees path is safe.
 
-        let rflags = RenameFlags::from_bits_retain(flags);
+        let rflags = RenameFlags::from_bits_retain(flags.into());
         root.rename(src, dst, rflags)
     }()
     .into_c_return()

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -301,6 +301,13 @@ utils::symver! {
 /// Rename a path within the rootfs referenced by root_fd. The flags argument is
 /// identical to the renameat2(2) flags that are supported on the system.
 ///
+/// # Future-proofing
+///
+/// This function takes two `root_fd` arguments in order for future extensions
+/// to be able to use them, but callers must specify the same *value* for both
+/// arguments. (NOTE: This is not referring to the same underlying file, the
+/// actual file descriptor number must be identical.)
+///
 /// # Return Value
 ///
 /// On success, this function returns 0.
@@ -311,28 +318,56 @@ utils::symver! {
 /// pathrs_errorinfo().
 #[no_mangle]
 pub unsafe extern "C" fn pathrs_inroot_rename(
+    old_root_fd: CBorrowedFd<'_>,
+    old_path: *const c_char,
+    new_root_fd: CBorrowedFd<'_>,
+    new_path: *const c_char,
+    flags: u64,
+) -> c_int {
+    let rflags = RenameFlags::from_bits_retain(flags);
+
+    || -> Result<_, Error> {
+        let old_root_fd = old_root_fd.try_as_borrowed_fd()?;
+        let new_root_fd = new_root_fd.try_as_borrowed_fd()?;
+        if old_root_fd.as_raw_fd() != new_root_fd.as_raw_fd() {
+            Err(ErrorImpl::InvalidArgument {
+                name: "new_root_fd".into(),
+                description: "new_root_fd and old_root_fd must have the same fd value".into(),
+            })?;
+        }
+        let root = RootRef::from_fd(new_root_fd);
+        let old_path = unsafe { utils::parse_path(old_path) }?; // SAFETY: C caller guarantees path is safe.
+        let new_path = unsafe { utils::parse_path(new_path) }?; // SAFETY: C caller guarantees path is safe.
+
+        root.rename(old_path, new_path, rflags)
+    }()
+    .into_c_return()
+}
+utils::symver! {
+    fn pathrs_inroot_rename <- (pathrs_inroot_rename, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_inroot_rename`, which previously only took
+/// a single `root_fd` argument.
+///
+/// cbindgen:ignore
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_inroot_rename_v1(
     root_fd: CBorrowedFd<'_>,
     src: *const c_char,
     dst: *const c_char,
     flags: u32,
 ) -> c_int {
-    || -> Result<_, Error> {
-        let root_fd = root_fd.try_as_borrowed_fd()?;
-        let root = RootRef::from_fd(root_fd);
-        let src = unsafe { utils::parse_path(src) }?; // SAFETY: C caller guarantees path is safe.
-        let dst = unsafe { utils::parse_path(dst) }?; // SAFETY: C caller guarantees path is safe.
-
-        let rflags = RenameFlags::from_bits_retain(flags.into());
-        root.rename(src, dst, rflags)
-    }()
-    .into_c_return()
+    pathrs_inroot_rename(root_fd, src, root_fd, dst, flags.into())
 }
 utils::symver! {
-    fn pathrs_inroot_rename <- (pathrs_inroot_rename, version = "LIBPATHRS_0.2", default);
+    // The old version of pathrs_inroot_rename only took a single root_fd
+    // argument.
+    fn __pathrs_inroot_rename_v1 <- (pathrs_inroot_rename, version = "LIBPATHRS_0.2");
     // This symbol was renamed in libpathrs 0.2. For backward compatibility with
     // pre-symbol-versioned builds of libpathrs, it needs to be a default so
     // that loaders will pick it when searching for the unversioned name.
-    fn pathrs_inroot_rename <- (pathrs_rename, version = "LIBPATHRS_0.1", default);
+    fn __pathrs_inroot_rename_v1 <- (pathrs_rename, version = "LIBPATHRS_0.1", default);
 }
 
 /// Remove the empty directory at path within the rootfs referenced by root_fd.

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -204,10 +204,10 @@ bitflags! {
     /// [`renameat2(2)`]: http://man7.org/linux/man-pages/man2/rename.2.html
     /// [`Root::rename`]: crate::Root::rename
     #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
-    pub struct RenameFlags: libc::c_uint {
-        const RENAME_EXCHANGE = libc::RENAME_EXCHANGE;
-        const RENAME_NOREPLACE = libc::RENAME_NOREPLACE;
-        const RENAME_WHITEOUT = libc::RENAME_WHITEOUT;
+    pub struct RenameFlags: u64 {
+        const RENAME_EXCHANGE = libc::RENAME_EXCHANGE as _;
+        const RENAME_NOREPLACE = libc::RENAME_NOREPLACE as _;
+        const RENAME_WHITEOUT = libc::RENAME_WHITEOUT as _;
 
         // Don't clobber unknown RENAME_* bits.
         const _ = !0;
@@ -216,7 +216,11 @@ bitflags! {
 
 impl From<RenameFlags> for rustix::fs::RenameFlags {
     fn from(flags: RenameFlags) -> Self {
-        Self::from_bits_retain(flags.bits())
+        debug_assert!(
+            flags.bits() < (1u64 << 32),
+            "RenameFlags cannot contain anything in the top 32 bits."
+        );
+        Self::from_bits_retain(flags.bits() as _)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,6 +57,8 @@ pub(in crate::tests) mod capi {
 
     mod procfs;
     pub(in crate::tests) use procfs::*;
+
+    mod test_compat;
 }
 
 pub(in crate::tests) mod traits {

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -259,6 +259,7 @@ impl CapiRoot {
             capi::core::pathrs_inroot_rename(
                 root_fd.into(),
                 source.as_ptr(),
+                root_fd.into(),
                 destination.as_ptr(),
                 rflags.bits() as _,
             )

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -258,7 +258,7 @@ impl CapiRoot {
                 root_fd.into(),
                 source.as_ptr(),
                 destination.as_ptr(),
-                rflags.bits(),
+                rflags.bits() as _,
             )
         })
     }

--- a/src/tests/capi/root.rs
+++ b/src/tests/capi/root.rs
@@ -138,9 +138,9 @@ impl CapiRoot {
                 let target = capi_utils::path_to_cstring(target);
                 unsafe {
                     capi::core::pathrs_inroot_symlink(
+                        target.as_ptr(),
                         root_fd.into(),
                         path.as_ptr(),
-                        target.as_ptr(),
                     )
                 }
             }
@@ -149,8 +149,10 @@ impl CapiRoot {
                 unsafe {
                     capi::core::pathrs_inroot_hardlink(
                         root_fd.into(),
-                        path.as_ptr(),
                         target.as_ptr(),
+                        root_fd.into(),
+                        path.as_ptr(),
+                        0,
                     )
                 }
             }

--- a/src/tests/capi/test_compat.rs
+++ b/src/tests/capi/test_compat.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MPL-2.0 OR LGPL-3.0-or-later
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
+ *
+ * == MPL-2.0 ==
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, this Source Code Form may also (at your option) be used
+ * under the terms of the GNU Lesser General Public License Version 3, as
+ * described below:
+ *
+ * == LGPL-3.0-or-later ==
+ *
+ *  This program is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or (at
+ *  your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License  for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    capi,
+    error::ErrorKind,
+    tests::{capi::utils as capi_utils, common as tests_common, traits::ErrorImpl},
+    utils::FdExt,
+    Root,
+};
+
+use std::os::unix::{fs::MetadataExt, io::AsFd};
+
+use anyhow::{Context, Error};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn hardlink_v1() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root = Root::open(root_dir.path())?;
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::__pathrs_inroot_hardlink_v1(
+                root.as_fd().into(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+            )
+        })
+        .map_err(|err| err.kind()),
+        Ok(0),
+        "__pathrs_inroot_hardlink_v1 should work"
+    );
+
+    let old_meta = root
+        .resolve_nofollow("b/c/file")?
+        .metadata()
+        .context("fstat b/c/file")?;
+    let new_meta = root
+        .resolve_nofollow("abc")
+        .context("hardlink abc should've been created")?
+        .metadata()
+        .context("fstat hardlink abc")?;
+    assert_eq!(
+        old_meta.ino(),
+        new_meta.ino(),
+        "inode numbers of hardlinks with __pathrs_inroot_hardlink_v1 should be the same",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hardlink_v2() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root1 = Root::open(root_dir.path())?;
+    let root2 = Root::open(root_dir.path())?;
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::pathrs_inroot_hardlink(
+                root1.as_fd().into(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                root2.as_fd().into(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                0,
+            )
+        })
+        .map_err(|err| err.kind().errno()),
+        Err(ErrorKind::InvalidArgument.errno()),
+        "pathrs_inroot_hardlink@LIBPATHRS_0.2.5 should reject old_root_fd != new_root_fd"
+    );
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::pathrs_inroot_hardlink(
+                root1.as_fd().into(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                root1.as_fd().into(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                0xFFFF,
+            )
+        })
+        .map_err(|err| err.kind().errno()),
+        Err(ErrorKind::InvalidArgument.errno()),
+        "pathrs_inroot_hardlink@LIBPATHRS_0.2.5 should reject flags != 0"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn symlink_v1() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root = Root::open(root_dir.path())?;
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::__pathrs_inroot_symlink_v1(
+                root.as_fd().into(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+            )
+        })
+        .map_err(|err| err.kind()),
+        Ok(0),
+        "__pathrs_inroot_symlink_v1 should work"
+    );
+
+    assert_eq!(
+        root.readlink("abc").map_err(|err| err.kind()),
+        Ok("b/c/file".into()),
+        "__pathrs_inroot_symlink_v1 should produce a symlink to the target"
+    );
+
+    Ok(())
+}

--- a/src/tests/capi/test_compat.rs
+++ b/src/tests/capi/test_compat.rs
@@ -41,7 +41,7 @@ use crate::{
 use std::os::unix::{fs::MetadataExt, io::AsFd};
 
 use anyhow::{Context, Error};
-use pretty_assertions::assert_eq;
+use pretty_assertions::{assert_eq, assert_matches};
 
 #[test]
 fn hardlink_v1() -> Result<(), Error> {
@@ -144,6 +144,66 @@ fn symlink_v1() -> Result<(), Error> {
         root.readlink("abc").map_err(|err| err.kind()),
         Ok("b/c/file".into()),
         "__pathrs_inroot_symlink_v1 should produce a symlink to the target"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rename_v1() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root = Root::open(root_dir.path())?;
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::__pathrs_inroot_rename_v1(
+                root.as_fd().into(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                0,
+            )
+        })
+        .map_err(|err| err.kind()),
+        Ok(0),
+        "__pathrs_inroot_symlink_v1 should work"
+    );
+
+    assert_matches!(
+        root.resolve_nofollow("abc"),
+        Ok(_),
+        "__pathrs_inroot_rename_v1 should rename the target file (target appears)"
+    );
+
+    assert_matches!(
+        root.resolve_nofollow("b/c/file").map_err(|err| err.kind()),
+        Err(ErrorKind::OsError(Some(libc::ENOENT))),
+        "__pathrs_inroot_rename_v1 should rename the target file (source disappears)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rename_v2() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root1 = Root::open(root_dir.path())?;
+    let root2 = Root::open(root_dir.path())?;
+
+    assert_eq!(
+        // SAFETY: Called with valid C-like arguments.
+        capi_utils::call_capi(|| unsafe {
+            capi::core::pathrs_inroot_rename(
+                root1.as_fd().into(),
+                capi_utils::path_to_cstring("abc").into_raw(),
+                root2.as_fd().into(),
+                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                0,
+            )
+        })
+        .map_err(|err| err.kind().errno()),
+        Err(ErrorKind::InvalidArgument.errno()),
+        "pathrs_inroot_rename@LIBPATHRS_0.2.5 should reject old_root_fd != new_root_fd"
     );
 
     Ok(())


### PR DESCRIPTION
For the pathrs_inroot_* API, it is a little cleaner to always have the
path to resolve be the first argument. However, when writing the e2e
tests I realised that diverging from the syscall API is just going to
cause confusion.

This is also a decent test case for our symbol versioning being used to
keep old binaries working (though in practice this is just a straight-up
breakage that doesn't need to be patched over).

Fixes #267
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>