### PR TITLE
README: drop the 3-col examples setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ Here is a toy example of using this library to open a path (`/etc/passwd`)
 inside a root filesystem (`/path/to/root`) safely. More detailed examples can
 be found in `examples/` and `tests/`.
 
-<table>
-<tr><th>Rust</th><th>C</th><th>Go</th></tr>
-<tr>
-<td>
+#### Rust ####
 
 ```rust
 use std::fs::File;
@@ -51,8 +48,7 @@ fn get_my_fd() -> Result<File, Error> {
 }
 ```
 
-</td>
-<td>
+#### C ####
 
 ```c
 #define _GNU_SOURCE
@@ -106,8 +102,7 @@ err:
 }
 ```
 
-</td>
-<td>
+#### Go ####
 
 ```go
 package main
@@ -138,10 +133,6 @@ func getMyFD() (*os.File, error) {
 	return handle.Open()
 }
 ```
-
-</td>
-</tr>
-</table>
 
 On Linux, libpathrs also provides an API for safe `procfs` operations with
 strict path safety [in the `procfs` module][docs.rs-procfs]. [Click

--- a/docs/procfs-api.md
+++ b/docs/procfs-api.md
@@ -43,10 +43,7 @@ The most common usage of the procfs API is writing to specific files in
 `/proc`. The following are two examples that are adapted from real code in
 container runtimes:
 
-<table>
-<tr><th>Rust</th><th>C</th><th>Go</th></tr>
-<tr>
-<td>
+#### Rust ####
 
 ```rust
 use pathrs::{
@@ -94,8 +91,7 @@ fn write_sysctl(name: impl AsRef<str>, value: impl AsRef<[u8]>) -> Result<(), Er
 }
 ```
 
-</td>
-<td>
+#### C #####
 
 ```c
 #include <unistd.h>
@@ -166,8 +162,7 @@ int write_sysctl(const char *name, const char *value)
 }
 ```
 
-</td>
-<td>
+#### Go ####
 
 ```go
 import (
@@ -227,9 +222,7 @@ func writeSysctl(name, value string) error {
 }
 ```
 
-</td>
-</tr>
-</table>
+- - -
 
 Another very powerful primitive is safe magic-link operations, which allow you
 to operate on certain files with guarantees from the kernel that the object is
@@ -239,10 +232,7 @@ able to call [`fsopen(2)`].
 
 [`fsopen(2)`]: https://www.man7.org/linux/man-pages/man2/fsopen.2.html
 
-<table>
-<tr><th>Rust</th><th>C</th><th>Go</th></tr>
-<tr>
-<td>
+#### Rust ####
 
 ```rust
 use std::fs::File;
@@ -263,8 +253,7 @@ fn get_self_exe() -> Result<File, Error> {
 }
 ```
 
-</td>
-<td>
+#### C ####
 
 ```c
 #include <unistd.h>
@@ -290,8 +279,7 @@ int get_self_exe(void)
 }
 ```
 
-</td>
-<td>
+#### Go ####
 
 ```go
 import (
@@ -315,9 +303,7 @@ func getSelfExe() (*os.File, error) {
 }
 ```
 
-</td>
-</tr>
-</table>
+- - -
 
 In some (rare) cases, you need to get the "real" path for a file descriptor.
 This path MUST NOT be used for actual filesystem operations because it's
@@ -326,10 +312,7 @@ to a symlink, which could lead to you operating on files you didn't expect
 (including host files). Similarly, you should not use the pathname for
 permissive security decisions because the attacker can always rename the file.
 
-<table>
-<tr><th>Rust</th><th>C</th><th>Go</th></tr>
-<tr>
-<td>
+#### Rust ####
 
 ```rust
 use std::{
@@ -349,8 +332,7 @@ fn get_unsafe_path(fd: impl AsFd) -> Result<PathBuf, Error> {
 }
 ```
 
-</td>
-<td>
+#### C ####
 
 ```c
 #define _GNU_SOURCE
@@ -409,8 +391,7 @@ err:
 }
 ```
 
-</td>
-<td>
+#### Go ####
 
 ```go
 import (
@@ -434,7 +415,3 @@ func getUnsafePath(fd int) (string, error) {
     return proc.Readlink(procfs.ProcThreadSelf, fmt.Sprintf("fd/%d", fd))
 }
 ```
-
-</td>
-</tr>
-</table>


### PR DESCRIPTION
The example code set up in 3 columns is not rendered good (at least on github.com) and is (arguably) not easy to view.

I can only see Rust code and a little bit of C, despite having a lot of screen estate. Using a horizontal scroll helps but is not very convenient (or common).

Replace the columns with subsections.

## Before ##

<img width="2817" height="1123" alt="image" src="https://github.com/user-attachments/assets/f04df83e-2e9a-49ee-aaf1-2ed191e76873" />
<img width="3312" height="1093" alt="image" src="https://github.com/user-attachments/assets/dd423953-b19a-4e09-8f74-1830ec536151" />

## After ##

<img width="2256" height="1715" alt="image" src="https://github.com/user-attachments/assets/5204588d-388b-4cb6-939c-5d901d20d39a" />
<img width="3054" height="1743" alt="image" src="https://github.com/user-attachments/assets/71a3911e-a9fb-4146-821b-8e919bd95173" />
