### PR TITLE
flags: switch OpenFlags to u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   to adjust their types.
   - As part of this, `pathrs_inroot_rename` now also takes a `uint64_t`, and
     thus the the Go `(*Root).Rename` wrapper takes a `uint64` as well.
+- `OpenFlags` is now bkaced by a `u64` (instead of `libc::c_int`), as recent
+  kernel changes such as `OPENAT2_REGULAR` will likely start to use some of the
+  upper flag bits available from `openat2(2)`. This has an impact on all C APIs
+  (and thus Go bindings) that accept `OpenFlags` arguments (we do provide old
+  symbol versions to ease the transition):
+  - `pathrs_reopen`
+  - `pathrs_inroot_open`
+  - `pathrs_inroot_creat`
+  - `pathrs_proc_open`
+  - `pathrs_proc_openat`
 
 ### Added ###
 - capi: We now have a new `pathrs_version` API that provides runtime version

--- a/e2e-tests/cmd/go/procfs.go
+++ b/e2e-tests/cmd/go/procfs.go
@@ -93,10 +93,7 @@ var procfsOpenCmd = cmdWithOptions(&cli.Command{
 		follow := cmd.Bool("follow")
 		subpath := cmd.StringArg("subpath")
 
-		oflags := unix.O_RDONLY
-		if val := ctx.Value("oflags"); val != nil {
-			oflags = val.(int)
-		}
+		oflags, _ := ctxOflags(ctx, "oflags")
 		if !follow {
 			oflags |= unix.O_NOFOLLOW
 		}

--- a/e2e-tests/cmd/go/root.go
+++ b/e2e-tests/cmd/go/root.go
@@ -109,8 +109,7 @@ var rootResolveCmd = cmdWithOptions(&cli.Command{
 
 		fmt.Println("HANDLE-PATH", handle.IntoFile().Name())
 
-		if val := ctx.Value("reopen"); val != nil {
-			oflags := val.(int)
+		if oflags, set := ctxOflags(ctx, "reopen"); set {
 			f, err := handle.OpenFile(oflags)
 			if err != nil {
 				return err
@@ -144,10 +143,7 @@ var rootOpenCmd = cmdWithOptions(&cli.Command{
 		follow := cmd.Bool("follow")
 		subpath := cmd.StringArg("subpath")
 
-		oflags := unix.O_RDONLY
-		if val := ctx.Value("oflags"); val != nil {
-			oflags = val.(int)
-		}
+		oflags, _ := ctxOflags(ctx, "oflags")
 		if !follow {
 			oflags |= unix.O_NOFOLLOW
 		}
@@ -184,7 +180,7 @@ var rootMkfileCmd = cmdWithOptions(&cli.Command{
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		root := ctx.Value("root").(*pathrs.Root)
 		subpath := cmd.StringArg("subpath")
-		oflags := ctx.Value("oflags").(int)
+		oflags, _ := ctxOflags(ctx, "oflags")
 		mode := ctx.Value("mode").(os.FileMode)
 
 		f, err := root.Create(subpath, oflags, mode)

--- a/e2e-tests/cmd/go/ux_oflags.go
+++ b/e2e-tests/cmd/go/ux_oflags.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var oflagValues = map[string]int{
+var oflagValues = map[string]uint64{
 	// Access modes (including O_PATH).
 	"O_RDWR":   unix.O_RDWR,
 	"O_RDONLY": unix.O_RDONLY,
@@ -51,12 +51,12 @@ var oflagValues = map[string]int{
 	"O_NONBLOCK": unix.O_NONBLOCK,
 }
 
-func parseOflags(flags string) (int, error) {
+func parseOflags(flags string) (uint64, error) {
 	oflagFieldsFunc := func(ch rune) bool {
 		return ch == '|' || ch == ','
 	}
 
-	var oflags int
+	var oflags uint64
 	for flag := range strings.FieldsFuncSeq(flags, oflagFieldsFunc) {
 		// Convert any flags to -> O_*.
 		flag = strings.ToUpper(flag)
@@ -70,6 +70,21 @@ func parseOflags(flags string) (int, error) {
 		oflags |= val
 	}
 	return oflags, nil
+}
+
+func ctxOflags(ctx context.Context, name string) (uint64, bool) {
+	if val := ctx.Value(name); val != nil {
+		switch val := val.(type) {
+		// TODO: Handle all integer types...?
+		case uint:
+			return uint64(val), true
+		case int:
+			return uint64(val), true
+		case uint64:
+			return uint64(val), true
+		}
+	}
+	return unix.O_RDONLY, false
 }
 
 func oflags(name, usage string, dfl any) uxOption {

--- a/go-pathrs/handle_linux.go
+++ b/go-pathrs/handle_linux.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 
+	"golang.org/x/sys/unix"
+
 	"cyphar.com/go-pathrs/internal/fdutils"
 	"cyphar.com/go-pathrs/internal/libpathrs"
 )
@@ -56,11 +58,11 @@ func HandleFromFile(file *os.File) (*Handle, error) {
 // and can be opened multiple times.
 //
 // The handle returned is only usable for reading, and this is method is
-// shorthand for [Handle.OpenFile] with os.O_RDONLY.
+// shorthand for [Handle.OpenFile] with [unix.O_RDONLY].
 //
 // TODO: Rename these to "Reopen" or something.
 func (h *Handle) Open() (*os.File, error) {
-	return h.OpenFile(os.O_RDONLY)
+	return h.OpenFile(unix.O_RDONLY)
 }
 
 // OpenFile creates an "upgraded" file handle to the file referenced by the
@@ -71,7 +73,7 @@ func (h *Handle) Open() (*os.File, error) {
 // handle.
 //
 // TODO: Rename these to "Reopen" or something.
-func (h *Handle) OpenFile(flags int) (*os.File, error) {
+func (h *Handle) OpenFile(flags uint64) (*os.File, error) {
 	return fdutils.WithFileFd(h.inner, func(fd uintptr) (*os.File, error) {
 		newFd, err := libpathrs.Reopen(fd, flags)
 		if err != nil {

--- a/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -60,8 +60,8 @@ func OpenRoot(path string) (uintptr, error) {
 }
 
 // Reopen wraps pathrs_reopen.
-func Reopen(fd uintptr, flags int) (uintptr, error) {
-	newFd := C.pathrs_reopen(C.int(fd), C.int(flags))
+func Reopen(fd uintptr, flags uint64) (uintptr, error) {
+	newFd := C.pathrs_reopen(C.int(fd), C.uint64_t(flags))
 	return uintptr(newFd), fetchError(newFd)
 }
 
@@ -84,11 +84,11 @@ func InRootResolveNoFollow(rootFd uintptr, path string) (uintptr, error) {
 }
 
 // InRootOpen wraps pathrs_inroot_open.
-func InRootOpen(rootFd uintptr, path string, flags int) (uintptr, error) {
+func InRootOpen(rootFd uintptr, path string, flags uint64) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_inroot_open(C.int(rootFd), cPath, C.int(flags))
+	fd := C.pathrs_inroot_open(C.int(rootFd), cPath, C.uint64_t(flags))
 	return uintptr(fd), fetchError(fd)
 }
 
@@ -145,11 +145,11 @@ func InRootRemoveAll(rootFd uintptr, path string) error {
 }
 
 // InRootCreat wraps pathrs_inroot_creat.
-func InRootCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
+func InRootCreat(rootFd uintptr, path string, flags uint64, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_inroot_creat(C.int(rootFd), cPath, C.int(flags), C.uint(mode))
+	fd := C.pathrs_inroot_creat(C.int(rootFd), cPath, C.uint64_t(flags), C.uint(mode))
 	return uintptr(fd), fetchError(fd)
 }
 
@@ -277,13 +277,13 @@ func init() {
 func ProcPid(pid uint32) ProcBase { return ProcBaseTypePid | ProcBase(pid) }
 
 // ProcOpenat wraps pathrs_proc_openat.
-func ProcOpenat(procRootFd int, base ProcBase, path string, flags int) (uintptr, error) {
+func ProcOpenat(procRootFd int, base ProcBase, path string, flags uint64) (uintptr, error) {
 	cBase := C.pathrs_proc_base_t(base)
 
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_proc_openat(C.int(procRootFd), cBase, cPath, C.int(flags))
+	fd := C.pathrs_proc_openat(C.int(procRootFd), cBase, cPath, C.uint64_t(flags))
 	return uintptr(fd), fetchError(fd)
 }
 

--- a/go-pathrs/procfs/procfs_linux.go
+++ b/go-pathrs/procfs/procfs_linux.go
@@ -127,7 +127,7 @@ func (proc *Handle) fd() int {
 }
 
 // TODO: Should we expose open?
-func (proc *Handle) open(base ProcBase, path string, flags int) (_ *os.File, Closer ThreadCloser, Err error) {
+func (proc *Handle) open(base ProcBase, path string, flags uint64) (_ *os.File, Closer ThreadCloser, Err error) {
 	var closer ThreadCloser
 	if base == ProcThreadSelf {
 		runtime.LockOSThread()
@@ -154,7 +154,7 @@ func (proc *Handle) open(base ProcBase, path string, flags int) (_ *os.File, Clo
 // (such as /proc/cpuinfo) or information about other processes (such as
 // /proc/1). Accessing your own process information should be done using
 // [Handle.OpenSelf] or [Handle.OpenThreadSelf].
-func (proc *Handle) OpenRoot(path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenRoot(path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcRoot, path, flags)
 	if closer != nil {
 		// should not happen
@@ -180,7 +180,7 @@ func (proc *Handle) OpenRoot(path string, flags int) (*os.File, error) {
 // Unlike [Handle.OpenThreadSelf], this method does not involve locking
 // the goroutine to the current OS thread and so is simpler to use and
 // theoretically has slightly less overhead.
-func (proc *Handle) OpenSelf(path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenSelf(path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcSelf, path, flags)
 	if closer != nil {
 		// should not happen
@@ -198,7 +198,7 @@ func (proc *Handle) OpenSelf(path string, flags int) (*os.File, error) {
 // Be aware that due to PID recycling, using this is generally not safe except
 // in certain circumstances. See the documentation of [ProcPid] for more
 // details.
-func (proc *Handle) OpenPid(pid int, path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenPid(pid int, path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcPid(pid), path, flags)
 	if closer != nil {
 		// should not happen
@@ -225,7 +225,7 @@ func (proc *Handle) OpenPid(pid int, path string, flags int) (*os.File, error) {
 // callback MUST be called AFTER you have finished using the returned
 // [os.File]. This callback is completely separate to [os.File.Close], so it
 // must be called regardless of how you close the handle.
-func (proc *Handle) OpenThreadSelf(path string, flags int) (*os.File, ThreadCloser, error) {
+func (proc *Handle) OpenThreadSelf(path string, flags uint64) (*os.File, ThreadCloser, error) {
 	return proc.open(ProcThreadSelf, path, flags)
 }
 

--- a/go-pathrs/root_linux.go
+++ b/go-pathrs/root_linux.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"syscall"
 
+	"golang.org/x/sys/unix"
+
 	"cyphar.com/go-pathrs/internal/fdutils"
 	"cyphar.com/go-pathrs/internal/libpathrs"
 )
@@ -83,10 +85,10 @@ func (r *Root) Resolve(path string) (*Handle, error) {
 	})
 }
 
-// ResolveNoFollow is effectively an [os.O_NOFOLLOW] version of [Root.Resolve].
-// Their behaviour is identical, except that *trailing* symlinks will not be
-// followed. If the final component is a trailing symlink, an [os.O_PATH]|[os.O_NOFOLLOW]
-// handle to the symlink itself is returned.
+// ResolveNoFollow is effectively an [unix.O_NOFOLLOW] version of
+// [Root.Resolve]. Their behaviour is identical, except that *trailing*
+// symlinks will not be followed. If the final component is a trailing symlink,
+// an [unix.O_PATH]|[unix.O_NOFOLLOW] handle to the symlink itself is returned.
 func (r *Root) ResolveNoFollow(path string) (*Handle, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
 		handleFd, err := libpathrs.InRootResolveNoFollow(rootFd, path)
@@ -101,14 +103,14 @@ func (r *Root) ResolveNoFollow(path string) (*Handle, error) {
 	})
 }
 
-// Open is effectively shorthand for [Root.Resolve] followed by [Handle.Open], but
-// can be slightly more efficient (it reduces CGo overhead and the number of
-// syscalls used when using the openat2-based resolver) and is arguably more
+// Open is effectively shorthand for [Root.Resolve] followed by [Handle.Open],
+// but can be slightly more efficient (it reduces CGo overhead and the number
+// of syscalls used when using the openat2-based resolver) and is arguably more
 // ergonomic to use.
 //
 // This is effectively equivalent to [os.Open].
 func (r *Root) Open(path string) (*os.File, error) {
-	return r.OpenFile(path, os.O_RDONLY)
+	return r.OpenFile(path, unix.O_RDONLY)
 }
 
 // OpenFile is effectively shorthand for [Root.Resolve] followed by
@@ -116,14 +118,14 @@ func (r *Root) Open(path string) (*os.File, error) {
 // overhead and the number of syscalls used when using the openat2-based
 // resolver) and is arguably more ergonomic to use.
 //
-// However, if flags contains [os.O_NOFOLLOW] and the path is a symlink, then
+// However, if flags contains [unix.O_NOFOLLOW] and the path is a symlink, then
 // OpenFile's behaviour will match that of openat2. In most cases an error will
-// be returned, but if [os.O_PATH] is provided along with [os.O_NOFOLLOW] then a
-// file equivalent to [Root.ResolveNoFollow] will be returned instead.
+// be returned, but if [unix.O_PATH] is provided along with [unix.O_NOFOLLOW]
+// then a file equivalent to [Root.ResolveNoFollow] will be returned instead.
 //
-// This is effectively equivalent to [os.OpenFile], except that [os.O_CREAT] is
-// not supported.
-func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
+// This is effectively equivalent to [os.OpenFile], except that [unix.O_CREAT]
+// is not supported.
+func (r *Root) OpenFile(path string, flags uint64) (*os.File, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*os.File, error) {
 		fd, err := libpathrs.InRootOpen(rootFd, path, flags)
 		if err != nil {
@@ -139,7 +141,7 @@ func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
 //
 // Unlike [os.Create], if the file already exists an error is created rather
 // than the file being opened and truncated.
-func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error) {
+func (r *Root) Create(path string, flags uint64, mode os.FileMode) (*os.File, error) {
 	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
 		return nil, err

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -253,7 +253,7 @@ int pathrs_open_root(const char *path);
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_reopen(int fd, int flags);
+int pathrs_reopen(int fd, uint64_t flags);
 
 /**
  * Resolve the given path within the rootfs referenced by root_fd. The path
@@ -319,7 +319,7 @@ int pathrs_inroot_resolve_nofollow(int root_fd, const char *path);
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_inroot_open(int root_fd, const char *path, int flags);
+int pathrs_inroot_open(int root_fd, const char *path, uint64_t flags);
 
 /**
  * Get the target of a symlink within the rootfs referenced by root_fd.
@@ -472,7 +472,7 @@ int pathrs_inroot_remove_all(int root_fd, const char *path);
  */
 int pathrs_inroot_creat(int root_fd,
                         const char *path,
-                        int flags,
+                        uint64_t flags,
                         unsigned int mode);
 
 /**
@@ -693,7 +693,7 @@ int pathrs_procfs_open(const pathrs_procfs_open_how *args, size_t size);
 int pathrs_proc_openat(int proc_rootfd,
                        pathrs_proc_base_t base,
                        const char *path,
-                       int flags);
+                       uint64_t flags);
 
 /**
  * Safely open a path inside a `/proc` handle.
@@ -734,7 +734,7 @@ int pathrs_proc_openat(int proc_rootfd,
  * the system errno(7) value associated with the error, etc), use
  * pathrs_errorinfo().
  */
-int pathrs_proc_open(pathrs_proc_base_t base, const char *path, int flags);
+int pathrs_proc_open(pathrs_proc_base_t base, const char *path, uint64_t flags);
 
 /**
  * `pathrs_proc_readlink` but with a caller-provided file descriptor for

--- a/src/capi/core.rs
+++ b/src/capi/core.rs
@@ -109,7 +109,7 @@ utils::symver! {
 /// the system errno(7) value associated with the error, etc), use
 /// pathrs_errorinfo().
 #[no_mangle]
-pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: c_int) -> RawFd {
+pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: u64) -> RawFd {
     let flags = OpenFlags::from_bits_retain(flags);
 
     || -> Result<_, Error> {
@@ -119,7 +119,21 @@ pub extern "C" fn pathrs_reopen(fd: CBorrowedFd<'_>, flags: c_int) -> RawFd {
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_reopen <- (pathrs_reopen, version = "LIBPATHRS_0.1", default);
+    fn pathrs_reopen <- (pathrs_reopen, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_reopen` to support 64-bit [`OpenFlags`].
+/// cbindgen:ignore
+#[doc(hidden)]
+#[no_mangle]
+pub extern "C" fn __pathrs_reopen_v1(fd: CBorrowedFd<'_>, flags: libc::c_int) -> RawFd {
+    // NOTE: i32 as u64 sign-extends so we need to cast to u32 first.
+    pathrs_reopen(fd, flags as u32 as u64)
+}
+utils::symver! {
+    // In libpathrs 0.2.5, all of the flags-bearing arguments were expanded to
+    // u64. This shim translates the old i32 (libc::c_int) callers.
+    fn __pathrs_reopen_v1 <- (pathrs_reopen, version = "LIBPATHRS_0.1");
 }
 
 /// Resolve the given path within the rootfs referenced by root_fd. The path
@@ -222,7 +236,7 @@ utils::symver! {
 pub unsafe extern "C" fn pathrs_inroot_open(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
-    flags: c_int,
+    flags: u64,
 ) -> RawFd {
     || -> Result<_, Error> {
         let root_fd = root_fd.try_as_borrowed_fd()?;
@@ -234,7 +248,26 @@ pub unsafe extern "C" fn pathrs_inroot_open(
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_inroot_open <- (pathrs_inroot_open, version = "LIBPATHRS_0.2", default);
+    fn pathrs_inroot_open <- (pathrs_inroot_open, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_inroot_open` to support 64-bit
+/// [`OpenFlags`].
+/// cbindgen:ignore
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_inroot_open_v1(
+    fd: CBorrowedFd<'_>,
+    path: *const c_char,
+    flags: libc::c_int,
+) -> RawFd {
+    // NOTE: i32 as u64 sign-extends so we need to cast to u32 first.
+    unsafe { pathrs_inroot_open(fd, path, flags as u32 as u64) }
+}
+utils::symver! {
+    // In libpathrs 0.2.5, all of the flags-bearing arguments were expanded to
+    // u64. This shim translates the old i32 (libc::c_int) callers.
+    fn __pathrs_inroot_open_v1 <- (pathrs_inroot_open, version = "LIBPATHRS_0.2");
 }
 
 /// Get the target of a symlink within the rootfs referenced by root_fd.
@@ -351,6 +384,7 @@ utils::symver! {
 /// a single `root_fd` argument.
 ///
 /// cbindgen:ignore
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn __pathrs_inroot_rename_v1(
     root_fd: CBorrowedFd<'_>,
@@ -511,7 +545,7 @@ utils::symver! {
 pub unsafe extern "C" fn pathrs_inroot_creat(
     root_fd: CBorrowedFd<'_>,
     path: *const c_char,
-    flags: c_int,
+    flags: u64,
     mode: c_uint,
 ) -> RawFd {
     || -> Result<_, Error> {
@@ -525,11 +559,31 @@ pub unsafe extern "C" fn pathrs_inroot_creat(
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_inroot_creat <- (pathrs_inroot_creat, version = "LIBPATHRS_0.2", default);
+    fn pathrs_inroot_creat <- (pathrs_inroot_creat, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_inroot_creat` to support 64-bit
+/// [`OpenFlags`].
+/// cbindgen:ignore
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_inroot_creat_v1(
+    fd: CBorrowedFd<'_>,
+    path: *const c_char,
+    flags: libc::c_int,
+    mode: c_uint,
+) -> RawFd {
+    // NOTE: i32 as u64 sign-extends so we need to cast to u32 first.
+    unsafe { pathrs_inroot_creat(fd, path, flags as u32 as u64, mode) }
+}
+utils::symver! {
+    // In libpathrs 0.2.5, all of the flags-bearing arguments were expanded to
+    // u64. This shim translates the old i32 (libc::c_int) callers.
+    fn __pathrs_inroot_creat_v1 <- (pathrs_inroot_creat, version = "LIBPATHRS_0.2");
     // This symbol was renamed in libpathrs 0.2. For backward compatibility with
     // pre-symbol-versioned builds of libpathrs, it needs to be a default so
     // that loaders will pick it when searching for the unversioned name.
-    fn pathrs_inroot_creat <- (pathrs_creat, version = "LIBPATHRS_0.1", default);
+    fn __pathrs_inroot_creat_v1 <- (pathrs_creat, version = "LIBPATHRS_0.1", default);
 }
 
 /// Create a new directory within the rootfs referenced by root_fd.
@@ -681,6 +735,7 @@ utils::symver! {
 /// arguments in the wrong order.
 ///
 /// cbindgen:ignore
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn __pathrs_inroot_symlink_v1(
     root_fd: CBorrowedFd<'_>,
@@ -757,6 +812,7 @@ utils::symver! {
 /// arguments in the wrong order.
 ///
 /// cbindgen:ignore
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn __pathrs_inroot_hardlink_v1(
     root_fd: CBorrowedFd<'_>,

--- a/src/capi/procfs.rs
+++ b/src/capi/procfs.rs
@@ -464,7 +464,7 @@ pub unsafe extern "C" fn pathrs_proc_openat(
     proc_rootfd: CBorrowedFd<'_>,
     base: CProcfsBase,
     path: *const c_char,
-    flags: c_int,
+    flags: u64,
 ) -> RawFd {
     || -> Result<_, Error> {
         let base = base.try_into()?;
@@ -482,7 +482,27 @@ pub unsafe extern "C" fn pathrs_proc_openat(
     .into_c_return()
 }
 utils::symver! {
-    fn pathrs_proc_openat <- (pathrs_proc_openat, version = "LIBPATHRS_0.2", default);
+    fn pathrs_proc_openat <- (pathrs_proc_openat, version = "LIBPATHRS_0.2.5", default);
+}
+
+/// A compatibility shim for `pathrs_proc_openat` to support 64-bit
+/// [`OpenFlags`].
+/// cbindgen:ignore
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_proc_openat_v1(
+    proc_rootfd: CBorrowedFd<'_>,
+    base: CProcfsBase,
+    path: *const c_char,
+    flags: libc::c_int,
+) -> RawFd {
+    // NOTE: i32 as u64 sign-extends so we need to cast to u32 first.
+    unsafe { pathrs_proc_openat(proc_rootfd, base, path, flags as u32 as u64) }
+}
+utils::symver! {
+    // In libpathrs 0.2.5, all of the flags-bearing arguments were expanded to
+    // u64. This shim translates the old i32 (libc::c_int) callers.
+    fn __pathrs_proc_openat_v1 <- (pathrs_proc_openat, version = "LIBPATHRS_0.2");
 }
 
 /// Safely open a path inside a `/proc` handle.
@@ -526,12 +546,30 @@ utils::symver! {
 pub unsafe extern "C" fn pathrs_proc_open(
     base: CProcfsBase,
     path: *const c_char,
-    flags: c_int,
+    flags: u64,
 ) -> RawFd {
     pathrs_proc_openat(PATHRS_PROC_DEFAULT_ROOTFD, base, path, flags)
 }
 utils::symver! {
     fn pathrs_proc_open <- (pathrs_proc_open, version = "LIBPATHRS_0.1", default);
+}
+
+/// A compatibility shim for `pathrs_proc_open` to support 64-bit [`OpenFlags`].
+/// cbindgen:ignore
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn __pathrs_proc_open_v1(
+    base: CProcfsBase,
+    path: *const c_char,
+    flags: libc::c_int,
+) -> RawFd {
+    // NOTE: i32 as u64 sign-extends so we need to cast to u32 first.
+    unsafe { pathrs_proc_open(base, path, flags as u32 as u64) }
+}
+utils::symver! {
+    // In libpathrs 0.2.5, all of the flags-bearing arguments were expanded to
+    // u64. This shim translates the old i32 (libc::c_int) callers.
+    fn __pathrs_proc_open_v1 <- (pathrs_proc_open, version = "LIBPATHRS_0.2");
 }
 
 /// `pathrs_proc_readlink` but with a caller-provided file descriptor for

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -37,6 +37,7 @@
 use crate::syscalls;
 
 use bitflags::bitflags;
+use rustix::fs as rustix_fs;
 
 bitflags! {
     /// Wrapper for the underlying `libc`'s `O_*` flags.
@@ -93,55 +94,70 @@ bitflags! {
     /// assert_eq!(OpenFlags::O_DIRECTORY.contains(OpenFlags::O_TMPFILE), false);
     /// ```
     #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
-    pub struct OpenFlags: libc::c_int {
+    pub struct OpenFlags: u64 {
         // Access modes (including O_PATH).
-        const O_RDWR = libc::O_RDWR;
-        const O_RDONLY = libc::O_RDONLY;
-        const O_WRONLY = libc::O_WRONLY;
-        const O_PATH = libc::O_PATH;
+        const O_RDWR = libc::O_RDWR as _;
+        const O_RDONLY = libc::O_RDONLY as _;
+        const O_WRONLY = libc::O_WRONLY as _;
+        const O_PATH = libc::O_PATH as _;
 
         // Fd flags.
-        const O_CLOEXEC = libc::O_CLOEXEC;
+        const O_CLOEXEC = libc::O_CLOEXEC as _;
 
         // Control lookups.
-        const O_NOFOLLOW = libc::O_NOFOLLOW;
-        const O_DIRECTORY = libc::O_DIRECTORY;
-        const O_NOCTTY = libc::O_NOCTTY;
+        const O_NOFOLLOW = libc::O_NOFOLLOW as _;
+        const O_DIRECTORY = libc::O_DIRECTORY as _;
+        const O_NOCTTY = libc::O_NOCTTY as _;
 
         // NOTE: This flag contains O_DIRECTORY!
-        const O_TMPFILE = libc::O_TMPFILE;
+        const O_TMPFILE = libc::O_TMPFILE as _;
 
         // File creation.
-        const O_CREAT = libc::O_CREAT;
-        const O_EXCL = libc::O_EXCL;
-        const O_TRUNC = libc::O_TRUNC;
-        const O_APPEND = libc::O_APPEND;
+        const O_CREAT = libc::O_CREAT as _;
+        const O_EXCL = libc::O_EXCL as _;
+        const O_TRUNC = libc::O_TRUNC as _;
+        const O_APPEND = libc::O_APPEND as _;
 
         // Sync.
-        const O_SYNC = libc::O_SYNC;
-        const O_ASYNC = libc::O_ASYNC;
-        const O_DSYNC = libc::O_DSYNC;
+        const O_SYNC = libc::O_SYNC as _;
+        const O_ASYNC = libc::O_ASYNC as _;
+        const O_DSYNC = libc::O_DSYNC as _;
         #[cfg(not(target_env = "musl"))] // musl doesn't provide FSYNC
-        const O_FSYNC = libc::O_FSYNC;
-        const O_RSYNC = libc::O_RSYNC;
-        const O_DIRECT = libc::O_DIRECT;
-        const O_NDELAY = libc::O_NDELAY;
-        const O_NOATIME = libc::O_NOATIME;
-        const O_NONBLOCK = libc::O_NONBLOCK;
+        const O_FSYNC = libc::O_FSYNC as _;
+        const O_RSYNC = libc::O_RSYNC as _;
+        const O_DIRECT = libc::O_DIRECT as _;
+        const O_NDELAY = libc::O_NDELAY as _;
+        const O_NOATIME = libc::O_NOATIME as _;
+        const O_NONBLOCK = libc::O_NONBLOCK as _;
 
         // NOTE: This is effectively a kernel-internal flag (auto-set on systems
         //       with large offset support). glibc defines it as 0, and it is
         //       also architecture-specific.
-        //const O_LARGEFILE = libc::O_LARGEFILE;
+        //const O_LARGEFILE = libc::O_LARGEFILE as _;
 
         // Don't clobber unknown O_* bits.
         const _ = !0;
     }
 }
 
-impl From<OpenFlags> for rustix::fs::OFlags {
-    fn from(flags: OpenFlags) -> Self {
-        Self::from_bits_retain(flags.bits() as u32)
+/// Convert an [`OpenFlags`] set of flags to the [`openat`]-compatible
+/// [`OFlags`]. If the value cannot be converted then `Err(())` is returned.
+///
+/// [`OFlags`]: rustix::fs::OFlags
+// TODO: It might even make sense to make this do an explicit check for O_*
+// flags versus openat2(2)-only flags if we end up having any in the lower
+// bits...
+#[doc(hidden)]
+impl TryFrom<OpenFlags> for rustix_fs::OFlags {
+    // No need for an actual error type, if this fails the meaning is obvious.
+    type Error = ();
+
+    fn try_from(flags: OpenFlags) -> Result<Self, Self::Error> {
+        flags
+            .bits()
+            .try_into()
+            .map(Self::from_bits_retain)
+            .map_err(|_| ())
     }
 }
 
@@ -154,7 +170,14 @@ impl OpenFlags {
         if self.contains(OpenFlags::O_PATH) {
             None
         } else {
-            Some(self.bits() & libc::O_ACCMODE)
+            let acc_mode = self.bits() & (libc::O_ACCMODE as u64);
+            debug_assert!(
+                acc_mode <= 0b11,
+                "{:X} masked by O_ACCMODE ({:X}) mask should only set bottom two bits",
+                self.bits(),
+                libc::O_ACCMODE,
+            );
+            Some(acc_mode as _)
         }
     }
 
@@ -181,10 +204,8 @@ impl OpenFlags {
             Some(acc) => {
                 acc == libc::O_WRONLY
                     || acc == libc::O_RDWR
-                    || !self
-                        // O_CREAT and O_TRUNC are silently ignored with O_PATH.
-                        .intersection(OpenFlags::O_TRUNC | OpenFlags::O_CREAT)
-                        .is_empty()
+                    // O_CREAT and O_TRUNC are silently ignored with O_PATH.
+                    || self.intersects(OpenFlags::O_TRUNC | OpenFlags::O_CREAT)
             }
         }
     }
@@ -247,7 +268,7 @@ mod tests {
                     fn [<openflags_ $test_name _access_mode>]() {
                         let flags = $(OpenFlags::$flag)|*;
                         let accmode: Option<i32> = $accmode;
-                        assert_eq!(flags.access_mode(), accmode, "{flags:?} access mode should be {:?}", accmode.map(OpenFlags::from_bits_retain));
+                        assert_eq!(flags.access_mode(), accmode, "{flags:?} access mode should be {:?}", accmode.map(|flags| OpenFlags::from_bits_retain(flags as _)));
                     }
 
                     #[test]

--- a/src/resolvers/openat2.rs
+++ b/src/resolvers/openat2.rs
@@ -56,7 +56,7 @@ pub(crate) fn open(
 ) -> Result<File, Error> {
     let rflags = libc::RESOLVE_IN_ROOT | libc::RESOLVE_NO_MAGICLINKS | rflags.bits();
     let how = OpenHow {
-        flags: oflags.bits() as u64,
+        flags: oflags,
         resolve: rflags,
         ..Default::default()
     };
@@ -87,7 +87,7 @@ pub(crate) fn resolve(
     let rflags = libc::RESOLVE_IN_ROOT | libc::RESOLVE_NO_MAGICLINKS | rflags.bits();
 
     let how = OpenHow {
-        flags: oflags.bits() as u64,
+        flags: oflags,
         resolve: rflags,
         ..Default::default()
     };

--- a/src/resolvers/procfs.rs
+++ b/src/resolvers/procfs.rs
@@ -140,8 +140,7 @@ fn openat2_resolve(
     oflags: OpenFlags,
     rflags: ResolverFlags,
 ) -> Result<OwnedFd, Error> {
-    // Copy the O_NOFOLLOW and RESOLVE_NO_SYMLINKS bits from rflags.
-    let oflags = oflags.bits() as u64;
+    // Copy the RESOLVE_NO_SYMLINKS bit from rflags.
     let rflags =
         libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_XDEV | rflags.bits();
 

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -773,7 +773,7 @@ pub(crate) mod openat2 {
     #[derive(Copy, Clone, Debug, Default)]
     pub(crate) struct OpenHow {
         /// O_* flags (`-EINVAL` on unknown or incompatible flags).
-        pub flags: u64,
+        pub flags: OpenFlags,
         /// O_CREAT or O_TMPFILE file mode (must be zero otherwise).
         pub mode: u64,
         /// RESOLVE_* flags (`-EINVAL` on unknown flags).
@@ -784,8 +784,11 @@ pub(crate) mod openat2 {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{{ ")?;
             // self.flags
-            write!(f, "flags: {:?}, ", OpenFlags::from_bits_retain(self.flags))?;
-            if self.flags & (libc::O_CREAT | libc::O_TMPFILE) as u64 != 0 {
+            write!(f, "flags: {:?}, ", self.flags)?;
+            if self
+                .flags
+                .intersects(OpenFlags::O_CREAT | OpenFlags::O_TMPFILE)
+            {
                 write!(f, "mode: 0o{:o}, ", self.mode)?;
             }
             // self.resolve
@@ -821,9 +824,9 @@ pub(crate) mod openat2 {
         // Add O_CLOEXEC and O_NOCTTY explicitly (as we do for openat). However,
         // O_NOCTTY cannot be set if O_PATH is set (openat2 verifies flag
         // arguments).
-        how.flags |= libc::O_CLOEXEC as u64;
-        if how.flags & libc::O_PATH as u64 == 0 {
-            how.flags |= libc::O_NOCTTY as u64;
+        how.flags.insert(OpenFlags::O_CLOEXEC);
+        if !how.flags.contains(OpenFlags::O_PATH) {
+            how.flags.insert(OpenFlags::O_NOCTTY);
         }
 
         // openat2(2) can fail with -EAGAIN if there was a racing rename or
@@ -895,8 +898,7 @@ pub(crate) mod openat2 {
         path: impl AsRef<Path>,
         mut how: OpenHow,
     ) -> Result<OwnedFd, Error> {
-        how.flags |= libc::O_NOFOLLOW as u64;
-
+        how.flags.insert(OpenFlags::O_NOFOLLOW);
         openat2_follow(dirfd, path, how)
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -392,14 +392,30 @@ pub(crate) fn openat_follow(
     // malicious file won't take control of our terminal.
     flags.insert(OpenFlags::O_CLOEXEC | OpenFlags::O_NOCTTY);
 
-    rustix_fs::openat(dirfd, path, flags.into(), Mode::from_raw_mode(mode)).map_err(|errno| {
-        Error::Openat {
+    rustix_fs::openat(
+        dirfd,
+        path,
+        // Emulate E2BIG if we are given a flag that cannot be represented with
+        // 32-bit openat(2) flags. openat(2) doesn't normally return E2BIG so
+        // this should avoid confusion with real syscall errors.
+        // TODO: It would be nice to make this a more descriptive error so that
+        // the fact this came from our wrapper and not the syscall itself would
+        // be more obvious?
+        flags.try_into().map_err(|_| Error::Openat {
             dirfd: dirfd.into(),
             path: path.into(),
             flags,
             mode,
-            source: errno,
-        }
+            source: Errno::TOOBIG, // E2BIG
+        })?,
+        Mode::from_raw_mode(mode),
+    )
+    .map_err(|errno| Error::Openat {
+        dirfd: dirfd.into(),
+        path: path.into(),
+        flags,
+        mode,
+        source: errno,
     })
 }
 
@@ -768,12 +784,7 @@ pub(crate) mod openat2 {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{{ ")?;
             // self.flags
-            if let Ok(oflags) = i32::try_from(self.flags) {
-                // If the flags can fit inside OpenFlags, pretty-print the flags.
-                write!(f, "flags: {:?}, ", OpenFlags::from_bits_retain(oflags))?;
-            } else {
-                write!(f, "flags: 0x{:x}, ", self.flags)?;
-            }
+            write!(f, "flags: {:?}, ", OpenFlags::from_bits_retain(self.flags))?;
             if self.flags & (libc::O_CREAT | libc::O_TMPFILE) as u64 != 0 {
                 write!(f, "mode: 0o{:o}, ", self.mode)?;
             }

--- a/src/tests/capi/test_compat.rs
+++ b/src/tests/capi/test_compat.rs
@@ -33,15 +33,122 @@
 use crate::{
     capi,
     error::ErrorKind,
+    flags::OpenFlags,
+    procfs::ProcfsHandle,
     tests::{capi::utils as capi_utils, common as tests_common, traits::ErrorImpl},
     utils::FdExt,
     Root,
 };
 
-use std::os::unix::{fs::MetadataExt, io::AsFd};
+use std::{
+    fs::File,
+    os::unix::{
+        fs::MetadataExt,
+        io::{AsFd, AsRawFd, OwnedFd},
+    },
+};
 
 use anyhow::{Context, Error};
 use pretty_assertions::{assert_eq, assert_matches};
+
+#[test]
+fn reopen_v1() -> Result<(), Error> {
+    let file: OwnedFd = File::open(".")?.into();
+
+    let oflags = OpenFlags::O_DIRECTORY | OpenFlags::O_RDONLY | OpenFlags::O_NOATIME;
+    let reopened_fd = capi_utils::call_capi_fd(|| {
+        capi::core::__pathrs_reopen_v1(file.as_fd().into(), oflags.bits() as i32)
+    })?;
+
+    assert_ne!(
+        file.as_raw_fd(),
+        reopened_fd.as_raw_fd(),
+        "new and reopened fds should have different fd numbers"
+    );
+    assert_eq!(
+        file.as_unsafe_path_unchecked()?,
+        reopened_fd.as_unsafe_path_unchecked()?,
+        "new and reopened fds should have the same 'real' path",
+    );
+    tests_common::check_oflags(&reopened_fd, oflags)?;
+
+    Ok(())
+}
+
+#[test]
+fn inroot_open_v1() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root = Root::open(root_dir.path())?;
+
+    {
+        let path = capi_utils::path_to_cstring("b/c");
+        let oflags = OpenFlags::O_DIRECTORY | OpenFlags::O_RDONLY | OpenFlags::O_NOATIME;
+        // SAFETY: Called with valid C-like arguments.
+        let file = capi_utils::call_capi_fd(|| unsafe {
+            capi::core::__pathrs_inroot_open_v1(
+                root.as_fd().into(),
+                path.as_ptr(),
+                oflags.bits() as _,
+            )
+        })?;
+        tests_common::check_oflags(&file, oflags)?;
+    }
+
+    {
+        let path = capi_utils::path_to_cstring("b/c/file");
+        let oflags = OpenFlags::O_RDWR | OpenFlags::O_TRUNC | OpenFlags::O_DIRECT;
+        // SAFETY: Called with valid C-like arguments.
+        let file = capi_utils::call_capi_fd(|| unsafe {
+            capi::core::__pathrs_inroot_open_v1(
+                root.as_fd().into(),
+                path.as_ptr(),
+                oflags.bits() as _,
+            )
+        })?;
+        tests_common::check_oflags(&file, oflags)?;
+    }
+
+    {
+        let path = capi_utils::path_to_cstring("b-file");
+        let oflags = OpenFlags::O_NOFOLLOW | OpenFlags::O_PATH;
+        // SAFETY: Called with valid C-like arguments.
+        let file = capi_utils::call_capi_fd(|| unsafe {
+            capi::core::__pathrs_inroot_open_v1(
+                root.as_fd().into(),
+                path.as_ptr(),
+                oflags.bits() as _,
+            )
+        })?;
+        tests_common::check_oflags(&file, oflags)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn inroot_creat_v1() -> Result<(), Error> {
+    let root_dir = tests_common::create_basic_tree()?;
+    let root = Root::open(root_dir.path())?;
+
+    {
+        let path = capi_utils::path_to_cstring("b/c/new-file");
+        let oflags = OpenFlags::O_RDWR | OpenFlags::O_NOATIME | OpenFlags::O_EXCL;
+        let mode = 0o644;
+        // SAFETY: Called with valid C-like arguments.
+        let file = capi_utils::call_capi_fd(|| unsafe {
+            capi::core::__pathrs_inroot_creat_v1(
+                root.as_fd().into(),
+                path.as_ptr(),
+                oflags.bits() as _,
+                mode,
+            )
+        })?;
+        tests_common::check_oflags(&file, oflags | OpenFlags::O_CREAT)?;
+        tests_common::check_mode(&file, libc::S_IFREG | mode)?;
+    }
+
+    Ok(())
+}
 
 #[test]
 fn hardlink_v1() -> Result<(), Error> {
@@ -215,6 +322,42 @@ fn rename_v2() -> Result<(), Error> {
         Err(ErrorKind::InvalidArgument.errno()),
         "pathrs_inroot_rename@LIBPATHRS_0.2.5 should reject old_root_fd != new_root_fd"
     );
+
+    Ok(())
+}
+
+#[test]
+fn procfs_open_v1() -> Result<(), Error> {
+    let path = capi_utils::path_to_cstring("stat");
+    let oflags = OpenFlags::O_RDONLY | OpenFlags::O_NOFOLLOW;
+    // SAFETY: Called with valid C-like arguments.
+    let file = capi_utils::call_capi_fd(|| unsafe {
+        capi::procfs::__pathrs_proc_open_v1(
+            capi::procfs::CProcfsBase::PATHRS_PROC_THREAD_SELF,
+            path.as_ptr(),
+            oflags.bits() as _,
+        )
+    })?;
+    tests_common::check_oflags(&file, oflags)?;
+
+    Ok(())
+}
+
+#[test]
+fn procfs_openat_v1() -> Result<(), Error> {
+    let proc_rootfd = ProcfsHandle::new()?;
+    let path = capi_utils::path_to_cstring("stat");
+    let oflags = OpenFlags::O_RDONLY | OpenFlags::O_NOFOLLOW;
+    // SAFETY: Called with valid C-like arguments.
+    let file = capi_utils::call_capi_fd(|| unsafe {
+        capi::procfs::__pathrs_proc_openat_v1(
+            proc_rootfd.as_fd().into(),
+            capi::procfs::CProcfsBase::PATHRS_PROC_THREAD_SELF,
+            path.as_ptr(),
+            oflags.bits() as _,
+        )
+    })?;
+    tests_common::check_oflags(&file, oflags)?;
 
     Ok(())
 }

--- a/src/tests/capi/test_compat.rs
+++ b/src/tests/capi/test_compat.rs
@@ -47,14 +47,16 @@ use pretty_assertions::{assert_eq, assert_matches};
 fn hardlink_v1() -> Result<(), Error> {
     let root_dir = tests_common::create_basic_tree()?;
     let root = Root::open(root_dir.path())?;
+    let path1 = capi_utils::path_to_cstring("abc");
+    let path2 = capi_utils::path_to_cstring("b/c/file");
 
     assert_eq!(
         // SAFETY: Called with valid C-like arguments.
         capi_utils::call_capi(|| unsafe {
             capi::core::__pathrs_inroot_hardlink_v1(
                 root.as_fd().into(),
-                capi_utils::path_to_cstring("abc").into_raw(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                path1.as_ptr(),
+                path2.as_ptr(),
             )
         })
         .map_err(|err| err.kind()),
@@ -85,15 +87,17 @@ fn hardlink_v2() -> Result<(), Error> {
     let root_dir = tests_common::create_basic_tree()?;
     let root1 = Root::open(root_dir.path())?;
     let root2 = Root::open(root_dir.path())?;
+    let path1 = capi_utils::path_to_cstring("abc");
+    let path2 = capi_utils::path_to_cstring("b/c/file");
 
     assert_eq!(
         // SAFETY: Called with valid C-like arguments.
         capi_utils::call_capi(|| unsafe {
             capi::core::pathrs_inroot_hardlink(
                 root1.as_fd().into(),
-                capi_utils::path_to_cstring("abc").into_raw(),
+                path1.as_ptr(),
                 root2.as_fd().into(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                path2.as_ptr(),
                 0,
             )
         })
@@ -107,9 +111,9 @@ fn hardlink_v2() -> Result<(), Error> {
         capi_utils::call_capi(|| unsafe {
             capi::core::pathrs_inroot_hardlink(
                 root1.as_fd().into(),
-                capi_utils::path_to_cstring("abc").into_raw(),
-                root1.as_fd().into(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                path1.as_ptr(),
+                root1.as_fd().into(), // *not* root2!
+                path2.as_ptr(),
                 0xFFFF,
             )
         })
@@ -125,14 +129,16 @@ fn hardlink_v2() -> Result<(), Error> {
 fn symlink_v1() -> Result<(), Error> {
     let root_dir = tests_common::create_basic_tree()?;
     let root = Root::open(root_dir.path())?;
+    let path1 = capi_utils::path_to_cstring("abc");
+    let path2 = capi_utils::path_to_cstring("b/c/file");
 
     assert_eq!(
         // SAFETY: Called with valid C-like arguments.
         capi_utils::call_capi(|| unsafe {
             capi::core::__pathrs_inroot_symlink_v1(
                 root.as_fd().into(),
-                capi_utils::path_to_cstring("abc").into_raw(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                path1.as_ptr(),
+                path2.as_ptr(),
             )
         })
         .map_err(|err| err.kind()),
@@ -153,14 +159,16 @@ fn symlink_v1() -> Result<(), Error> {
 fn rename_v1() -> Result<(), Error> {
     let root_dir = tests_common::create_basic_tree()?;
     let root = Root::open(root_dir.path())?;
+    let path1 = capi_utils::path_to_cstring("b/c/file");
+    let path2 = capi_utils::path_to_cstring("abc");
 
     assert_eq!(
         // SAFETY: Called with valid C-like arguments.
         capi_utils::call_capi(|| unsafe {
             capi::core::__pathrs_inroot_rename_v1(
                 root.as_fd().into(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
-                capi_utils::path_to_cstring("abc").into_raw(),
+                path1.as_ptr(),
+                path2.as_ptr(),
                 0,
             )
         })
@@ -189,15 +197,17 @@ fn rename_v2() -> Result<(), Error> {
     let root_dir = tests_common::create_basic_tree()?;
     let root1 = Root::open(root_dir.path())?;
     let root2 = Root::open(root_dir.path())?;
+    let path1 = capi_utils::path_to_cstring("b/c/file");
+    let path2 = capi_utils::path_to_cstring("abc");
 
     assert_eq!(
         // SAFETY: Called with valid C-like arguments.
         capi_utils::call_capi(|| unsafe {
             capi::core::pathrs_inroot_rename(
                 root1.as_fd().into(),
-                capi_utils::path_to_cstring("abc").into_raw(),
+                path1.as_ptr(),
                 root2.as_fd().into(),
-                capi_utils::path_to_cstring("b/c/file").into_raw(),
+                path2.as_ptr(),
                 0,
             )
         })

--- a/src/tests/common/handle.rs
+++ b/src/tests/common/handle.rs
@@ -38,13 +38,14 @@ use crate::{
     utils::FdExt,
 };
 
-use std::os::unix::io::AsFd;
+use std::os::unix::{fs::MetadataExt, io::AsFd};
 
 use anyhow::{Context, Error};
 use pretty_assertions::assert_eq;
 use rustix::{
-    fs::{self as rustix_fs, OFlags},
+    fs::{self as rustix_fs, Mode, OFlags},
     io::{self as rustix_io, FdFlags},
+    process::{self as rustix_process},
 };
 
 pub type LookupResult<'a> = (&'a str, libc::mode_t);
@@ -101,11 +102,42 @@ where
     }
 }
 
+pub(in crate::tests) fn check_mode(fd: impl AsFd, create_mode: u32) -> Result<(), Error> {
+    let fd = fd.as_fd();
+
+    // Get the umask.
+    let umask = {
+        let umask = rustix_process::umask(Mode::empty());
+        rustix_process::umask(umask);
+        umask.bits()
+    };
+
+    let got_mode = fd.metadata()?.mode()
+        // Strip type bits from mode if the caller didn't include them.
+        & !if create_mode & libc::S_IFMT == 0 {
+            libc::S_IFMT
+        } else {
+            0
+        };
+
+    assert_eq!(
+        create_mode & !umask,
+        got_mode,
+        "created fd {:?} should have mode {} ({create_mode} &^ {umask})",
+        fd.as_unsafe_path_unchecked()?,
+        create_mode & !umask
+    );
+
+    Ok(())
+}
+
 pub(in crate::tests) fn check_oflags(fd: impl AsFd, flags: OpenFlags) -> Result<(), Error> {
     let fd = fd.as_fd();
 
     // Convert to OFlags so we can compare them.
-    let mut wanted_flags = OFlags::from_bits_retain(flags.bits() as u32);
+    let mut wanted_flags: OFlags = flags
+        .try_into()
+        .expect("OpenFlags should be convertible to rustix OFlags");
     // O_CLOEXEC is always automatically enabled by libpathrs.
     wanted_flags.insert(OFlags::CLOEXEC);
 

--- a/src/utils/raw_procfs.rs
+++ b/src/utils/raw_procfs.rs
@@ -148,7 +148,7 @@ impl<'fd> RawProcfsRoot<'fd> {
             self.try_into_maybe_owned_fd()?.as_fd(),
             path,
             OpenHow {
-                flags: oflags.bits() as _,
+                flags: oflags,
                 mode: 0,
                 resolve: (ResolveFlags::RESOLVE_NO_MAGICLINKS
                     | ResolveFlags::RESOLVE_NO_XDEV


### PR DESCRIPTION
Recently it seems that `OPENAT2_*` flags will start taking up bits of the
higher 32-bits available with `openat2(2)` and so we will need to be able
to represent them.

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>