### PR TITLE
release: fix vendor.tar.zst generation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,19 @@ jobs:
           cargo hack --each-feature --keep-going \
             build --target=${{ matrix.target }} --release
 
+  check-release-script:
+    name: check release script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: compute libpathrs crate version
+        run: |-
+          CRATE_VERSION="$(cargo metadata --no-deps --format-version=1 | jq -rM '.packages[] | select(.name == "pathrs") | .version')"
+          echo "CRATE_VERSION=$CRATE_VERSION" >>"$GITHUB_ENV"
+      - run: ./hack/release.sh
+      - run: tar tvf ./release/${CRATE_VERSION}/libpathrs-${CRATE_VERSION}.tar.xz
+      - run: tar tvf ./release/${CRATE_VERSION}/libpathrs.vendor.tar.zst
+
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -636,6 +649,7 @@ jobs:
       - check
       - check-msrv
       - check-cross
+      - check-release-script
       - fmt
       - clippy
       - check-lint-nohack

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -138,7 +138,8 @@ rm -rf "$outputdir" && mkdir -p "$outputdir"
 #done
 
 # Generate vendor.tar.zst.
-generate_vendor - | zstd -11 >"$outputdir/$project.vendor.tar.zst"
+generate_vendor "$outputdir/$project.vendor.tar"
+zstd -11 --rm "$outputdir/$project.vendor.tar" -o "$outputdir/$project.vendor.tar.zst"
 
 # Generate new archive.
 git archive --format=tar --prefix="$project-$version/" "$commit" | xz > "$outputdir/$project-$version.tar.xz"


### PR DESCRIPTION
Our old pipeline-based compression setup for the vendor tarball would
result in a corrupted tar archive (as other commands would output
informaiton to stdout that would be captured and prepended to the tar
archive contents).

The simplest solution is to just two-phase it. We could build-in the
compression to the archive step, but arguably doing two-pass compression
is slightly better anyway.

Fixes #400
Fixes: https://github.com/cyphar/libpathrs/commit/8b989b34e4affd5eb2e5d8442a584eb8afbabf25 ("make: add signed release build script")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>