### PR TITLE
readlink: move ENOENT -> EINVAL logic to syscall wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `/proc/sys/fs/protected_symlinks` would fail. We now conservatively assume
     that `fs.protected_symlinks` is enabled if we cannot access the file for
     any reason.
-- `Root::readlink` would previously return `ENOENT` if the target path existed
-  but was not a symlink. This occurred because of a peculiar asymmetry in the
-  kernel APIs for `readlinkat(2)`, but users found it confusing and so we now
-  remap the error in that case to `EINVAL` (as you would get from `readlink(2)`
-  with a path). This will make it easier to distinguish the "target path does
-  not exist" and "target path is not a symlink" cases.
+- `Root::readlink` and `ProcfsHandle::readlink` would previously return
+  `ENOENT` if the target path existed but was not a symlink. This occurred
+  because of a peculiar asymmetry in the kernel APIs for `readlinkat(2)`, but
+  users found it confusing and so we now remap the error in that case to
+  `EINVAL` (as you would get from `readlink(2)` with a path). This will make it
+  easier to distinguish the "target path does not exist" and "target path is
+  not a symlink" cases.
 
 ## [0.2.4] - 2026-03-03 ##
 

--- a/e2e-tests/tests/procfs-readlink.bats
+++ b/e2e-tests/tests/procfs-readlink.bats
@@ -97,42 +97,55 @@ function teardown() {
 
 # Make sure that thread-self and self are actually handled differently.
 @test "procfs readlink [self != thread-self]" {
-	# This is a little ugly, but if we get ENOENT from trying to *resolve*
-	# $base/task then we know we are in thread-self. Unfortunately, readlinkat
-	# also returns ENOENT if the target is not a symlink so we need to check
-	# whether the error is coming from readlinkat as well.
-
+	# EINVAL => Non-symlink.
 	pathrs-cmd procfs --base self readlink task
-	check-errno ENOENT
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
+	# ENOENT => No such path.
 	pathrs-cmd procfs --base thread-self readlink task
 	check-errno ENOENT
 	[[ "$output" != *"error:"*"readlinkat"* ]] # Make sure the error is NOT from readlinkat(2).
 }
 
-@test "procfs readlink [non-symlink]" {
-	pathrs-cmd procfs readlink uptime
+@test "procfs readlink [enoent]" {
+	pathrs-cmd procfs readlink non-exist
 	check-errno ENOENT
+	[[ "$output" != *"error:"*"readlinkat"* ]] # Make sure the error is NOT from readlinkat(2).
+}
+
+@test "procfs readlink [file einval]" {
+	pathrs-cmd procfs readlink uptime
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
 	pathrs-cmd procfs --base root readlink tty/drivers
-	check-errno ENOENT
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
 	pathrs-cmd procfs --base root readlink self/fdinfo/0
-	check-errno ENOENT
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
 	pathrs-cmd procfs --base pid=1 readlink stat
-	check-errno ENOENT
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
 	pathrs-cmd procfs --base self readlink status
-	check-errno ENOENT
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 
 	pathrs-cmd procfs --base thread-self readlink stack
-	check-errno ENOENT
+	check-errno EINVAL
+	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
+}
+
+@test "procfs readlink [dir einval]" {
+	pathrs-cmd procfs readlink tty
+	check-errno EINVAL
+	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
+
+	pathrs-cmd procfs --base root readlink self/fdinfo
+	check-errno EINVAL
 	[[ "$output" == *"error:"*"readlinkat"* ]] # Make sure the error is from readlinkat(2).
 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -870,16 +870,7 @@ impl RootRef<'_> {
         let link = self
             .resolve_nofollow(path)
             .wrap("resolve symlink O_NOFOLLOW for readlink")?;
-        syscalls::readlinkat(link, "").map_err(|mut err| {
-            // readlinkat(fd, "") returns ENOENT if the file descriptor is not a
-            // symlink, which is in stark contrast to the EINVAL you would
-            // normally get from readlinkat(dfd, path). As we know the target
-            // file exists at this point (because resolve_nofollow succeeded),
-            // we can just map ENOENT to EINVAL to reduce user confusion.
-            *err.errno_mut() = match err.errno() {
-                Errno::NOENT => Errno::INVAL,
-                errno => errno,
-            };
+        syscalls::readlinkat(link, "").map_err(|err| {
             ErrorImpl::RawOsError {
                 operation: "readlink resolve symlink".into(),
                 source: err,

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -316,10 +316,6 @@ impl Error {
         *match_source_errno!(self)
     }
 
-    pub(crate) fn errno_mut(&mut self) -> &mut Errno {
-        match_source_errno!(self)
-    }
-
     // TODO: Switch to returning &Errno.
     pub(crate) fn root_cause(&self) -> IOError {
         IOError::from_raw_os_error(self.errno().raw_os_error())
@@ -454,7 +450,16 @@ pub(crate) fn readlinkat(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<Pat
             Error::Readlinkat {
                 dirfd: dirfd.into(),
                 path: path.into(),
-                source: errno,
+                source: match errno {
+                    // readlinkat(fd, "") returns ENOENT if the file descriptor
+                    // is not a symlink, which is in stark contrast to the
+                    // EINVAL you would normally get from readlinkat(dfd, path).
+                    // As we know the target file exists at this point (because
+                    // resolve_nofollow succeeded), we can just map ENOENT to
+                    // EINVAL to reduce user confusion.
+                    Errno::NOENT if path.as_os_str().is_empty() => Errno::INVAL,
+                    errno => errno,
+                },
             }
         })?;
 

--- a/src/tests/test_procfs.rs
+++ b/src/tests/test_procfs.rs
@@ -307,6 +307,10 @@ procfs_tests! {
     symlink_overmount: readlink(ProcfsBase::ProcRoot, "net") => (error: Ok);
     symlink_parentdir_overmount: open(ProcfsBase::ProcRoot, "net/unix", O_RDONLY) => (error: ErrOvermount("/proc/self/net", ErrorKind::OsError(Some(libc::EXDEV))));
     symlink_parentdir_overmount: open_follow(ProcfsBase::ProcRoot, "net/unix", O_RDONLY) => (error: ErrOvermount("/proc/self/net", ErrorKind::OsError(Some(libc::EXDEV))));
+    // Readlink with non-symlinks.
+    enoent: readlink(ProcfsBase::ProcRoot, "non-exist") => (error: Err(ErrorKind::OsError(Some(libc::ENOENT))));
+    dir_einval: readlink(ProcfsBase::ProcRoot, "self/fdinfo") => (error: Err(ErrorKind::OsError(Some(libc::EINVAL))));
+    file_einval: readlink(ProcfsBase::ProcRoot, "tty/drivers") => (error: Err(ErrorKind::OsError(Some(libc::EINVAL))));
     // Magic-links with no overmount.
     magiclink_nomount: open(self, "cwd", O_PATH) => (error: Ok);
     magiclink_nomount: open_follow(self, "cwd", O_RDONLY) => (error: Ok);


### PR DESCRIPTION
~~Needs #385.~~

- - -

In commit https://github.com/cyphar/libpathrs/commit/08856cca4c8267e4860e307cac572c81c5e0f0fd ("root: make readlink return -EINVAL for
non-symlinks"), we made Root::readlink remap -ENOENT to -EINVAL, but the
exact same issue applies to ProcfsHandle::readlink and so we really
should just do this in the syscall wrapper to be safe.

This also removes the need for errno_mut.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>