### PR TITLE
root: make readlink return -EINVAL for non-symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `/proc/sys/fs/protected_symlinks` would fail. We now conservatively assume
     that `fs.protected_symlinks` is enabled if we cannot access the file for
     any reason.
+- `Root::readlink` would previously return `ENOENT` if the target path existed
+  but was not a symlink. This occurred because of a peculiar asymmetry in the
+  kernel APIs for `readlinkat(2)`, but users found it confusing and so we now
+  remap the error in that case to `EINVAL` (as you would get from `readlink(2)`
+  with a path). This will make it easier to distinguish the "target path does
+  not exist" and "target path is not a symlink" cases.
 
 ## [0.2.4] - 2026-03-03 ##
 

--- a/e2e-tests/tests/root-readlink.bats
+++ b/e2e-tests/tests/root-readlink.bats
@@ -49,12 +49,22 @@ function teardown() {
 	grep -Fx 'LINK-TARGET ../../link-b' <<<"$output"
 }
 
-@test "root readlink [non-symlink]" {
+@test "root readlink [file einval]" {
 	ROOT="$(setup_tmpdir)"
 
 	echo "/some/random/path" >"$ROOT/file"
 
 	pathrs-cmd root --root "$ROOT" readlink file
-	check-errno ENOENT
+	check-errno EINVAL
+	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
+}
+
+@test "root readlink [dir einval]" {
+	ROOT="$(setup_tmpdir)"
+
+	mkdir -p "$ROOT/dir"
+
+	pathrs-cmd root --root "$ROOT" readlink dir
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -870,7 +870,16 @@ impl RootRef<'_> {
         let link = self
             .resolve_nofollow(path)
             .wrap("resolve symlink O_NOFOLLOW for readlink")?;
-        syscalls::readlinkat(link, "").map_err(|err| {
+        syscalls::readlinkat(link, "").map_err(|mut err| {
+            // readlinkat(fd, "") returns ENOENT if the file descriptor is not a
+            // symlink, which is in stark contrast to the EINVAL you would
+            // normally get from readlinkat(dfd, path). As we know the target
+            // file exists at this point (because resolve_nofollow succeeded),
+            // we can just map ENOENT to EINVAL to reduce user confusion.
+            *err.errno_mut() = match err.errno() {
+                Errno::NOENT => Errno::INVAL,
+                errno => errno,
+            };
             ErrorImpl::RawOsError {
                 operation: "readlink resolve symlink".into(),
                 source: err,

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -283,32 +283,41 @@ pub(crate) enum Error {
     },
 }
 
+macro_rules! match_source_errno {
+    ($self:expr) => {
+        match $self {
+            Error::InvalidFd { source, .. }
+            | Error::Accessat { source, .. }
+            | Error::Openat { source, .. }
+            | Error::Openat2 { source, .. }
+            | Error::Readlinkat { source, .. }
+            | Error::Mkdirat { source, .. }
+            | Error::Mknodat { source, .. }
+            | Error::Unlinkat { source, .. }
+            | Error::Linkat { source, .. }
+            | Error::Symlinkat { source, .. }
+            | Error::Renameat { source, .. }
+            | Error::Renameat2 { source, .. }
+            | Error::Fstatfs { source, .. }
+            | Error::Fstatat { source, .. }
+            | Error::Statx { source, .. }
+            | Error::Fsopen { source, .. }
+            | Error::FsconfigCreate { source, .. }
+            | Error::FsconfigSetString { source, .. }
+            | Error::Fsmount { source, .. }
+            | Error::OpenTree { source, .. }
+            | Error::PrctlGet { source, .. } => source,
+        }
+    };
+}
+
 impl Error {
     pub(crate) fn errno(&self) -> Errno {
-        // XXX: This should probably be a macro...
-        *match self {
-            Error::InvalidFd { source, .. } => source,
-            Error::Accessat { source, .. } => source,
-            Error::Openat { source, .. } => source,
-            Error::Openat2 { source, .. } => source,
-            Error::Readlinkat { source, .. } => source,
-            Error::Mkdirat { source, .. } => source,
-            Error::Mknodat { source, .. } => source,
-            Error::Unlinkat { source, .. } => source,
-            Error::Linkat { source, .. } => source,
-            Error::Symlinkat { source, .. } => source,
-            Error::Renameat { source, .. } => source,
-            Error::Renameat2 { source, .. } => source,
-            Error::Fstatfs { source, .. } => source,
-            Error::Fstatat { source, .. } => source,
-            Error::Statx { source, .. } => source,
-            Error::Fsopen { source, .. } => source,
-            Error::FsconfigCreate { source, .. } => source,
-            Error::FsconfigSetString { source, .. } => source,
-            Error::Fsmount { source, .. } => source,
-            Error::OpenTree { source, .. } => source,
-            Error::PrctlGet { source, .. } => source,
-        }
+        *match_source_errno!(self)
+    }
+
+    pub(crate) fn errno_mut(&mut self) -> &mut Errno {
+        match_source_errno!(self)
     }
 
     // TODO: Switch to returning &Errno.

--- a/src/tests/capi/utils.rs
+++ b/src/tests/capi/utils.rs
@@ -37,6 +37,7 @@ use crate::{
 };
 
 use std::{
+    cmp,
     ffi::{CStr, CString, OsStr},
     fmt,
     os::unix::{
@@ -158,7 +159,7 @@ where
     Func: Fn(*mut libc::c_char, libc::size_t) -> libc::c_int,
 {
     // Get the actual size by passing NULL.
-    let mut actual_size = {
+    let actual_size = {
         // Try zero-size.
         let size1 = fetch_error(func(123 as *mut _, 0))? as usize;
         // Try NULL ptr.
@@ -167,24 +168,61 @@ where
         size1
     };
 
-    // Start with a smaller buffer so we can exercise the trimming logic.
-    // TODO: Use slice::assume_init_ref() once maybe_uninit_slice is stabilised.
-    let mut linkbuf: Vec<u8> = Vec::with_capacity(0);
-    actual_size /= 2;
-    while actual_size > linkbuf.capacity() {
-        linkbuf.reserve(actual_size);
-        actual_size = fetch_error(func(
+    // Wrapper around func() to allow for us to call it with different sizes.
+    let readlink_func = |size| -> Result<PathBuf, CapiError> {
+        let mut linkbuf: Vec<u8> = Vec::with_capacity(size);
+        let got_size = fetch_error(func(
             linkbuf.as_mut_ptr() as *mut libc::c_char,
             linkbuf.capacity(),
         ))? as usize;
-    }
-    // SAFETY: The C code guarantees that actual_size is how many bytes are filled.
-    unsafe { linkbuf.set_len(actual_size) };
-
-    Ok(PathBuf::from(OsStr::from_bytes(
+        // SAFETY: The C-API readlink methods return the number of bytes it
+        // would take to store the data. If this is >capacity then the entire
+        // array was filled (and data was truncated), otherwise it indicates how
+        // many bytes were filled.
+        unsafe { linkbuf.set_len(cmp::min(got_size, linkbuf.capacity())) };
         // readlink does *not* append a null terminator!
-        CString::new(linkbuf)
-            .expect("constructing a CString from the C API's copied CString should work")
-            .to_bytes(),
-    )))
+        Ok(OsStr::from_bytes(
+            CString::new(linkbuf)
+                .expect("constructing a CString from the C API's copied CString should work")
+                .to_bytes(),
+        )
+        .into())
+    };
+
+    // Get the actual link with the exactly correct buffer size.
+    let actual_linktarget = readlink_func(actual_size)?;
+
+    // Try to see different results and make sure they are actually truncated as
+    // expected.
+    // TODO: Maybe make this property-based? A bit ugly because this is being
+    // done deep within other tests... :/
+    for test_size in [
+        1,
+        2,
+        actual_size / 3,
+        actual_size / 2,
+        actual_size - 1, // actual_size must be > 0 -- symlinks cannot be empty
+        actual_size + 1,
+        actual_size + 2,
+        actual_size * 2,
+    ] {
+        let test_linktarget = readlink_func(test_size)?;
+
+        if test_size >= actual_size {
+            assert_eq!(
+                actual_linktarget,
+                test_linktarget,
+                "readlink(linkbuf_len={test_size} >= actual_size={actual_size}) should return the same link target string",
+            );
+        } else {
+            let actual_linktarget_truncated =
+                OsStr::from_bytes(&actual_linktarget.as_os_str().as_bytes()[..test_size]);
+            assert_eq!(
+                actual_linktarget_truncated,
+                test_linktarget.as_os_str(),
+                "readlink(linkbuf_len={test_size} < actual_size={actual_size}) should truncate link target string to {test_size} bytes",
+            );
+        }
+    }
+    Ok(actual_linktarget)
 }

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -595,6 +595,8 @@ root_op_tests! {
     root_dotdot: open_subpath("..", O_RDONLY) => Ok(".");
 
     enoent: readlink("non-exist") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
+    dir_einval: readlink("b/c") => Err(ErrorKind::OsError(Some(libc::EINVAL)));
+    file_einval: readlink("b/c/file") => Err(ErrorKind::OsError(Some(libc::EINVAL)));
     abslink: readlink("e") => Ok("/b/c/d/e");
     rellink: readlink("b-file") => Ok("b/c/file");
     root: readlink("root-link1") => Ok("/");

--- a/src/tests/test_root_ops.rs
+++ b/src/tests/test_root_ops.rs
@@ -246,6 +246,15 @@ macro_rules! root_op_tests {
         }
     };
 
+    ($(#[cfg($ignore_meta:meta)])* @impl readlink $test_name:ident ($path:expr) => $expected_result:expr) => {
+        root_op_tests! {
+            $(#[cfg_attr(not($ignore_meta), ignore)])*
+            fn $test_name(root) {
+                utils::check_root_readlink(&root, $path, $expected_result)
+            }
+        }
+    };
+
     ($(#[cfg($ignore_meta:meta)])* @impl remove_dir $test_name:ident ($path:expr) => $expected_result:expr) => {
         root_op_tests!{
             $(#[cfg_attr(not($ignore_meta), ignore)])*
@@ -584,6 +593,76 @@ root_op_tests! {
     root_slash: open_subpath("/", O_RDONLY) => Ok(".");
     root_dot: open_subpath(".", O_RDONLY) => Ok(".");
     root_dotdot: open_subpath("..", O_RDONLY) => Ok(".");
+
+    enoent: readlink("non-exist") => Err(ErrorKind::OsError(Some(libc::ENOENT)));
+    abslink: readlink("e") => Ok("/b/c/d/e");
+    rellink: readlink("b-file") => Ok("b/c/file");
+    root: readlink("root-link1") => Ok("/");
+    root_dotdot1: readlink("root-link2") => Ok("/..");
+    root_dotdot2: readlink("root-link3") => Ok("/../../../../..");
+    escape1: readlink("escape-link1") => Ok("../../../../../../../../../../target");
+    escape2: readlink("escape-link2") => Ok("/../../../../../../../../../../target");
+    fake_rel: readlink("a-fake1") => Ok("a/fake");
+    fake_dotdot1: readlink("a-fake2") => Ok("a/fake/foo/bar/..");
+    fake_dotdot2: readlink("a-fake3") => Ok("a/fake/../../b");
+    fake_abs: readlink("c/a-fake1") => Ok("/a/fake");
+    fake_abs_dotdot1: readlink("c/a-fake2") => Ok("/a/fake/foo/bar/..");
+    fake_abs_dotdot2: readlink("c/a-fake3") => Ok("/a/fake/../../b");
+    nonlexical_level1_abs: readlink("link1/target_abs") => Ok("/target");
+    nonlexical_level1_rel: readlink("link1/target_rel") => Ok("../target");
+    nonlexical_level2_abs_abs: readlink("link2/link1_abs") => Ok("/link1");
+    nonlexical_level2_abs_rel: readlink("link2/link1_rel") => Ok("../link1");
+    nonlexical_level3_abs: readlink("link3/target_abs") => Ok("/link2/link1_rel/target_rel");
+    nonlexical_level3_rel: readlink("link3/target_rel") => Ok("../link2/link1_rel/target_rel");
+    dangling_tricky1: readlink("link3/deep_dangling1") => Ok("../link2/link1_rel/target_rel/nonexist");
+    dangling_tricky2: readlink("link3/deep_dangling2") => Ok("../link2/link1_abs/target_abs/nonexist");
+    deep_dangling1: readlink("dangling/a") => Ok("b/c");
+    deep_dangling2: readlink("dangling/b/c") => Ok("../c");
+    deep_dangling3: readlink("dangling/c") => Ok("d/e");
+    deep_dangling4: readlink("dangling/d/e") => Ok("../e");
+    deep_dangling5: readlink("dangling/e") => Ok("f/../g");
+    deep_dangling6: readlink("dangling/g") => Ok("h/i/j/nonexistent");
+    deep_dangling_fileasdir1: readlink("dangling-file/a") => Ok("b/c");
+    deep_dangling_fileasdir2: readlink("dangling-file/b/c") => Ok("../c");
+    deep_dangling_fileasdir3: readlink("dangling-file/c") => Ok("d/e");
+    deep_dangling_fileasdir4: readlink("dangling-file/d/e") => Ok("../e");
+    deep_dangling_fileasdir5: readlink("dangling-file/e") => Ok("f/../g");
+    deep_dangling_fileasdir6: readlink("dangling-file/g") => Ok("h/i/j/file/foo");
+    loop_basic1: readlink("loop/basic-loop1") => Ok("basic-loop1");
+    loop_basic2: readlink("loop/basic-loop2") => Ok("/loop/basic-loop2");
+    loop_basic3: readlink("loop/basic-loop3") => Ok("../loop/basic-loop3");
+    loop_inner_level1_rel: readlink("loop/a/link") => Ok("../b/link");
+    loop_inner_level1_abs1: readlink("loop/b/link") => Ok("/loop/c/link");
+    loop_inner_level1_abs2: readlink("loop/c/link") => Ok("/loop/d/link");
+    loop_inner_level2: readlink("loop/d") => Ok("e");
+    loop_inner_level3: readlink("loop/e/link") => Ok("../a/link");
+    loop_full: readlink("loop/link") => Ok("a/link");
+    // MS_NOSYMFOLLOW does not block readlink.
+    nosymfollow_good: readlink("nosymfollow/goodlink") => Ok("/");
+    nosymfollow_bad: readlink("nosymfollow/badlink") => Ok("/"); // MS_NOSYMFOLLOW
+    nosymfollow_dir_bad: readlink("nosymfollow/nosymdir/dir/badlink") => Ok("/"); // MS_NOSYMFOLLOW
+    nosymfollow_dir_good: readlink("nosymfollow/nosymdir/dir/goodlink") => Ok("/");
+    nosymfollow_nested_good: readlink("nosymfollow/nosymdir/dir/foo/yessymdir/bar/goodlink") => Ok("/");
+    // fs.protected_symlinks does not block readlink.
+    protected_symlinks_selfdir_selfsym: readlink("tmpfs-self/link-self") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_selfdir_otheruidsym: readlink("tmpfs-self/link-otheruid") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_selfdir_othergidsym: readlink("tmpfs-self/link-othergid") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_selfdir_othersym: readlink("tmpfs-self/link-other") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_selfsym: readlink("tmpfs-other/link-self") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_selfuidsym: readlink("tmpfs-other/link-selfuid") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_ownersym: readlink("tmpfs-other/link-owner") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_otheruidsym: readlink("tmpfs-other/link-otheruid") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_othergidsym: readlink("tmpfs-other/link-othergid") => Ok("file");
+    #[cfg(feature = "_test_as_root")]
+    protected_symlinks_otherdir_othersym: readlink("tmpfs-other/link-other") => Ok("file");
 
     empty_dir: remove_dir("a") => Ok(());
     empty_dir: remove_file("a") => Err(ErrorKind::OsError(Some(libc::EISDIR)));
@@ -1033,6 +1112,32 @@ mod utils {
                 );
 
                 tests_common::check_oflags(&file, oflags)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn check_root_readlink<R: RootImpl>(
+        root: R,
+        path: impl AsRef<Path>,
+        expected_result: Result<&str, ErrorKind>,
+    ) -> Result<(), Error> {
+        let path = path.as_ref();
+        match root.readlink(path) {
+            Err(err) => {
+                tests_common::check_err(&Err::<(), _>(err), &expected_result)
+                    .with_context(|| format!("root readlink {path:?}"))?;
+            }
+            Ok(linkname) => {
+                let linkname = linkname
+                    .as_path()
+                    .to_str()
+                    .expect("linkname should be valid utf-8");
+                assert_eq!(
+                    Ok(linkname),
+                    expected_result,
+                    "readlink file had unexpected path {linkname:?}"
+                );
             }
         }
         Ok(())


### PR DESCRIPTION
readlink() will return -EINVAL for non-symlinks, but the race-free
readlinkat(fd, "") approach returns -ENOENT if fd is not a symlink. This
mismatch can very easily cause confusion (in fact, I found this bug
while trying to use Root::readlink elsewhere).

As -ENOENT cannot be returned from readlinkat(fd, "") for any other
reason, map it to -EINVAL to match the API to what users would expect.
It's a bit strange the kernel does this, but oh well...

Fixes: e5d212d ("root: add readlink method")
Signed-off-by: Aleksa Sarai <aleksa@amutable.com>