### PR TITLE
codecov: work around bug in coverage configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ comment:
   require_changes: true
   behavior: once
   branches:
-    - master
+    - main
 
 component_management:
   default_rules:
@@ -50,6 +50,25 @@ component_management:
 
 coverage:
   range: 60..95
+  status:
+    project:
+      default:
+        target: auto
+      pathrs:
+        target: 80%
+        threshold: 0%
+        paths:
+          - "src/**"
+          - "!src/capi/**"
+      libpathrs.so:
+        target: 80%
+        threshold: 0%
+        paths:
+          - "src/capi/**"
+    patch:
+      default:
+        target: auto
+        informational: true
 
 github_checks:
   annotations: true


### PR DESCRIPTION
Despite the (lackluster) docs implying this is not necessary, it seems
that you need to configure the coverage settings for components both in
the components section and in the top-level coverage section.

Ref: https://github.com/codecov/feedback/discussions/355
Signed-off-by: Aleksa Sarai <aleksa@amutable.com>