### PR TITLE
ci: bump to cbindgen v0.29.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ name: rust-ci
 
 env:
   RUST_MSRV: &RUST_MSRV "1.63"
+  CBINDGEN_VERSION: "0.29.3"
 
 jobs:
   codespell:
@@ -132,7 +133,7 @@ jobs:
         with:
           components: rustfmt,clippy
       - name: install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --force --locked cbindgen@${{ env.CBINDGEN_VERSION }}
       - name: make lint
         run: make CARGO_NIGHTLY=cargo lint
 
@@ -142,7 +143,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --force --locked cbindgen@${{ env.CBINDGEN_VERSION }}
       - run: make validate-cbindgen
 
   validate-elf-symbols:

--- a/include/pathrs.h
+++ b/include/pathrs.h
@@ -137,7 +137,11 @@
  *
  * Unknown values will result in an error being returned.
  */
-enum pathrs_proc_base_t {
+enum pathrs_proc_base_t
+#if __STDC_VERSION__ >= 202311L
+  : uint64_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
     /**
      * Use /proc. Note that this mode may be more expensive because we have
      * to take steps to try to avoid leaking unmasked procfs handles, so you
@@ -159,7 +163,11 @@ enum pathrs_proc_base_t {
      */
     PATHRS_PROC_THREAD_SELF = 18446744066171166239ull,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum pathrs_proc_base_t pathrs_proc_base_t;
+#else
 typedef uint64_t pathrs_proc_base_t;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
     uint64_t flags;


### PR DESCRIPTION
This version added support for C23 fixed-type enum syntax, which caused
our CI to break as the output of cbindgen changed. To avoid this
happening in the future, lock the cbindgen version in CI.

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>