### PR TITLE
ci: pin cbindgen v0.29.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ name: rust-ci
 
 env:
   RUST_MSRV: &RUST_MSRV "1.63"
+  CBINDGEN_VERSION: "0.29.2"
 
 jobs:
   codespell:
@@ -132,7 +133,7 @@ jobs:
         with:
           components: rustfmt,clippy
       - name: install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --force --locked cbindgen@${{ env.CBINDGEN_VERSION }}
       - name: make lint
         run: make CARGO_NIGHTLY=cargo lint
 
@@ -142,7 +143,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --force --locked cbindgen@${{ env.CBINDGEN_VERSION }}
       - run: make validate-cbindgen
 
   validate-elf-symbols:


### PR DESCRIPTION
cbindgen v0.29.3 added support for C23 fixed-type enum syntax
unconditionally (mozilla/cbindgen#1156) -- it is gated with `#if` guards
but Python's cffi cannot handle those and so our Python bindings would
not build.

So, pin the newest release without this feature to make our CI green
again (we did not pin the cbindgen version used in our CI so the new
update also broke our CI).

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>