### PR TITLE
procfs: opath: enforce fstype checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   to make cross-compilation workflows easier to write (in particular, this is
   needed for runc's release scripts).
 
+### Changed ###
+- The `O_PATH` resolver for `procfs` now has an additional bit of hardening
+  (each component must be on a procfs -- previously we would check that it is
+  on the same mount, which is an even stronger requirement but on older kernels
+  it is possible to not have a mount ID to check against).
+
 ### Fixed ###
 - Previously, `staticlib` builds of libpathrs (i.e., `libpathrs.a`)
   inadvertently included symbol versioned symbols (`@@LIBPATHRS_X.Y`), which

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -689,14 +689,9 @@ impl<'fd> ProcfsHandleRef<'fd> {
         })
     }
 
+    #[inline]
     fn verify_same_procfs_mnt(&self, fd: impl AsFd) -> Result<(), Error> {
-        // Detect if the file we landed on is from a bind-mount.
-        verify_same_mnt(self.as_raw_procfs(), self.mnt_id, &fd, "")?;
-        // For pre-5.8 kernels there is no STATX_MNT_ID, so the best we can
-        // do is check the fs_type to avoid mounts non-procfs filesystems.
-        // Unfortunately, attackers can bind-mount procfs files and still
-        // cause damage so this protection is marginal at best.
-        verify_is_procfs(&fd)
+        verify_same_procfs_mnt(self.as_raw_procfs(), self.mnt_id, fd)
     }
 
     /// Try to convert a [`BorrowedFd`] into a [`ProcfsHandle`] with the same
@@ -1020,6 +1015,27 @@ pub(crate) fn verify_same_mnt(
         ))?
     }
     Ok(())
+}
+
+pub(crate) fn verify_same_procfs_mnt(
+    proc_rootfd: RawProcfsRoot<'_>,
+    root_mnt_id: Option<u64>,
+    fd: impl AsFd,
+) -> Result<(), Error> {
+    let fd = fd.as_fd();
+
+    // Detect if the file we landed on is from a bind-mount.
+    verify_same_mnt(proc_rootfd, root_mnt_id, fd, "")?;
+
+    // For pre-5.8 kernels there is no STATX_MNT_ID, so the protection we get
+    // from verify_same_mnt() can be a little weaker (as it relies on fdinfo,
+    // which needs other protections to be made safe).
+    //
+    // To try to frustrate attackers, we still check for the fstype here (even
+    // though it is strictly weaker than the mount-id check). Unfortunately,
+    // arbitrary procfs files can still easily cause damage so this protection
+    // is marginal at best.
+    verify_is_procfs(fd)
 }
 
 #[cfg(test)]

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -310,7 +310,7 @@ fn opath_resolve(
         // Check that the next component is on the same mountpoint.
         // NOTE: If the root is the host /proc mount, this is only safe if there
         // are no racing mounts.
-        procfs::verify_same_mnt(proc_rootfd, root_mnt_id, &next, "")
+        procfs::verify_same_procfs_mnt(proc_rootfd, root_mnt_id, &next)
             .with_wrap(|| format!("open next component {part:?}"))
             .wrap("emulated procfs resolver RESOLVE_NO_XDEV")?;
 
@@ -385,7 +385,7 @@ fn opath_resolve(
                 // code!).
                 Ok(final_reopen) => {
                     // Re-verify the next component is on the same mount.
-                    procfs::verify_same_mnt(proc_rootfd, root_mnt_id, &final_reopen, "")
+                    procfs::verify_same_procfs_mnt(proc_rootfd, root_mnt_id, &final_reopen)
                         .wrap("re-open final component")
                         .wrap("emulated procfs resolver RESOLVE_NO_XDEV")?;
                     return Ok(final_reopen);


### PR DESCRIPTION
The statfs(2) checks are much weaker than the mnt_id ones, but at least
we can make an attacker's life harder on older kernels by rejecting any
non-procfs inodes during resolution.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>