### PR TITLE
opath resolver: assume fs.protected_symlinks=1 if /proc access fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Fixed ###
+- Containers often have `/proc/sys` overmounted with a read-only mount to avoid
+  container escapes, this caused:
+  - The `O_PATH` resolver to panic because the hardened procfs lookup for
+    `/proc/sys/fs/protected_symlinks` would fail. We now conservatively assume
+    that `fs.protected_symlinks` is enabled if we cannot access the file for
+    any reason.
+
 ## [0.2.4] - 2026-03-03 ##
 
 > そう。神を生贄に捧げる！

--- a/src/resolvers/opath/imp.rs
+++ b/src/resolvers/opath/imp.rs
@@ -153,7 +153,11 @@ fn check_current(
 static PROTECTED_SYMLINKS_SYSCTL: Lazy<u32> = Lazy::new(|| {
     let procfs = ProcfsHandle::new().expect("should be able to get a procfs handle");
     utils::sysctl_read_parse(&procfs, "fs.protected_symlinks")
-        .expect("should be able to parse fs.protected_symlinks")
+        // In container workloads, /proc/sys might be overmounted as read-only
+        // and we really don't want to fail in this case so we just assume that
+        // fs.protected_symlinks is enabled (to be conservative).
+        // TODO(log): Add logging?
+        .unwrap_or(1u32)
 });
 
 /// Verify that we should follow the symlink as per `fs.protected_symlinks`.


### PR DESCRIPTION
In containers, /proc/sys is a read-only overmount which will get
rejected by the procfs resolver. We should figure out a nice way of
permitting those kinds of overmounts (where the mount subpath matches
the subpath we access) but assuming the more conservative option here is
a quick hotfix.

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>